### PR TITLE
Fix theme default to show showcase window

### DIFF
--- a/themes/DefaultDark.json
+++ b/themes/DefaultDark.json
@@ -17,7 +17,7 @@
     "HoverTitleColor": {"R":64,"G":128,"B":128,"A":255},
     "HoverColor": {"R":80,"G":80,"B":80,"A":255},
     "ActiveColor": {"R":0,"G":128,"B":128,"A":255},
-    "Open": false,
+    "Open": true,
     "Hovered": false,
     "Flow": false,
     "Closable": true,


### PR DESCRIPTION
## Summary
- ensure windows created from theme are visible

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687411a9c7a4832a9240b8c22924a51e