### PR TITLE
Fix showcase tab visibility

### DIFF
--- a/showcase.go
+++ b/showcase.go
@@ -47,13 +47,14 @@ func makeShowcaseWindow() *windowData {
 	hFlow.addItemTo(NewButton(&itemData{Text: "Three", Size: point{X: 60, Y: 24}, FontSize: 8}))
 	hFlow.addItemTo(NewButton(&itemData{Text: "Four", Size: point{X: 60, Y: 24}, FontSize: 8}))
 
-	tabFlow := &itemData{
-		ItemType:   ITEM_FLOW,
-		FlowType:   FLOW_VERTICAL,
-		Size:       point{X: 380, Y: 120},
-		Color:      ColorDarkGray,
-		ClickColor: ColorDarkTeal,
-		FontSize:   8,
+       tabFlow := &itemData{
+               ItemType:   ITEM_FLOW,
+               FlowType:   FLOW_VERTICAL,
+               Size:       point{X: 380, Y: 120},
+               Fixed:      true,
+               Color:      ColorDarkGray,
+               ClickColor: ColorDarkTeal,
+               FontSize:   8,
 		Tabs: []*itemData{
 			{Name: "Tab 1", ItemType: ITEM_FLOW, FlowType: FLOW_VERTICAL},
 			{Name: "Tab 2", ItemType: ITEM_FLOW, FlowType: FLOW_VERTICAL},


### PR DESCRIPTION
## Summary
- keep showcase tabs at a fixed height so they render properly

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6871d7d1745c832aaa1ff522c5045a64