### PR TITLE
Fix duplicate case for PART_TOP_LEFT

### DIFF
--- a/input.go
+++ b/input.go
@@ -98,12 +98,6 @@ func (g *Game) Update() error {
 					if !win.setSize(point{X: tx, Y: ty}) {
 						win.Position.X += posCh.X
 					}
-				} else if part == PART_TOP_LEFT {
-					tx := win.Size.Y - sizeCh.Y
-					ty := win.Size.X + sizeCh.X
-					if !win.setSize(point{X: tx, Y: ty}) {
-						win.Position.Y -= posCh.Y
-					}
 				}
 				break
 			}


### PR DESCRIPTION
## Summary
- remove the duplicate `PART_TOP_LEFT` resize branch in `input.go`

## Testing
- `go build ./...` *(fails: `X11/extensions/Xrandr.h` missing)*

------
https://chatgpt.com/codex/tasks/task_e_684dfc473db4832a93a3b75c1a9f8f6f