### PR TITLE
Prevent theme from resetting font size

### DIFF
--- a/theme.go
+++ b/theme.go
@@ -126,8 +126,6 @@ func copyItemStyle(dst, src *itemData) {
 	dst.Outlined = src.Outlined
 	dst.AuxSize = src.AuxSize
 	dst.AuxSpace = src.AuxSpace
-	dst.FontSize = src.FontSize
-	dst.LineSpace = src.LineSpace
 	dst.TextColor = src.TextColor
 	dst.Color = src.Color
 	dst.HoverColor = src.HoverColor


### PR DESCRIPTION
## Summary
- avoid copying `FontSize` or `LineSpace` from theme data

This ensures that changing themes no longer alters the font size of existing UI items.

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6874b4236df4832aace50a52fd58fc4d