### PR TITLE
Add support for flow size percentages

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Drawn using vectors and supports floating-point UI scaling.
 # Windows, and flows:
 window -> main-flow -> sub-flow  
 Each flow has a direction, horizontal or vertical.
+Flows can also size themselves relative to their parent by setting `SizePercent`.
 
 ![flows-screenshot](https://github.com/user-attachments/assets/dcc79179-361d-420c-959f-c1785433bb5b)
 

--- a/example.go
+++ b/example.go
@@ -10,16 +10,16 @@ func makeTestWindow() *windowData {
 		})
 
 	mainFlow := &itemData{
-		ItemType: ITEM_FLOW,
-		Size:     newWindow.Size,
-		FlowType: FLOW_HORIZONTAL,
+		ItemType:    ITEM_FLOW,
+		SizePercent: point{X: 1, Y: 1},
+		FlowType:    FLOW_HORIZONTAL,
 	}
 	newWindow.addItemTo(mainFlow)
 
 	leftFlow := &itemData{
-		ItemType: ITEM_FLOW,
-		Size:     point{X: 100, Y: 300},
-		FlowType: FLOW_VERTICAL,
+		ItemType:    ITEM_FLOW,
+		SizePercent: point{X: 0.33, Y: 1},
+		FlowType:    FLOW_VERTICAL,
 	}
 	mainFlow.addItemTo(leftFlow)
 
@@ -37,9 +37,9 @@ func makeTestWindow() *windowData {
 	leftFlow.addItemTo(leftCheckbox1)
 
 	rightFlow := &itemData{
-		ItemType: ITEM_FLOW,
-		Size:     point{X: 200, Y: 300},
-		FlowType: FLOW_HORIZONTAL,
+		ItemType:    ITEM_FLOW,
+		SizePercent: point{X: 0.67, Y: 1},
+		FlowType:    FLOW_HORIZONTAL,
 	}
 	mainFlow.addItemTo(rightFlow)
 

--- a/struct.go
+++ b/struct.go
@@ -28,15 +28,17 @@ type windowData struct {
 }
 
 type itemData struct {
-	Parent    *itemData
-	Text      string
-	Position  point
-	Size      point
-	Alignment alignType
-	PinTo     pinType
-	FontSize  float32
-	LineSpace float32 //Multiplier, 1.0 = no gap between lines
-	ItemType  itemTypeData
+	Parent      *itemData
+	Window      *windowData
+	Text        string
+	Position    point
+	Size        point
+	SizePercent point
+	Alignment   alignType
+	PinTo       pinType
+	FontSize    float32
+	LineSpace   float32 //Multiplier, 1.0 = no gap between lines
+	ItemType    itemTypeData
 
 	Value float32
 

--- a/util.go
+++ b/util.go
@@ -40,10 +40,12 @@ func (item *itemData) getItemRect(win *windowData) rect {
 
 func (parent *itemData) addItemTo(item *itemData) {
 	item.Parent = parent
+	item.Window = parent.Window
 	parent.Contents = append(parent.Contents, item)
 }
 
 func (parent *windowData) addItemTo(item *itemData) {
+	item.Window = parent
 	parent.Contents = append(parent.Contents, item)
 }
 
@@ -270,7 +272,23 @@ func (win *windowData) GetPos() point {
 }
 
 func (item *itemData) GetSize() point {
-	return point{X: item.Size.X * uiScale, Y: item.Size.Y * uiScale}
+	size := item.Size
+	if item.SizePercent.X != 0 || item.SizePercent.Y != 0 {
+		var parentSize point
+		switch {
+		case item.Parent != nil:
+			parentSize = item.Parent.GetSize()
+		case item.Window != nil:
+			parentSize = item.Window.GetSize()
+		}
+		if item.SizePercent.X != 0 {
+			size.X = parentSize.X * item.SizePercent.X / uiScale
+		}
+		if item.SizePercent.Y != 0 {
+			size.Y = parentSize.Y * item.SizePercent.Y / uiScale
+		}
+	}
+	return point{X: size.X * uiScale, Y: size.Y * uiScale}
 }
 
 func (item *itemData) GetPos() point {


### PR DESCRIPTION
## Summary
- allow flows to size themselves as a percentage of their parent
- propagate parent window pointers when building item trees
- demonstrate percentage sizing in `example.go`
- document the `SizePercent` feature

## Testing
- `go vet ./...` *(fails: `X11/extensions/Xrandr.h` not found)*
- `go fmt ./...`


------
https://chatgpt.com/codex/tasks/task_e_686f346dc3e4832ab1f4d223baa56437