### PR TITLE
Add color selector widget with slider controls

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -84,3 +84,35 @@ var defaultInput = &itemData{
 	HoverColor: color.RGBA{R: 96, G: 96, B: 96, A: 255},
 	ClickColor: color.RGBA{R: 0, G: 128, B: 128, A: 255},
 }
+
+var defaultSlider = &itemData{
+	ItemType:  ITEM_SLIDER,
+	Size:      point{X: 128, Y: 16},
+	Position:  point{X: 4, Y: 4},
+	Fillet:    4,
+	Filled:    true,
+	Outlined:  true,
+	Border:    1,
+	BorderPad: 2,
+
+	TextColor:  color.RGBA{255, 255, 255, 255},
+	Color:      color.RGBA{64, 64, 64, 255},
+	HoverColor: color.RGBA{96, 96, 96, 255},
+	ClickColor: color.RGBA{0, 128, 128, 255},
+}
+
+var defaultColorSelector = &itemData{
+	ItemType:  ITEM_COLORSEL,
+	Size:      point{X: 128, Y: 80},
+	Position:  point{X: 4, Y: 4},
+	Fillet:    4,
+	Filled:    true,
+	Outlined:  true,
+	Border:    1,
+	BorderPad: 2,
+
+	TextColor:  color.RGBA{255, 255, 255, 255},
+	Color:      color.RGBA{0, 0, 0, 255},
+	HoverColor: color.RGBA{96, 96, 96, 255},
+	ClickColor: color.RGBA{0, 128, 128, 255},
+}

--- a/example.go
+++ b/example.go
@@ -52,6 +52,8 @@ func makeTestWindow() *windowData {
 	rightFlow.addItemTo(rightText1)
 	rightFlow.addItemTo(rightText2)
 	rightFlow.addItemTo(rightText3)
+	colorSel := NewColorSelector(nil)
+	rightFlow.addItemTo(colorSel)
 
 	return newWindow
 }

