### PR TITLE
Fix vertical flow offset check

### DIFF
--- a/render.go
+++ b/render.go
@@ -190,7 +190,7 @@ func (item *itemData) drawFlows(parent *itemData, offset point, screen *ebiten.I
 			if parent.ItemType == ITEM_FLOW {
 				if parent.FlowType == FLOW_HORIZONTAL {
 					objOff = pointAdd(objOff, point{X: subItem.GetPos().X})
-				} else if parent.FlowType == FLOW_HORIZONTAL {
+				} else if parent.FlowType == FLOW_VERTICAL {
 					objOff = pointAdd(objOff, point{Y: subItem.GetPos().Y})
 				}
 			}


### PR DESCRIPTION
## Summary
- fix copy-paste typo when checking parent's flow type

## Testing
- `go test ./...` *(fails: `X11/extensions/Xrandr.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dfc5071c8832ab29f64bfafac7335