### PR TITLE
Add showcase window example

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# Agent Instructions
+
+To compile and test this project, run the setup script once to install system dependencies:
+
+```sh
+./scripts/setup.sh
+```
+
+Then run the following checks before committing any changes:
+
+```sh
+go vet ./...
+go build ./...
+```
+
+The project has no tests, but building should succeed.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Each flow has a direction, horizontal or vertical.
 
 ![flows-screenshot](https://github.com/user-attachments/assets/dcc79179-361d-420c-959f-c1785433bb5b)
 
+An additional showcase window demonstrating all widget types can be found in
+`showcase.go`.
+
 
 
 # Flow and item pinning:

--- a/main.go
+++ b/main.go
@@ -43,6 +43,9 @@ func main() {
 	newWindow2.Position.Y += 192
 	newWindow2.AddWindow(false)
 
+	showcase := makeShowcaseWindow()
+	showcase.AddWindow(false)
+
 	err := loadIcons()
 	if err != nil {
 		fmt.Printf("Error: %v\n", err.Error())

--- a/render.go
+++ b/render.go
@@ -196,8 +196,8 @@ func (item *itemData) drawFlows(parent *itemData, offset point, screen *ebiten.I
 		} else {
 			flowOff := pointAdd(drawOffset, flowOffset)
 
-			objOff := flowOff
-			if parent.ItemType == ITEM_FLOW {
+                        objOff := flowOff
+                        if parent != nil && parent.ItemType == ITEM_FLOW {
 				if parent.FlowType == FLOW_HORIZONTAL {
 					objOff = pointAdd(objOff, point{X: subItem.GetPos().X})
 				} else if parent.FlowType == FLOW_VERTICAL {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+sudo apt-get update
+sudo apt-get install -y libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxxf86vm-dev libgl1-mesa-dev

--- a/showcase.go
+++ b/showcase.go
@@ -1,0 +1,47 @@
+package main
+
+// makeShowcaseWindow creates a window demonstrating most widget types.
+func makeShowcaseWindow() *windowData {
+	win := NewWindow(&windowData{
+		Title:    "Showcase",
+		Size:     point{X: 400, Y: 420},
+		Position: point{X: 420, Y: 8},
+		AutoSize: true,
+	})
+
+	mainFlow := &itemData{
+		ItemType: ITEM_FLOW,
+		Size:     win.Size,
+		FlowType: FLOW_VERTICAL,
+	}
+	win.addItemTo(mainFlow)
+
+	titleText := NewText(&itemData{Text: "Demonstration of widgets", Size: point{X: 380, Y: 32}, FontSize: 10})
+	mainFlow.addItemTo(titleText)
+
+	btnImage := NewButton(&itemData{Text: "Sprite Button", ImageName: "1", Size: point{X: 100, Y: 64}, FontSize: 8})
+	mainFlow.addItemTo(btnImage)
+
+	chk := NewCheckbox(&itemData{Text: "Enable option", Size: point{X: 140, Y: 32}, FontSize: 8})
+	mainFlow.addItemTo(chk)
+
+	radioA := NewRadio(&itemData{Text: "Choice A", RadioGroup: "grp1", Size: point{X: 140, Y: 32}, FontSize: 8})
+	radioB := NewRadio(&itemData{Text: "Choice B", RadioGroup: "grp1", Size: point{X: 140, Y: 32}, FontSize: 8})
+	mainFlow.addItemTo(radioA)
+	mainFlow.addItemTo(radioB)
+
+	slider := NewSlider(&itemData{Size: point{X: 180, Y: 24}, MinValue: 0, MaxValue: 100, IntOnly: false, FontSize: 8})
+	mainFlow.addItemTo(slider)
+
+	input := NewInput(&itemData{Size: point{X: 180, Y: 24}, FontSize: 8})
+	mainFlow.addItemTo(input)
+
+	hFlow := &itemData{ItemType: ITEM_FLOW, FlowType: FLOW_HORIZONTAL, Size: point{X: 380, Y: 40}, Scrollable: true}
+	mainFlow.addItemTo(hFlow)
+	hFlow.addItemTo(NewButton(&itemData{Text: "One", Size: point{X: 60, Y: 24}, FontSize: 8}))
+	hFlow.addItemTo(NewButton(&itemData{Text: "Two", Size: point{X: 60, Y: 24}, FontSize: 8}))
+	hFlow.addItemTo(NewButton(&itemData{Text: "Three", Size: point{X: 60, Y: 24}, FontSize: 8}))
+	hFlow.addItemTo(NewButton(&itemData{Text: "Four", Size: point{X: 60, Y: 24}, FontSize: 8}))
+
+	return win
+}


### PR DESCRIPTION
## Summary
- add new showcase window to demonstrate widgets
- open showcase window in main.go
- mention showcase window in README

## Testing
- `go vet ./...` *(fails: X11/extensions/Xrandr.h missing)*
- `go build ./...` *(fails: X11/extensions/Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_686f3f8c23bc832a86f9b3bc3992ebd0