--- a/input.go
+++ b/input.go
@@ -184,7 +184,45 @@ func (item *itemData) clickFlows(mpos point, click bool) {
 func (item *itemData) clickItem(mpos point, click bool) {
 	// If the mouse isn't within the item, just return
 	if !item.DrawRect.containsPoint(mpos) {
+		if item.ItemType == ITEM_SLIDER || item.ItemType == ITEM_COLORSEL {
+			item.Dragging = false
+		}
 		return
+	}
+
+	pressed := ebiten.IsMouseButtonPressed(ebiten.MouseButton0)
+
+	if item.ItemType == ITEM_SLIDER && pressed {
+		rel := (mpos.X - item.DrawRect.X0) / (item.DrawRect.X1 - item.DrawRect.X0)
+		if rel < 0 {
+			rel = 0
+		}
+		if rel > 1 {
+			rel = 1
+		}
+		item.Value = rel
+		item.Dragging = true
+	} else if item.ItemType == ITEM_COLORSEL && pressed {
+		step := (item.DrawRect.Y1 - item.DrawRect.Y0) / 4
+		idx := int((mpos.Y - item.DrawRect.Y0) / step)
+		rel := (mpos.X - item.DrawRect.X0) / (item.DrawRect.X1 - item.DrawRect.X0)
+		if rel < 0 {
+			rel = 0
+		}
+		if rel > 1 {
+			rel = 1
+		}
+		switch idx {
+		case 0:
+			item.Value = rel
+		case 1:
+			item.Value2 = rel
+		case 2:
+			item.Value3 = rel
+		}
+		item.Dragging = true
+	} else if item.ItemType == ITEM_COLORSEL && inpututil.IsMouseButtonJustPressed(ebiten.MouseButton1) {
+		item.UseHSV = !item.UseHSV
 	}
 
 	if click {

--- a/render.go
+++ b/render.go
@@ -385,6 +385,68 @@ func (item *itemData) drawItem(parent *itemData, offset point, screen *ebiten.Im
 				1, item.TextColor, false)
 		}
 
+	} else if item.ItemType == ITEM_SLIDER {
+
+		trackH := maxSize.Y / 3
+		ty := offset.Y + (maxSize.Y-trackH)/2
+		drawRoundRect(subImg, &roundRect{
+			Size:     point{X: maxSize.X, Y: trackH},
+			Position: point{X: offset.X, Y: ty},
+			Fillet:   item.Fillet,
+			Filled:   true,
+			Color:    item.Color,
+		})
+		knobX := offset.X + item.Value*(maxSize.X-trackH)
+		drawRoundRect(subImg, &roundRect{
+			Size:     point{X: trackH, Y: trackH},
+			Position: point{X: knobX, Y: ty},
+			Fillet:   item.Fillet,
+			Filled:   true,
+			Color:    item.ClickColor,
+		})
+
+	} else if item.ItemType == ITEM_COLORSEL {
+
+		step := maxSize.Y / 4
+
+		drawSlider := func(val float32, y float32) {
+			trackH := step / 3
+			ty := y + (step-trackH)/2
+			drawRoundRect(subImg, &roundRect{
+				Size:     point{X: maxSize.X, Y: trackH},
+				Position: point{X: offset.X, Y: ty},
+				Fillet:   item.Fillet,
+				Filled:   true,
+				Color:    item.Color,
+			})
+			knobX := offset.X + val*(maxSize.X-trackH)
+			drawRoundRect(subImg, &roundRect{
+				Size:     point{X: trackH, Y: trackH},
+				Position: point{X: knobX, Y: ty},
+				Fillet:   item.Fillet,
+				Filled:   true,
+				Color:    item.ClickColor,
+			})
+		}
+
+		drawSlider(item.Value, offset.Y)
+		drawSlider(item.Value2, offset.Y+step)
+		drawSlider(item.Value3, offset.Y+2*step)
+
+		if item.UseHSV {
+			item.Color = hsvToRGB(item.Value, item.Value2, item.Value3)
+		} else {
+			item.Color = color.RGBA{uint8(item.Value * 255), uint8(item.Value2 * 255), uint8(item.Value3 * 255), 255}
+		}
+
+		drawRoundRect(subImg, &roundRect{
+			Size:     point{X: maxSize.X, Y: step - 2},
+			Position: point{X: offset.X, Y: offset.Y + 3*step},
+			Fillet:   item.Fillet,
+			Filled:   true,
+			Color:    item.Color,
+		})
+
 	} else if item.ItemType == ITEM_TEXT {
 
 		textSize := (item.FontSize * uiScale) + 2

--- a/struct.go
+++ b/struct.go
@@ -39,7 +39,12 @@ type itemData struct {
 	LineSpace float32 //Multiplier, 1.0 = no gap between lines
 	ItemType  itemTypeData
 
-	Value float32
+	Value  float32
+	Value2 float32
+	Value3 float32
+
+	Dragging bool
+	UseHSV   bool
 
 	Hovered, Checked, Focused,
 	Disabled, Invisible bool
@@ -147,4 +152,6 @@ const (
 	ITEM_BUTTON
 	ITEM_CHECKBOX
 	ITEM_INPUT
+	ITEM_SLIDER
+	ITEM_COLORSEL
 )

--- a/util.go
+++ b/util.go
@@ -2,10 +2,37 @@ package main
 
 import (
 	"image"
+	"image/color"
 	"math"
 
 	"github.com/hajimehoshi/ebiten/v2/text/v2"
 )
+
+func hsvToRGB(h, s, v float32) color.RGBA {
+	var r, g, b float32
+	i := int(h * 6)
+	f := h*6 - float32(i)
+	p := v * (1 - s)
+	q := v * (1 - f*s)
+	t := v * (1 - (1-f)*s)
+
+	switch i % 6 {
+	case 0:
+		r, g, b = v, t, p
+	case 1:
+		r, g, b = q, v, p
+	case 2:
+		r, g, b = p, v, t
+	case 3:
+		r, g, b = p, q, v
+	case 4:
+		r, g, b = t, p, v
+	case 5:
+		r, g, b = v, p, q
+	}
+
+	return color.RGBA{uint8(r * 255), uint8(g * 255), uint8(b * 255), 255}
+}
 
 func (rect rect) containsPoint(b point) bool {
 	return b.X >= rect.X0 && b.Y >= rect.Y0 &&

--- a/window.go
+++ b/window.go
@@ -113,6 +113,24 @@ func NewInput(item *itemData) *itemData {
 	return &newItem
 }
 
+// Create a new slider from the default theme
+func NewSlider(item *itemData) *itemData {
+	newItem := *defaultSlider
+	if item != nil {
+		mergeData(&newItem, item)
+	}
+	return &newItem
+}
+
+// Create a new color selector from the default theme
+func NewColorSelector(item *itemData) *itemData {
+	newItem := *defaultColorSelector
+	if item != nil {
+		mergeData(&newItem, item)
+	}
+	return &newItem
+}
+
 // Create a new textbox from the default theme
 func NewText(item *itemData) *itemData {
 	newItem := *defaultText


### PR DESCRIPTION
## Summary
- add fields for slider and color selector widgets
- implement new ITEM_SLIDER and ITEM_COLORSEL types
- add defaults and constructors for slider and color selector
- implement HSV to RGB conversion helper
- add rendering and input handling for sliders and color selector
- demo new color selector in example

## Testing
- `go build ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686f2dd605d8832a992a9557dbf9edee