### PR TITLE
Fix typographical error in struct field

### DIFF
--- a/struct.go
+++ b/struct.go
@@ -41,7 +41,7 @@ type itemData struct {
 	Value float32
 
 	Hovered, Checked,
-	Disabled, Invisable bool
+	Disabled, Invisible bool
 	Clicked  time.Time
 	FlowType flowType
 	Scroll   point


### PR DESCRIPTION
## Summary
- rename `Invisable` field to `Invisible`

## Testing
- `go vet ./...` *(fails: X11/extensions/Xrandr.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dfc543b38832aaded7e85aace2548