### PR TITLE
Fix asset loading path

### DIFF
--- a/paths.go
+++ b/paths.go
@@ -1,0 +1,18 @@
+//go:build !test
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func init() {
+	exe, err := os.Executable()
+	if err != nil {
+		return
+	}
+	dir := filepath.Dir(exe)
+	// Ignore error to avoid failing when permissions prevent chdir
+	_ = os.Chdir(dir)
+}


### PR DESCRIPTION
## Summary
- load resources relative to executable directory

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6874a358c858832aa5b44e133abb4cb8