### PR TITLE
Fix tab colors for tabbed flows

### DIFF
--- a/example.go
+++ b/example.go
@@ -48,9 +48,11 @@ func makeTestWindow() *windowData {
 	leftFlow.addItemTo(leftInput1)
 
 	tabFlow := &itemData{
-		ItemType: ITEM_FLOW,
-		Size:     point{X: 200, Y: 300},
-		FlowType: FLOW_VERTICAL,
+		ItemType:   ITEM_FLOW,
+		Size:       point{X: 200, Y: 300},
+		FlowType:   FLOW_VERTICAL,
+		Color:      ColorDarkGray,
+		ClickColor: ColorDarkTeal,
 		Tabs: []*itemData{
 			{Name: "Tab 1", ItemType: ITEM_FLOW, FlowType: FLOW_VERTICAL},
 			{Name: "Tab 2", ItemType: ITEM_FLOW, FlowType: FLOW_VERTICAL},

--- a/showcase.go
+++ b/showcase.go
@@ -48,10 +48,12 @@ func makeShowcaseWindow() *windowData {
 	hFlow.addItemTo(NewButton(&itemData{Text: "Four", Size: point{X: 60, Y: 24}, FontSize: 8}))
 
 	tabFlow := &itemData{
-		ItemType: ITEM_FLOW,
-		FlowType: FLOW_VERTICAL,
-		Size:     point{X: 380, Y: 120},
-		FontSize: 8,
+		ItemType:   ITEM_FLOW,
+		FlowType:   FLOW_VERTICAL,
+		Size:       point{X: 380, Y: 120},
+		Color:      ColorDarkGray,
+		ClickColor: ColorDarkTeal,
+		FontSize:   8,
 		Tabs: []*itemData{
 			{Name: "Tab 1", ItemType: ITEM_FLOW, FlowType: FLOW_VERTICAL},
 			{Name: "Tab 2", ItemType: ITEM_FLOW, FlowType: FLOW_VERTICAL},


### PR DESCRIPTION
## Summary
- apply tab colors in example and showcase windows so tab headers are visible

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6871d04f513c832a980b5688c23d0279