### PR TITLE
Refactor theme management

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -3,13 +3,13 @@ package main
 import "image/color"
 
 var defaultTheme = &windowData{
-       TitleHeight:     24,
-       Border:          1,
-       Outlined:        true,
-       Fillet:          4,
-       Padding:         0,
-       Margin:          0,
-       BorderPad:       0,
+	TitleHeight:     24,
+	Border:          1,
+	Outlined:        true,
+	Fillet:          4,
+	Padding:         0,
+	Margin:          0,
+	BorderPad:       0,
 	TitleColor:      color.RGBA{R: 255, G: 255, B: 255, A: 255},
 	TitleTextColor:  color.RGBA{R: 255, G: 255, B: 255, A: 255},
 	TitleBGColor:    color.RGBA{R: 0, G: 0, B: 0, A: 0},
@@ -28,18 +28,18 @@ var defaultTheme = &windowData{
 }
 
 var defaultButton = &itemData{
-        Text:      "Button",
-        ItemType:  ITEM_BUTTON,
-        Size:      point{X: 128, Y: 64},
-        Position:  point{X: 4, Y: 4},
-        FontSize:  12,
-        LineSpace: 1.2,
+	Text:      "Button",
+	ItemType:  ITEM_BUTTON,
+	Size:      point{X: 128, Y: 64},
+	Position:  point{X: 4, Y: 4},
+	FontSize:  12,
+	LineSpace: 1.2,
 
-       Padding: 0,
-       Margin:  0,
+	Padding: 0,
+	Margin:  0,
 
-        Fillet: 8,
-        Filled: true, Outlined: true,
+	Fillet: 8,
+	Filled: true, Outlined: true,
 	Border:    1,
 	BorderPad: 4,
 
@@ -54,10 +54,10 @@ var defaultText = &itemData{
 	ItemType:  ITEM_TEXT,
 	Size:      point{X: 128, Y: 128},
 	Position:  point{X: 4, Y: 4},
-       FontSize:  24,
-       LineSpace: 1.2,
-       Padding:   0,
-       Margin:    0,
+	FontSize:  24,
+	LineSpace: 1.2,
+	Padding:   0,
+	Margin:    0,
 	TextColor: color.RGBA{R: 255, G: 255, B: 255, A: 255},
 }
 
@@ -67,11 +67,11 @@ var defaultCheckbox = &itemData{
 	Size:      point{X: 128, Y: 32},
 	Position:  point{X: 4, Y: 4},
 	AuxSize:   point{X: 16, Y: 16},
-       AuxSpace:  4,
-       FontSize:  12,
-       LineSpace: 1.2,
-       Padding:   0,
-       Margin:    0,
+	AuxSpace:  4,
+	FontSize:  12,
+	LineSpace: 1.2,
+	Padding:   0,
+	Margin:    0,
 
 	Fillet: 8,
 	Filled: true, Outlined: true,
@@ -88,10 +88,10 @@ var defaultInput = &itemData{
 	ItemType:  ITEM_INPUT,
 	Size:      point{X: 128, Y: 24},
 	Position:  point{X: 4, Y: 4},
-       FontSize:  12,
-       LineSpace: 1.2,
-       Padding:   0,
-       Margin:    0,
+	FontSize:  12,
+	LineSpace: 1.2,
+	Padding:   0,
+	Margin:    0,
 
 	Fillet: 4,
 	Filled: true, Outlined: false,
@@ -110,11 +110,11 @@ var defaultRadio = &itemData{
 	Size:      point{X: 128, Y: 32},
 	Position:  point{X: 4, Y: 4},
 	AuxSize:   point{X: 16, Y: 16},
-       AuxSpace:  4,
-       FontSize:  12,
-       LineSpace: 1.2,
-       Padding:   0,
-       Margin:    0,
+	AuxSpace:  4,
+	FontSize:  12,
+	LineSpace: 1.2,
+	Padding:   0,
+	Margin:    0,
 
 	Fillet: 8,
 	Filled: true, Outlined: true,
@@ -132,10 +132,10 @@ var defaultSlider = &itemData{
 	Size:     point{X: 128, Y: 24},
 	Position: point{X: 4, Y: 4},
 	AuxSize:  point{X: 8, Y: 16},
-       AuxSpace: 4,
-       FontSize: 12,
-       Padding:  0,
-       Margin:   0,
+	AuxSpace: 4,
+	FontSize: 12,
+	Padding:  0,
+	Margin:   0,
 
 	MinValue: 0,
 	MaxValue: 100,
@@ -157,9 +157,9 @@ var defaultDropdown = &itemData{
 	ItemType: ITEM_DROPDOWN,
 	Size:     point{X: 128, Y: 24},
 	Position: point{X: 4, Y: 4},
-       FontSize: 12,
-       Padding:  0,
-       Margin:   0,
+	FontSize: 12,
+	Padding:  0,
+	Margin:   0,
 
 	Fillet: 4,
 	Filled: true, Outlined: true,
@@ -176,12 +176,22 @@ var defaultDropdown = &itemData{
 // base copies preserve the initial defaults so that LoadTheme can reset
 // to these values before applying theme overrides.
 var (
-    baseWindow   = *defaultTheme
-    baseButton   = *defaultButton
-    baseText     = *defaultText
-    baseCheckbox = *defaultCheckbox
-    baseRadio    = *defaultRadio
-    baseInput    = *defaultInput
-    baseSlider   = *defaultSlider
-    baseDropdown = *defaultDropdown
+	baseWindow   = *defaultTheme
+	baseButton   = *defaultButton
+	baseText     = *defaultText
+	baseCheckbox = *defaultCheckbox
+	baseRadio    = *defaultRadio
+	baseInput    = *defaultInput
+	baseSlider   = *defaultSlider
+	baseDropdown = *defaultDropdown
+	baseTheme    = &Theme{
+		Window:   baseWindow,
+		Button:   baseButton,
+		Text:     baseText,
+		Checkbox: baseCheckbox,
+		Radio:    baseRadio,
+		Input:    baseInput,
+		Slider:   baseSlider,
+		Dropdown: baseDropdown,
+	}
 )

--- a/glob.go
+++ b/glob.go
@@ -16,14 +16,15 @@ var (
 	screenWidth  = 1024
 	screenHeight = 1024
 
-	signalHandle    chan os.Signal
-	mplusFaceSource *text.GoTextFaceSource
-	windows         []*windowData
-	activeWindow    *windowData
-	focusedItem     *itemData
-	uiScale         float32 = 1.0
-	currentTheme    string
-	clickFlash      = time.Millisecond * 100
+	signalHandle     chan os.Signal
+	mplusFaceSource  *text.GoTextFaceSource
+	windows          []*windowData
+	activeWindow     *windowData
+	focusedItem      *itemData
+	uiScale          float32 = 1.0
+	currentTheme     *Theme
+	currentThemeName string
+	clickFlash       = time.Millisecond * 100
 
 	whiteImage    = ebiten.NewImage(3, 3)
 	whiteSubImage = whiteImage.SubImage(image.Rect(1, 1, 2, 2)).(*ebiten.Image)

--- a/struct.go
+++ b/struct.go
@@ -8,17 +8,17 @@ import (
 )
 
 type windowData struct {
-       Title    string
-       Position point
-       Size     point
-       PinTo    pinType
+	Title    string
+	Position point
+	Size     point
+	PinTo    pinType
 
-       Padding   float32
-       Margin    float32
-       Border    float32
-       BorderPad float32
-       Fillet    float32
-       Outlined  bool
+	Padding   float32
+	Margin    float32
+	Border    float32
+	BorderPad float32
+	Fillet    float32
+	Outlined  bool
 
 	Open, Hovered, Flow,
 	Closable, Movable, Resizable,
@@ -38,6 +38,8 @@ type windowData struct {
 	HoverTitleColor, HoverColor, ActiveColor color.RGBA
 
 	Contents []*itemData
+
+	Theme *Theme
 }
 
 type itemData struct {
@@ -81,10 +83,10 @@ type itemData struct {
 	Image     *ebiten.Image
 
 	//Style
-       Padding, Margin float32
+	Padding, Margin float32
 
-       Fillet            float32
-       Border, BorderPad float32
+	Fillet            float32
+	Border, BorderPad float32
 	Filled, Outlined  bool
 	AuxSize           point
 	AuxSpace          float32

--- a/theme.go
+++ b/theme.go
@@ -4,102 +4,37 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"reflect"
 	"sort"
 	"strings"
 )
 
-// applyJSON merges the JSON object data into the given struct by
-// only updating fields present in the JSON. This prevents missing
-// values from overwriting existing settings.
-func applyJSON(target interface{}, data json.RawMessage) error {
-	var obj map[string]json.RawMessage
-	if err := json.Unmarshal(data, &obj); err != nil {
-		return err
-	}
-	v := reflect.ValueOf(target).Elem()
-	for name, raw := range obj {
-		f := v.FieldByName(name)
-		if !f.IsValid() || !f.CanSet() {
-			continue
-		}
-		valPtr := reflect.New(f.Type())
-		if err := json.Unmarshal(raw, valPtr.Interface()); err != nil {
-			return err
-		}
-		f.Set(valPtr.Elem())
-	}
-	return nil
+// Theme bundles all style information for windows and widgets.
+type Theme struct {
+	Window   windowData
+	Button   itemData
+	Text     itemData
+	Checkbox itemData
+	Radio    itemData
+	Input    itemData
+	Slider   itemData
+	Dropdown itemData
 }
 
-// LoadTheme reads a theme JSON file from the themes directory
-// and sets it as the default style.
+// LoadTheme reads a theme JSON file from the themes directory and
+// sets it as the current theme without modifying existing windows.
 func LoadTheme(name string) error {
 	file := filepath.Join("themes", name+".json")
 	data, err := os.ReadFile(file)
 	if err != nil {
 		return err
 	}
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(data, &raw); err != nil {
+	// Start with the compiled in defaults
+	th := *baseTheme
+	if err := json.Unmarshal(data, &th); err != nil {
 		return err
 	}
-
-	// Reset to the built-in defaults before applying overrides
-	*defaultTheme = baseWindow
-	*defaultButton = baseButton
-	*defaultText = baseText
-	*defaultCheckbox = baseCheckbox
-	*defaultRadio = baseRadio
-	*defaultInput = baseInput
-	*defaultSlider = baseSlider
-	*defaultDropdown = baseDropdown
-
-	if v, ok := raw["Window"]; ok {
-		if err := applyJSON(defaultTheme, v); err != nil {
-			return err
-		}
-	}
-	if v, ok := raw["Button"]; ok {
-		if err := applyJSON(defaultButton, v); err != nil {
-			return err
-		}
-	}
-	if v, ok := raw["Text"]; ok {
-		if err := applyJSON(defaultText, v); err != nil {
-			return err
-		}
-	}
-	if v, ok := raw["Checkbox"]; ok {
-		if err := applyJSON(defaultCheckbox, v); err != nil {
-			return err
-		}
-	}
-	if v, ok := raw["Radio"]; ok {
-		if err := applyJSON(defaultRadio, v); err != nil {
-			return err
-		}
-	}
-	if v, ok := raw["Input"]; ok {
-		if err := applyJSON(defaultInput, v); err != nil {
-			return err
-		}
-	}
-	if v, ok := raw["Slider"]; ok {
-		if err := applyJSON(defaultSlider, v); err != nil {
-			return err
-		}
-	}
-	if v, ok := raw["Dropdown"]; ok {
-		if err := applyJSON(defaultDropdown, v); err != nil {
-			return err
-		}
-	}
-
-	// Apply new defaults to all existing windows and items so that
-	// the currently displayed UI reflects the loaded theme.
-	ApplyTheme()
-
+	currentTheme = &th
+	currentThemeName = name
 	return nil
 }
 
@@ -119,81 +54,4 @@ func listThemes() ([]string, error) {
 	}
 	sort.Strings(names)
 	return names, nil
-}
-
-// ApplyTheme updates all existing windows and items using the
-// currently loaded default styles. This is used after loading a
-// new theme so that the on-screen UI immediately reflects the
-// new colors and margins without recreating the windows.
-func ApplyTheme() {
-	for _, win := range windows {
-		applyThemeToWindow(win)
-	}
-}
-
-func applyThemeToWindow(win *windowData) {
-	// Preserve dynamic state that themes shouldn't modify
-	open := win.Open
-	movable := win.Movable
-	resizable := win.Resizable
-	closable := win.Closable
-
-	// Merge the window with the defaultTheme values
-	mergeData(win, defaultTheme)
-
-	// Restore the preserved state
-	win.Open = open
-	win.Movable = movable
-	win.Resizable = resizable
-	win.Closable = closable
-
-	for _, item := range win.Contents {
-		applyThemeToItem(item)
-	}
-}
-
-func applyThemeToItem(it *itemData) {
-	// Preserve interactive state that shouldn't be affected by themes
-	open := it.Open
-	checked := it.Checked
-	value := it.Value
-	selected := it.Selected
-	hoverIndex := it.HoverIndex
-	scroll := it.Scroll
-	focused := it.Focused
-
-	switch it.ItemType {
-	case ITEM_BUTTON:
-		mergeData(it, defaultButton)
-	case ITEM_TEXT:
-		mergeData(it, defaultText)
-	case ITEM_CHECKBOX:
-		mergeData(it, defaultCheckbox)
-	case ITEM_RADIO:
-		mergeData(it, defaultRadio)
-	case ITEM_INPUT:
-		mergeData(it, defaultInput)
-	case ITEM_SLIDER:
-		mergeData(it, defaultSlider)
-	case ITEM_DROPDOWN:
-		mergeData(it, defaultDropdown)
-	}
-
-	// Restore preserved state
-	it.Open = open
-	it.Checked = checked
-	it.Value = value
-	it.Selected = selected
-	it.HoverIndex = hoverIndex
-	it.Scroll = scroll
-	it.Focused = focused
-
-	for _, child := range it.Contents {
-		applyThemeToItem(child)
-	}
-	for _, tab := range it.Tabs {
-		for _, sub := range tab.Contents {
-			applyThemeToItem(sub)
-		}
-	}
 }

--- a/theme_selector.go
+++ b/theme_selector.go
@@ -8,32 +8,32 @@ func makeThemeSelector() *windowData {
 		log.Printf("listThemes error: %v", err)
 		return nil
 	}
-	if currentTheme == "" {
-		currentTheme = names[0]
+	if currentThemeName == "" {
+		currentThemeName = names[0]
 	}
-       win := NewWindow(&windowData{
-               Title:     "Themes",
-               PinTo:     PIN_TOP_RIGHT,
-               Movable:   false,
-               Resizable: false,
-               Closable:  false,
-               // Give the dropdown room to fully render by accounting for the
-               // title bar height and the control's size.
-               Size:     point{X: 192, Y: 160},
-               Position: point{X: 4, Y: 4},
-               Open:     true,
-       })
+	win := NewWindow(&windowData{
+		Title:     "Themes",
+		PinTo:     PIN_TOP_RIGHT,
+		Movable:   false,
+		Resizable: false,
+		Closable:  false,
+		// Give the dropdown room to fully render by accounting for the
+		// title bar height and the control's size.
+		Size:     point{X: 192, Y: 160},
+		Position: point{X: 4, Y: 4},
+		Open:     true,
+	})
 	dd := NewDropdown(&itemData{Size: point{X: 150, Y: 24}, FontSize: 8})
 	dd.Options = names
 	for i, n := range names {
-		if n == currentTheme {
+		if n == currentThemeName {
 			dd.Selected = i
 			break
 		}
 	}
 	dd.OnSelect = func(idx int) {
-		currentTheme = names[idx]
-		if err := LoadTheme(currentTheme); err != nil {
+		currentThemeName = names[idx]
+		if err := LoadTheme(currentThemeName); err != nil {
 			log.Printf("LoadTheme error: %v", err)
 		}
 	}

--- a/window.go
+++ b/window.go
@@ -95,16 +95,23 @@ func (target *windowData) RemoveWindow() {
 
 // Create a new window from the default theme
 func NewWindow(win *windowData) *windowData {
-	newWindow := *defaultTheme
+	if currentTheme == nil {
+		currentTheme = baseTheme
+	}
+	newWindow := currentTheme.Window
 	if win != nil {
 		mergeData(&newWindow, win)
 	}
+	newWindow.Theme = currentTheme
 	return &newWindow
 }
 
 // Create a new button from the default theme
 func NewButton(item *itemData) *itemData {
-	newItem := *defaultButton
+	if currentTheme == nil {
+		currentTheme = baseTheme
+	}
+	newItem := currentTheme.Button
 	if item != nil {
 		mergeData(&newItem, item)
 	}
@@ -113,7 +120,10 @@ func NewButton(item *itemData) *itemData {
 
 // Create a new button from the default theme
 func NewCheckbox(item *itemData) *itemData {
-	newItem := *defaultCheckbox
+	if currentTheme == nil {
+		currentTheme = baseTheme
+	}
+	newItem := currentTheme.Checkbox
 	if item != nil {
 		mergeData(&newItem, item)
 	}
@@ -122,7 +132,10 @@ func NewCheckbox(item *itemData) *itemData {
 
 // Create a new radio button from the default theme
 func NewRadio(item *itemData) *itemData {
-	newItem := *defaultRadio
+	if currentTheme == nil {
+		currentTheme = baseTheme
+	}
+	newItem := currentTheme.Radio
 	if item != nil {
 		mergeData(&newItem, item)
 	}
@@ -131,7 +144,10 @@ func NewRadio(item *itemData) *itemData {
 
 // Create a new input box from the default theme
 func NewInput(item *itemData) *itemData {
-	newItem := *defaultInput
+	if currentTheme == nil {
+		currentTheme = baseTheme
+	}
+	newItem := currentTheme.Input
 	if item != nil {
 		mergeData(&newItem, item)
 	}
@@ -140,7 +156,10 @@ func NewInput(item *itemData) *itemData {
 
 // Create a new slider from the default theme
 func NewSlider(item *itemData) *itemData {
-	newItem := *defaultSlider
+	if currentTheme == nil {
+		currentTheme = baseTheme
+	}
+	newItem := currentTheme.Slider
 	if item != nil {
 		mergeData(&newItem, item)
 	}
@@ -149,7 +168,10 @@ func NewSlider(item *itemData) *itemData {
 
 // Create a new dropdown from the default theme
 func NewDropdown(item *itemData) *itemData {
-	newItem := *defaultDropdown
+	if currentTheme == nil {
+		currentTheme = baseTheme
+	}
+	newItem := currentTheme.Dropdown
 	if item != nil {
 		mergeData(&newItem, item)
 	}
@@ -158,7 +180,10 @@ func NewDropdown(item *itemData) *itemData {
 
 // Create a new textbox from the default theme
 func NewText(item *itemData) *itemData {
-	newItem := *defaultText
+	if currentTheme == nil {
+		currentTheme = baseTheme
+	}
+	newItem := currentTheme.Text
 	if item != nil {
 		mergeData(&newItem, item)
 	}


### PR DESCRIPTION
## Summary
- simplify theme system by introducing a `Theme` struct
- keep one theme pointer and avoid mutating window/item data when loading a theme
- update constructors to read styles from the active theme
- rename theme global variables and adjust theme selector

## Testing
- `./scripts/setup.sh`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68749a6a2d54832a95b8946048172243