### PR TITLE
Fix theme style application

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -28,7 +28,7 @@ var defaultTheme = &windowData{
 }
 
 var defaultButton = &itemData{
-	Text:      "Button",
+	Text:      "",
 	ItemType:  ITEM_BUTTON,
 	Size:      point{X: 128, Y: 64},
 	Position:  point{X: 4, Y: 4},
@@ -50,7 +50,7 @@ var defaultButton = &itemData{
 }
 
 var defaultText = &itemData{
-	Text:      "Sample text:\nThe quick brown fox\njumps over the lazy dog.",
+	Text:      "",
 	ItemType:  ITEM_TEXT,
 	Size:      point{X: 128, Y: 128},
 	Position:  point{X: 4, Y: 4},
@@ -62,7 +62,7 @@ var defaultText = &itemData{
 }
 
 var defaultCheckbox = &itemData{
-	Text:      "Option 1",
+	Text:      "",
 	ItemType:  ITEM_CHECKBOX,
 	Size:      point{X: 128, Y: 32},
 	Position:  point{X: 4, Y: 4},
@@ -105,7 +105,7 @@ var defaultInput = &itemData{
 }
 
 var defaultRadio = &itemData{
-	Text:      "Radio",
+	Text:      "",
 	ItemType:  ITEM_RADIO,
 	Size:      point{X: 128, Y: 32},
 	Position:  point{X: 4, Y: 4},

--- a/theme.go
+++ b/theme.go
@@ -80,11 +80,34 @@ func applyThemeToAll() {
 
 // applyThemeToWindow merges the current theme's window settings into the given
 // window and recursively updates contained items.
+func copyWindowStyle(dst, src *windowData) {
+	dst.Padding = src.Padding
+	dst.Margin = src.Margin
+	dst.Border = src.Border
+	dst.BorderPad = src.BorderPad
+	dst.Fillet = src.Fillet
+	dst.Outlined = src.Outlined
+	dst.TitleHeight = src.TitleHeight
+	dst.BGColor = src.BGColor
+	dst.TitleBGColor = src.TitleBGColor
+	dst.TitleColor = src.TitleColor
+	dst.TitleTextColor = src.TitleTextColor
+	dst.BorderColor = src.BorderColor
+	dst.SizeTabColor = src.SizeTabColor
+	dst.DragbarColor = src.DragbarColor
+	dst.CloseBGColor = src.CloseBGColor
+	dst.DragbarSpacing = src.DragbarSpacing
+	dst.ShowDragbar = src.ShowDragbar
+	dst.HoverTitleColor = src.HoverTitleColor
+	dst.HoverColor = src.HoverColor
+	dst.ActiveColor = src.ActiveColor
+}
+
 func applyThemeToWindow(win *windowData) {
 	if win == nil || currentTheme == nil {
 		return
 	}
-	mergeData(win, &currentTheme.Window)
+	copyWindowStyle(win, &currentTheme.Window)
 	win.Theme = currentTheme
 	for _, item := range win.Contents {
 		applyThemeToItem(item)
@@ -93,6 +116,29 @@ func applyThemeToWindow(win *windowData) {
 
 // applyThemeToItem merges style data from the current theme based on item type
 // and recursively processes child items.
+func copyItemStyle(dst, src *itemData) {
+	dst.Padding = src.Padding
+	dst.Margin = src.Margin
+	dst.Fillet = src.Fillet
+	dst.Border = src.Border
+	dst.BorderPad = src.BorderPad
+	dst.Filled = src.Filled
+	dst.Outlined = src.Outlined
+	dst.AuxSize = src.AuxSize
+	dst.AuxSpace = src.AuxSpace
+	dst.FontSize = src.FontSize
+	dst.LineSpace = src.LineSpace
+	dst.TextColor = src.TextColor
+	dst.Color = src.Color
+	dst.HoverColor = src.HoverColor
+	dst.ClickColor = src.ClickColor
+	dst.DisabledColor = src.DisabledColor
+	dst.CheckedColor = src.CheckedColor
+	if src.MaxVisible != 0 {
+		dst.MaxVisible = src.MaxVisible
+	}
+}
+
 func applyThemeToItem(it *itemData) {
 	if it == nil || currentTheme == nil {
 		return
@@ -115,7 +161,7 @@ func applyThemeToItem(it *itemData) {
 		src = &currentTheme.Dropdown
 	}
 	if src != nil {
-		mergeData(it, src)
+		copyItemStyle(it, src)
 	}
 	for _, child := range it.Contents {
 		applyThemeToItem(child)


### PR DESCRIPTION
## Summary
- avoid overwriting window/item data when applying themes
- clear demo text from default theme definitions

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6874b02e6354832a92be2c298f010e2c