### PR TITLE
Fix default windows closing

### DIFF
--- a/example.go
+++ b/example.go
@@ -1,14 +1,15 @@
 package main
 
 func makeTestWindow() *windowData {
-	newWindow := NewWindow(
-		&windowData{
-			TitleHeight: 24,
-			Title:       "Test Window",
-			Size:        point{X: 300, Y: 300},
-			Position:    point{X: 8, Y: 8},
-			AutoSize:    true,
-		})
+       newWindow := NewWindow(
+               &windowData{
+                       TitleHeight: 24,
+                       Title:       "Test Window",
+                       Size:        point{X: 300, Y: 300},
+                       Position:    point{X: 8, Y: 8},
+                       AutoSize:    true,
+                       Open:        true,
+               })
 
 	mainFlow := &itemData{
 		ItemType: ITEM_FLOW,

--- a/showcase.go
+++ b/showcase.go
@@ -2,12 +2,13 @@ package main
 
 // makeShowcaseWindow creates a window demonstrating most widget types.
 func makeShowcaseWindow() *windowData {
-	win := NewWindow(&windowData{
-		Title:    "Showcase",
-		Size:     point{X: 400, Y: 420},
-		Position: point{X: 8, Y: 8},
-		AutoSize: true,
-	})
+       win := NewWindow(&windowData{
+               Title:    "Showcase",
+               Size:     point{X: 400, Y: 420},
+               Position: point{X: 8, Y: 8},
+               AutoSize: true,
+               Open:     true,
+       })
 
 	mainFlow := &itemData{
 		ItemType: ITEM_FLOW,

--- a/theme_selector.go
+++ b/theme_selector.go
@@ -11,17 +11,18 @@ func makeThemeSelector() *windowData {
 	if currentTheme == "" {
 		currentTheme = names[0]
 	}
-	win := NewWindow(&windowData{
-		Title:     "Themes",
-		PinTo:     PIN_TOP_RIGHT,
-		Movable:   false,
-		Resizable: false,
-		Closable:  false,
-		// Give the dropdown room to fully render by accounting for the
-		// title bar height and the control's size.
-		Size:     point{X: 192, Y: 160},
-		Position: point{X: 4, Y: 4},
-	})
+       win := NewWindow(&windowData{
+               Title:     "Themes",
+               PinTo:     PIN_TOP_RIGHT,
+               Movable:   false,
+               Resizable: false,
+               Closable:  false,
+               // Give the dropdown room to fully render by accounting for the
+               // title bar height and the control's size.
+               Size:     point{X: 192, Y: 160},
+               Position: point{X: 4, Y: 4},
+               Open:     true,
+       })
 	dd := NewDropdown(&itemData{Size: point{X: 150, Y: 24}, FontSize: 8})
 	dd.Options = names
 	for i, n := range names {


### PR DESCRIPTION
## Summary
- ensure newly created windows start open so they aren't hidden after merging theme defaults

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687490f84e04832a9597288041222a82