### PR TITLE
Add window auto-size feature

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -14,7 +14,7 @@ var defaultTheme = &windowData{
 	BGColor:         color.RGBA{R: 16, G: 16, B: 16, A: 255},
 	ActiveColor:     color.RGBA{R: 0, G: 128, B: 128, A: 255},
 
-	Movable: true, Closable: true, Resizable: true, Open: true,
+	Movable: true, Closable: true, Resizable: true, Open: true, AutoSize: false,
 }
 
 var defaultButton = &itemData{

--- a/example.go
+++ b/example.go
@@ -7,6 +7,7 @@ func makeTestWindow() *windowData {
 			Title:       "Test Window",
 			Size:        point{X: 300, Y: 300},
 			Position:    point{X: 8, Y: 8},
+			AutoSize:    true,
 		})
 
 	mainFlow := &itemData{

--- a/input.go
+++ b/input.go
@@ -146,6 +146,12 @@ func (g *Game) Update() error {
 
 	mposOld = mpos
 
+	for _, win := range windows {
+		if win.AutoSize {
+			win.updateAutoSize()
+		}
+	}
+
 	return nil
 }
 

--- a/struct.go
+++ b/struct.go
@@ -16,7 +16,8 @@ type windowData struct {
 
 	Open, Hovered, Flow,
 	Closable, Movable, Resizable,
-	HoverClose, HoverDragbar bool
+	HoverClose, HoverDragbar,
+	AutoSize bool
 
 	TitleHeight float32
 


### PR DESCRIPTION
## Summary
- allow windows to automatically resize to fit their contents
- update default theme structure
- enable auto-size on the example test window
- call auto-sizing logic in the update loop

## Testing
- `go build ./...` *(fails: X11 headers missing)*
- `go vet ./...` *(fails: X11 headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_686f26dde650832a86a71b0fb34886f7