### PR TITLE
Update screenshot action to install key packages

### DIFF
--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -15,6 +15,10 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
+      - name: Install X keyboard packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y x11-xkb-utils xkb-data
       - name: Run screenshot script
         run: |
           chmod +x scripts/headless_screenshot.sh

--- a/scripts/headless_screenshot.sh
+++ b/scripts/headless_screenshot.sh
@@ -9,7 +9,9 @@ sudo apt-get install -y xvfb xdotool
 go mod download
 
 # Start virtual frame buffer
-Xvfb :99 -screen 0 1024x768x24 &
+# xkbcomp may return non-zero for unknown keysyms; redirect output so it
+# doesn't cause the script to fail.
+Xvfb :99 -screen 0 1024x768x24 >/tmp/xvfb.log 2>&1 &
 XVFB_PID=$!
 sleep 2
 


### PR DESCRIPTION
## Summary
- install xkeyboard packages in screenshot workflow
- ignore xkbcomp warnings in headless screenshot script

## Testing
- `./scripts/setup.sh` *(passed)*
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6871ce25f000832ab11afb8171c0a17b