### PR TITLE
Fix slider layout and stable drag

### DIFF
--- a/util.go
+++ b/util.go
@@ -9,8 +9,8 @@ func (win *windowData) getWinRect() rect {
 	return rect{
 		X0: winPos.X,
 		Y0: winPos.Y,
-		X1: winPos.X + (win.GetSize().X),
-		Y1: winPos.Y + (win.GetSize().Y) - (win.GetTitleSize()),
+		X1: winPos.X + win.GetSize().X,
+		Y1: winPos.Y + win.GetSize().Y,
 	}
 }
 


### PR DESCRIPTION
## Summary
- fix bottom window rectangle so resizing uses correct bottom edge
- keep active drag part while resizing or moving windows
- adjust slider layout so the value text sits after the slider track

## Testing
- `./scripts/setup.sh`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6874b66db670832a8095675d70b3e6b3