### PR TITLE
Fix theme selector visibility

### DIFF
--- a/theme_selector.go
+++ b/theme_selector.go
@@ -13,13 +13,14 @@ func makeThemeSelector() *windowData {
 	}
 	win := NewWindow(&windowData{
 		Title:     "Themes",
-		Movable:   true,
-		Resizable: true,
-		Closable:  true,
+		PinTo:     PIN_TOP_RIGHT,
+		Movable:   false,
+		Resizable: false,
+		Closable:  false,
 		// Give the dropdown room to fully render by accounting for the
 		// title bar height and the control's size.
 		Size:     point{X: 192, Y: 160},
-		Position: point{X: float32(screenWidth) - 200, Y: 4},
+		Position: point{X: 4, Y: 4},
 		Open:     true,
 	})
 	dd := NewDropdown(&itemData{Size: point{X: 150, Y: 24}, FontSize: 8})


### PR DESCRIPTION
## Summary
- revert theme selector window to its original pinned position so it stays on screen regardless of window width

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6874a88a705c832a93cdb8f712c7a88c