### PR TITLE
Clean up EUI repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## A Minimal vector-based Ebitenengine retained-mode UI library
-### This library is no where near complete (PRE-ALPHA), and breaking changes will come very often.
+### This library is nowhere near complete (PRE-ALPHA), and breaking changes will come very often.
 *For quicker development, the code is not composed as a library at this time*  
 Drawn using vectors and supports floating-point UI scaling.
 
@@ -14,8 +14,8 @@ Each flow has a direction, horizontal or vertical.
 
 
 # Flow and item pinning:
-Flows and items can have pinning type set. The default is PIN_TOP_LEFT.  
-The pin changes the point of refrence for the item/flow position.
+Flows and items can have pinning type set. The default is PIN_TOP_LEFT.
+The pin changes the point of reference for the item/flow position.
 
 Other options are:  
 PIN_TOP_LEFT  

--- a/input.go
+++ b/input.go
@@ -76,7 +76,7 @@ func (g *Game) Update() error {
 				} else if part == PART_RIGHT {
 					sizeCh.Y = 0
 					win.setSize(pointAdd(win.Size, sizeCh))
-					//Corner reize
+					//Corner resize
 				} else if part == PART_TOP_LEFT {
 					if !win.setSize(pointSub(win.Size, sizeCh)) {
 						win.Position = pointAdd(win.Position, posCh)
@@ -97,12 +97,6 @@ func (g *Game) Update() error {
 
 					if !win.setSize(point{X: tx, Y: ty}) {
 						win.Position.X += posCh.X
-					}
-				} else if part == PART_TOP_LEFT {
-					tx := win.Size.Y - sizeCh.Y
-					ty := win.Size.X + sizeCh.X
-					if !win.setSize(point{X: tx, Y: ty}) {
-						win.Position.Y -= posCh.Y
 					}
 				}
 				break

--- a/struct.go
+++ b/struct.go
@@ -41,7 +41,7 @@ type itemData struct {
 	Value float32
 
 	Hovered, Checked,
-	Disabled, Invisable bool
+	Disabled, Invisible bool
 	Clicked  time.Time
 	FlowType flowType
 	Scroll   point


### PR DESCRIPTION
## Summary
- fix duplicate `PART_TOP_LEFT` block in `input.go`
- correct 'resize' comment
- improve README wording and fix typos
- rename `Invisable` field to `Invisible`

## Testing
- `go vet ./...` *(fails: X11 header missing)*

------
https://chatgpt.com/codex/tasks/task_e_684dfa235e7c832a9ff4b077eba43a10