### PR TITLE
Store drawn item rects for input use

### DIFF
--- a/input.go
+++ b/input.go
@@ -125,66 +125,34 @@ func (g *Game) Update() error {
 }
 
 func (win *windowData) clickWindowItems(mpos point, click bool) {
-	//If the mouse isn't within the window, just return
+	// If the mouse isn't within the window, just return
 	if !win.getMainRect().containsPoint(mpos) {
 		return
 	}
 	win.Hovered = true
-	winPos := pointAdd(win.GetPos(), point{X: 0, Y: win.GetTitleSize()})
 
 	for _, item := range win.Contents {
-		itemPos := pointAdd(winPos, item.getPosition(win))
-
 		if item.ItemType == ITEM_FLOW {
-			item.clickFlows(nil, itemPos, mpos, click)
+			item.clickFlows(mpos, click)
 		} else {
-			item.clickItem(nil, itemPos, mpos, click)
+			item.clickItem(mpos, click)
 		}
 	}
 }
 
-func (item *itemData) clickFlows(parent *itemData, offset, mpos point, click bool) {
-
-	var flowOffset point
-
+func (item *itemData) clickFlows(mpos point, click bool) {
 	for _, subItem := range item.Contents {
-
 		if subItem.ItemType == ITEM_FLOW {
-			flowPos := pointAdd(offset, item.GetPos())
-			flowOff := pointAdd(flowPos, flowOffset)
-			itemPos := pointAdd(flowOff, subItem.GetPos())
-			subItem.clickFlows(item, itemPos, mpos, click)
+			subItem.clickFlows(mpos, click)
 		} else {
-			flowOff := pointAdd(offset, flowOffset)
-			subItem.clickItem(item, flowOff, mpos, click)
-		}
-
-		if item.FlowType == FLOW_HORIZONTAL {
-			flowOffset = pointAdd(flowOffset, point{X: subItem.GetSize().X, Y: 0})
-		} else if item.FlowType == FLOW_VERTICAL {
-			flowOffset = pointAdd(flowOffset, point{X: 0, Y: subItem.GetSize().Y})
+			subItem.clickItem(mpos, click)
 		}
 	}
 }
 
-func (item *itemData) clickItem(parent *itemData, offset, mpos point, click bool) {
-	if parent == nil {
-		parent = item
-	}
-	maxSize := item.GetSize()
-	if item.Size.X > parent.Size.X {
-		maxSize.X = parent.GetSize().X
-	}
-	if item.Size.Y > parent.Size.Y {
-		maxSize.Y = parent.GetSize().Y
-	}
-	itemRect := rect{
-		X0: offset.X, X1: offset.X + maxSize.X,
-		Y0: offset.Y, Y1: offset.Y + maxSize.Y,
-	}
-
-	//If the mouse isn't within the item, just return
-	if !itemRect.containsPoint(mpos) {
+func (item *itemData) clickItem(mpos point, click bool) {
+	// If the mouse isn't within the item, just return
+	if !item.DrawRect.containsPoint(mpos) {
 		return
 	}
 

--- a/render.go
+++ b/render.go
@@ -172,6 +172,14 @@ func (win *windowData) drawItems(screen *ebiten.Image) {
 }
 
 func (item *itemData) drawFlows(parent *itemData, offset point, screen *ebiten.Image) {
+	// Store the drawn rectangle for input handling
+	item.DrawRect = rect{
+		X0: offset.X,
+		Y0: offset.Y,
+		X1: offset.X + item.GetSize().X,
+		Y1: offset.Y + item.GetSize().Y,
+	}
+
 	vector.StrokeRect(screen, offset.X, offset.Y, item.GetSize().X, item.GetSize().Y, 1, color.RGBA{R: 32, G: 32, B: 32}, false)
 
 	var flowOffset point
@@ -223,10 +231,14 @@ func (item *itemData) drawItem(parent *itemData, offset point, screen *ebiten.Im
 		maxSize.Y = parent.GetSize().Y
 	}
 
-	subImg := screen.SubImage(rect{
-		X0: offset.X, X1: offset.X + maxSize.X,
-		Y0: offset.Y, Y1: offset.Y + maxSize.Y,
-	}.getRectangle()).(*ebiten.Image)
+	item.DrawRect = rect{
+		X0: offset.X,
+		Y0: offset.Y,
+		X1: offset.X + maxSize.X,
+		Y1: offset.Y + maxSize.Y,
+	}
+
+	subImg := screen.SubImage(item.DrawRect.getRectangle()).(*ebiten.Image)
 
 	if item.ItemType == ITEM_CHECKBOX {
 

--- a/struct.go
+++ b/struct.go
@@ -61,6 +61,11 @@ type itemData struct {
 
 	Action   func()
 	Contents []*itemData
+
+	// DrawRect stores the last drawn rectangle of the item in screen
+	// coordinates so input handling can use the exact same area that was
+	// rendered.
+	DrawRect rect
 }
 
 type roundRect struct {


### PR DESCRIPTION
## Summary
- keep track of the rectangle used to draw each UI item
- reuse these stored rectangles when handling mouse input

## Testing
- `go vet ./...` *(fails: X11/extensions/Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_686ecd806048832a8e9cc08a2a8ad46b