### PR TITLE
Adjust mid-left pin position

### DIFF
--- a/window.go
+++ b/window.go
@@ -144,7 +144,7 @@ func (pin pinType) getWinPosition(win *windowData) point {
 	case PIN_TOP_CENTER:
 		return point{X: float32(screenWidth/2) - win.GetSize().X/2, Y: 0}
 	case PIN_MID_LEFT:
-		return point{X: 0, Y: float32(screenHeight/2) - (win.GetSize().Y + (win.GetTitleSize())/2)}
+		return point{X: 0, Y: float32(screenHeight/2) - win.GetSize().Y/2}
 	case PIN_MID_CENTER:
 		return point{X: float32(screenWidth/2) - win.GetSize().X/2, Y: float32(screenHeight/2) - (win.GetSize().Y - (win.GetTitleSize())/2)}
 	case PIN_MID_RIGHT:


### PR DESCRIPTION
## Summary
- fix Y coordinate calculation for PIN_MID_LEFT

## Testing
- `go vet ./...` *(fails: X11 header not found)*
- `go test ./...` *(fails: X11 header not found)*
- `go build ./...` *(fails: X11 header not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dfc55f044832ab44786020f7b0ba4