### PR TITLE
Fix dropdown defaults after theme selection

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -153,3 +153,16 @@ var defaultDropdown = &itemData{
 	ClickColor: color.RGBA{R: 0, G: 128, B: 128, A: 255},
 	MaxVisible: 5,
 }
+
+// base copies preserve the initial defaults so that LoadTheme can reset
+// to these values before applying theme overrides.
+var (
+    baseWindow   = *defaultTheme
+    baseButton   = *defaultButton
+    baseText     = *defaultText
+    baseCheckbox = *defaultCheckbox
+    baseRadio    = *defaultRadio
+    baseInput    = *defaultInput
+    baseSlider   = *defaultSlider
+    baseDropdown = *defaultDropdown
+)

--- a/theme.go
+++ b/theme.go
@@ -29,18 +29,29 @@ func LoadTheme(name string) error {
 		return err
 	}
 	var t Theme
-	if err := json.Unmarshal(data, &t); err != nil {
-		return err
-	}
-	*defaultTheme = t.Window
-	*defaultButton = t.Button
-	*defaultText = t.Text
-	*defaultCheckbox = t.Checkbox
-	*defaultRadio = t.Radio
-	*defaultInput = t.Input
-	*defaultSlider = t.Slider
-	*defaultDropdown = t.Dropdown
-	return nil
+       if err := json.Unmarshal(data, &t); err != nil {
+               return err
+       }
+
+       // Reset to the built-in defaults before applying overrides
+       *defaultTheme = baseWindow
+       *defaultButton = baseButton
+       *defaultText = baseText
+       *defaultCheckbox = baseCheckbox
+       *defaultRadio = baseRadio
+       *defaultInput = baseInput
+       *defaultSlider = baseSlider
+       *defaultDropdown = baseDropdown
+
+       mergeData(defaultTheme, &t.Window)
+       mergeData(defaultButton, &t.Button)
+       mergeData(defaultText, &t.Text)
+       mergeData(defaultCheckbox, &t.Checkbox)
+       mergeData(defaultRadio, &t.Radio)
+       mergeData(defaultInput, &t.Input)
+       mergeData(defaultSlider, &t.Slider)
+       mergeData(defaultDropdown, &t.Dropdown)
+       return nil
 }
 
 // listThemes returns the available theme names from the themes directory


### PR DESCRIPTION
## Summary
- ensure LoadTheme resets defaults before applying overrides
- keep an untouched copy of defaults for resets

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68747c13ec64832abed26b0041378320