### PR TITLE
Fix containsPoint Y comparison

### DIFF
--- a/util.go
+++ b/util.go
@@ -16,7 +16,7 @@ func (item *itemData) containsPoint(win *windowData, b point) bool {
 	return b.X >= win.getPosition().X+(item.getPosition(win).X) &&
 		b.X <= win.getPosition().X+(item.getPosition(win).X)+(item.GetSize().X) &&
 		b.Y >= win.getPosition().Y+(item.getPosition(win).Y) &&
-		b.Y <= win.getPosition().Y+(item.getPosition(win).Y)+(item.GetPos().Y)
+		b.Y <= win.getPosition().Y+(item.getPosition(win).Y)+(item.GetSize().Y)
 }
 
 func (win *windowData) getWinRect() rect {


### PR DESCRIPTION
## Summary
- compare item Y range against `item.GetSize().Y` in `containsPoint`

## Testing
- `go vet ./...` *(fails: fatal error: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684dfc447ec8832a9b450075f640cb27