### PR TITLE
Fix slider text clipping and showcase widgets

### DIFF
--- a/input.go
+++ b/input.go
@@ -290,6 +290,7 @@ func (item *itemData) setSliderValue(mpos point) {
 	item.Value = item.MinValue + ratio*(item.MaxValue-item.MinValue)
 	if item.IntOnly {
 		item.Value = float32(int(item.Value + 0.5))
+		ratio = (item.Value - item.MinValue) / (item.MaxValue - item.MinValue)
 	}
 }
 

--- a/render.go
+++ b/render.go
@@ -552,8 +552,9 @@ func (item *itemData) drawItem(parent *itemData, offset point, screen *ebiten.Im
 			SecondaryAlign: text.AlignCenter,
 		}
 		tdop := ebiten.DrawImageOptions{}
+		tw, _ := text.Measure(valueText, face, 0)
 		tdop.GeoM.Translate(
-			float64(offset.X+maxSize.X-item.AuxSpace),
+			float64(offset.X+maxSize.X-item.AuxSpace-float32(tw)),
 			float64(offset.Y+(maxSize.Y/2)),
 		)
 		top := &text.DrawOptions{DrawImageOptions: tdop, LayoutOptions: loo}

--- a/showcase.go
+++ b/showcase.go
@@ -21,6 +21,8 @@ func makeShowcaseWindow() *windowData {
 
 	btnImage := NewButton(&itemData{Text: "Sprite Button", ImageName: "1", Size: point{X: 100, Y: 64}, FontSize: 8})
 	mainFlow.addItemTo(btnImage)
+	btnText := NewButton(&itemData{Text: "Text Button", Size: point{X: 100, Y: 24}, FontSize: 8})
+	mainFlow.addItemTo(btnText)
 
 	chk := NewCheckbox(&itemData{Text: "Enable option", Size: point{X: 140, Y: 32}, FontSize: 8})
 	mainFlow.addItemTo(chk)
@@ -32,6 +34,8 @@ func makeShowcaseWindow() *windowData {
 
 	slider := NewSlider(&itemData{Size: point{X: 180, Y: 24}, MinValue: 0, MaxValue: 100, IntOnly: false, FontSize: 8})
 	mainFlow.addItemTo(slider)
+	intSlider := NewSlider(&itemData{Size: point{X: 180, Y: 24}, MinValue: 0, MaxValue: 10, IntOnly: true, FontSize: 8})
+	mainFlow.addItemTo(intSlider)
 
 	input := NewInput(&itemData{Size: point{X: 180, Y: 24}, FontSize: 8})
 	mainFlow.addItemTo(input)


### PR DESCRIPTION
## Summary
- prevent slider value text from being drawn outside widget
- snap slider position to int value
- show text-only button and integer slider in showcase

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6871c2abaeb4832abba65aa69fa00dd7