### PR TITLE
Fix dropdown pinned position

### DIFF
--- a/render.go
+++ b/render.go
@@ -177,7 +177,7 @@ func (win *windowData) drawBorder(screen *ebiten.Image) {
 }
 
 func (win *windowData) drawItems(screen *ebiten.Image) {
-        winPos := pointAdd(win.GetPos(), point{X: 0, Y: win.GetTitleSize()})
+        winPos := pointAdd(win.getPosition(), point{X: 0, Y: win.GetTitleSize()})
 
         for _, item := range win.Contents {
                 itemPos := pointAdd(winPos, item.getPosition(win))


### PR DESCRIPTION
## Summary
- ensure dropdown items are drawn relative to the pinned window position

## Testing
- `./scripts/setup.sh`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687467fe5564832aa1ac1b5fb170a952