### PR TITLE
Add headless screenshot support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,6 @@ PIN_MID_RIGHT
 PIN_BOTTOM_LEFT  
 PIN_BOTTOM_CENTER  
 PIN_BOTTOM_RIGHT
+
+## Rendering a screenshot on a headless system
+Run `scripts/headless_screenshot.sh` to install dependencies and launch the demo under `Xvfb`. The script sends a key press to trigger Ebitengine's built-in screenshot function. The resulting PNG is saved in the current directory with a name such as `screenshot_YYYYMMDDHHMMSS.png`.

--- a/scripts/headless_screenshot.sh
+++ b/scripts/headless_screenshot.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+
+# Ensure system dependencies are installed
+./scripts/setup.sh
+sudo apt-get install -y xvfb xdotool
+
+# Download Go module dependencies
+go mod download
+
+# Start virtual frame buffer
+Xvfb :99 -screen 0 1024x768x24 &
+XVFB_PID=$!
+sleep 2
+
+# Run the demo with a screenshot key
+DISPLAY=:99 EBITENGINE_SCREENSHOT_KEY=q go run . &
+APP_PID=$!
+
+# Give the window time to initialize
+sleep 5
+
+# Trigger screenshot
+xdotool search --name "EUI Prototype" key q
+
+# Wait a moment for the image to be written
+sleep 2
+
+# Clean up
+kill $APP_PID || true
+wait $APP_PID 2>/dev/null || true
+kill $XVFB_PID || true
+wait $XVFB_PID 2>/dev/null || true
+
+echo "Screenshot saved as screenshot_<timestamp>.png"


### PR DESCRIPTION
## Summary
- add `headless_screenshot.sh` to automate installing dependencies and capturing a screenshot on headless systems
- document the new script in the README

## Testing
- `./scripts/setup.sh`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_686fb4c5a42c832abc555f1bb11a6795