### PR TITLE
Improve UI spacing and slider layout

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -7,7 +7,7 @@ var defaultTheme = &windowData{
 	Border:          0,
 	Outlined:        false,
 	Fillet:          4,
-	Padding:         0,
+	Padding:         4,
 	Margin:          4,
 	BorderPad:       0,
 	TitleColor:      Color(color.RGBA{R: 255, G: 255, B: 255, A: 255}),

--- a/render.go
+++ b/render.go
@@ -186,7 +186,8 @@ func (win *windowData) drawBorder(screen *ebiten.Image) {
 }
 
 func (win *windowData) drawItems(screen *ebiten.Image) {
-	winPos := pointAdd(win.getPosition(), point{X: 0, Y: win.GetTitleSize()})
+	pad := win.Padding + win.BorderPad
+	winPos := pointAdd(win.getPosition(), point{X: pad, Y: win.GetTitleSize() + pad})
 	clip := win.getMainRect()
 
 	for _, item := range win.Contents {
@@ -228,6 +229,7 @@ func (item *itemData) drawFlows(parent *itemData, offset point, clip rect, scree
 			tabHeight = th
 		}
 		x := offset.X
+		spacing := float32(4) * uiScale
 		for i, tab := range item.Tabs {
 			face := &text.GoTextFace{Source: mplusFaceSource, Size: float64(tabHeight - 22)}
 			tw, _ := text.Measure(tab.Name, face, 0)
@@ -245,7 +247,7 @@ func (item *itemData) drawFlows(parent *itemData, offset point, clip rect, scree
 			dop.GeoM.Translate(float64(x+w/2), float64(offset.Y+tabHeight/2))
 			text.Draw(subImg, tab.Name, face, &text.DrawOptions{DrawImageOptions: dop, LayoutOptions: loo})
 			tab.DrawRect = rect{X0: x, Y0: offset.Y, X1: x + w, Y1: offset.Y + tabHeight}
-			x += w
+			x += w + spacing
 		}
 		drawOffset = pointAdd(drawOffset, point{Y: tabHeight})
 		vector.StrokeRect(subImg,
@@ -555,17 +557,21 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 			itemColor = item.HoverColor
 		}
 
-		// Prepare value text so the slider track can account for its width
+		// Prepare value text and measure the largest value label so the
+		// slider track remains consistent length
 		valueText := fmt.Sprintf("%.2f", item.Value)
+		maxLabel := fmt.Sprintf("%.2f", item.MaxValue)
 		if item.IntOnly {
 			valueText = fmt.Sprintf("%d", int(item.Value))
+			maxLabel = fmt.Sprintf("%d", int(item.MaxValue))
 		}
 
 		textSize := (item.FontSize * uiScale) + 2
 		face := &text.GoTextFace{Source: mplusFaceSource, Size: float64(textSize)}
-		tw, _ := text.Measure(valueText, face, 0)
+		maxW, _ := text.Measure(maxLabel, face, 0)
 
-		trackWidth := maxSize.X - item.AuxSize.X - item.AuxSpace*4 - float32(tw)
+		gap := item.AuxSpace * 3
+		trackWidth := maxSize.X - item.AuxSize.X - gap - float32(maxW)
 		if trackWidth < 0 {
 			trackWidth = 0
 		}
@@ -600,7 +606,7 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 		loo := text.LayoutOptions{LineSpacing: 1.2, PrimaryAlign: text.AlignStart, SecondaryAlign: text.AlignCenter}
 		tdop := ebiten.DrawImageOptions{}
 		tdop.GeoM.Translate(
-			float64(offset.X+trackWidth+item.AuxSpace*2),
+			float64(offset.X+trackWidth+gap),
 			float64(offset.Y+(maxSize.Y/2)),
 		)
 		top := &text.DrawOptions{DrawImageOptions: tdop, LayoutOptions: loo}
@@ -812,8 +818,8 @@ func drawTabShape(screen *ebiten.Image, pos point, size point, col Color) {
 		indices  []uint16
 	)
 
-	slope := size.Y / 3
-	fillet := size.Y / 5
+	slope := size.Y / 4
+	fillet := size.Y / 8
 
 	path.MoveTo(pos.X, pos.Y+size.Y)
 	path.LineTo(pos.X+slope, pos.Y+fillet)

--- a/themes/DefaultDark.json
+++ b/themes/DefaultDark.json
@@ -2,7 +2,7 @@
   "Window": {
     "Border": 1,
     "Outlined": true,
-    "Padding": 0,
+    "Padding": 4,
     "BGColor": {
       "R": 16,
       "G": 16,

--- a/themes/FlatDark.json
+++ b/themes/FlatDark.json
@@ -2,7 +2,7 @@
   "Window": {
     "Border": 0,
     "Outlined": false,
-    "Padding": 0,
+    "Padding": 4,
     "BGColor": {
       "R": 32,
       "G": 32,

--- a/themes/FlatLight.json
+++ b/themes/FlatLight.json
@@ -2,7 +2,7 @@
   "Window": {
     "Border": 0,
     "Outlined": false,
-    "Padding": 0,
+    "Padding": 4,
     "BGColor": {
       "R": 245,
       "G": 245,

--- a/themes/FlatMonochromatic.json
+++ b/themes/FlatMonochromatic.json
@@ -2,7 +2,7 @@
   "Window": {
     "Border": 0,
     "Outlined": false,
-    "Padding": 0,
+    "Padding": 4,
     "BGColor": { "HSV": [210, 0.4, 0.6, 1] },
     "TitleBGColor": { "HSV": [210, 0.5, 0.3, 1] },
     "TitleColor": { "HSV": [210, 0.3, 0.9, 1] },

--- a/themes/FlatOpposed.json
+++ b/themes/FlatOpposed.json
@@ -2,7 +2,7 @@
   "Window": {
     "Border": 0,
     "Outlined": false,
-    "Padding": 0,
+    "Padding": 4,
     "BGColor": {
       "R": 20,
       "G": 20,

--- a/themes/OutlinedDark.json
+++ b/themes/OutlinedDark.json
@@ -2,7 +2,7 @@
   "Window": {
     "Border": 1,
     "Outlined": true,
-    "Padding": 0,
+    "Padding": 4,
     "BGColor": {
       "R": 32,
       "G": 32,

--- a/themes/OutlinedLight.json
+++ b/themes/OutlinedLight.json
@@ -2,7 +2,7 @@
   "Window": {
     "Border": 1,
     "Outlined": true,
-    "Padding": 0,
+    "Padding": 4,
     "BGColor": {
       "R": 245,
       "G": 245,

--- a/themes/OutlinedMonochromatic.json
+++ b/themes/OutlinedMonochromatic.json
@@ -2,7 +2,7 @@
   "Window": {
     "Border": 1,
     "Outlined": true,
-    "Padding": 0,
+    "Padding": 4,
     "BGColor": {
       "HSV": [
         210,

--- a/themes/OutlinedOpposed.json
+++ b/themes/OutlinedOpposed.json
@@ -2,7 +2,7 @@
   "Window": {
     "Border": 1,
     "Outlined": true,
-    "Padding": 0,
+    "Padding": 4,
     "BGColor": {
       "R": 20,
       "G": 20,

--- a/util.go
+++ b/util.go
@@ -33,11 +33,12 @@ func (parent *windowData) addItemTo(item *itemData) {
 }
 
 func (win *windowData) getMainRect() rect {
+	pad := win.Padding + win.BorderPad
 	return rect{
-		X0: win.getPosition().X,
-		Y0: win.getPosition().Y + (win.GetTitleSize()) + 1,
-		X1: win.getPosition().X + win.GetSize().X,
-		Y1: win.getPosition().Y + win.GetSize().Y - (win.GetTitleSize()),
+		X0: win.getPosition().X + pad,
+		Y0: win.getPosition().Y + win.GetTitleSize() + pad + 1,
+		X1: win.getPosition().X + win.GetSize().X - pad,
+		Y1: win.getPosition().Y + win.GetSize().Y - win.GetTitleSize() - pad,
 	}
 }
 


### PR DESCRIPTION
## Summary
- add interior padding to windows
- insert spacing between tabs and tweak tab corner curves
- keep slider track length consistent and add gap before value text
- bump default and theme padding values

## Testing
- `./scripts/setup.sh`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687549d77194832a947e05e14072f5df