### PR TITLE
Fix clipping and theme colors for dropdowns and tabs

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -173,6 +173,19 @@ var defaultDropdown = &itemData{
 	MaxVisible: 5,
 }
 
+var defaultTab = &itemData{
+	ItemType:   ITEM_FLOW,
+	FontSize:   12,
+	Filled:     true,
+	Border:     0,
+	BorderPad:  2,
+	Fillet:     4,
+	TextColor:  Color(color.RGBA{R: 255, G: 255, B: 255, A: 255}),
+	Color:      Color(color.RGBA{R: 64, G: 64, B: 64, A: 255}),
+	HoverColor: Color(color.RGBA{R: 96, G: 96, B: 96, A: 255}),
+	ClickColor: Color(color.RGBA{R: 0, G: 160, B: 160, A: 255}),
+}
+
 // base copies preserve the initial defaults so that LoadTheme can reset
 // to these values before applying theme overrides.
 var (
@@ -184,6 +197,7 @@ var (
 	baseInput    = *defaultInput
 	baseSlider   = *defaultSlider
 	baseDropdown = *defaultDropdown
+	baseTab      = *defaultTab
 	baseTheme    = &Theme{
 		Window:   baseWindow,
 		Button:   baseButton,
@@ -193,5 +207,6 @@ var (
 		Input:    baseInput,
 		Slider:   baseSlider,
 		Dropdown: baseDropdown,
+		Tab:      baseTab,
 	}
 )

--- a/render.go
+++ b/render.go
@@ -243,7 +243,9 @@ func (item *itemData) drawFlows(parent *itemData, offset point, clip rect, scree
 			loo := text.LayoutOptions{PrimaryAlign: text.AlignCenter, SecondaryAlign: text.AlignCenter}
 			dop := ebiten.DrawImageOptions{}
 			dop.GeoM.Translate(float64(x+w/2), float64(offset.Y+tabHeight/2))
-			text.Draw(subImg, tab.Name, face, &text.DrawOptions{DrawImageOptions: dop, LayoutOptions: loo})
+			dto := &text.DrawOptions{DrawImageOptions: dop, LayoutOptions: loo}
+			dto.ColorScale.ScaleWithColor(item.TextColor)
+			text.Draw(subImg, tab.Name, face, dto)
 			tab.DrawRect = rect{X0: x, Y0: offset.Y, X1: x + w, Y1: offset.Y + tabHeight}
 			x += w
 		}
@@ -725,7 +727,9 @@ func drawDropdownOptions(item *itemData, offset point, clip rect, screen *ebiten
 		drawRoundRect(subImg, &roundRect{Size: maxSize, Position: point{X: offset.X, Y: y}, Fillet: item.Fillet, Filled: true, Color: col})
 		td := ebiten.DrawImageOptions{}
 		td.GeoM.Translate(float64(offset.X+item.BorderPad+item.Padding), float64(y+optionH/2))
-		text.Draw(subImg, item.Options[i], face, &text.DrawOptions{DrawImageOptions: td, LayoutOptions: loo})
+		tdo := &text.DrawOptions{DrawImageOptions: td, LayoutOptions: loo}
+		tdo.ColorScale.ScaleWithColor(item.TextColor)
+		text.Draw(subImg, item.Options[i], face, tdo)
 	}
 }
 

--- a/theme.go
+++ b/theme.go
@@ -23,6 +23,7 @@ type Theme struct {
 	Input    itemData
 	Slider   itemData
 	Dropdown itemData
+	Tab      itemData
 }
 
 // LoadTheme reads a theme JSON file from the themes directory and
@@ -143,6 +144,10 @@ func applyThemeToItem(it *itemData) {
 	}
 	var src *itemData
 	switch it.ItemType {
+	case ITEM_FLOW:
+		if len(it.Tabs) > 0 {
+			src = &currentTheme.Tab
+		}
 	case ITEM_BUTTON:
 		src = &currentTheme.Button
 	case ITEM_TEXT:

--- a/themes/DefaultDark.json
+++ b/themes/DefaultDark.json
@@ -328,5 +328,80 @@
       "B": 0,
       "A": 0
     }
+  },
+  "Dropdown": {
+    "Fillet": 4,
+    "Border": 0,
+    "BorderPad": 2,
+    "Filled": true,
+    "Outlined": false,
+    "TextColor": {
+      "R": 255,
+      "G": 255,
+      "B": 255,
+      "A": 255
+    },
+    "Color": {
+      "R": 48,
+      "G": 48,
+      "B": 48,
+      "A": 255
+    },
+    "HoverColor": {
+      "R": 96,
+      "G": 96,
+      "B": 96,
+      "A": 255
+    },
+    "ClickColor": {
+      "R": 0,
+      "G": 128,
+      "B": 128,
+      "A": 255
+    },
+    "DisabledColor": {
+      "R": 0,
+      "G": 0,
+      "B": 0,
+      "A": 0
+    },
+    "CheckedColor": {
+      "R": 0,
+      "G": 0,
+      "B": 0,
+      "A": 0
+    },
+    "MaxVisible": 5
+  },
+  "Tab": {
+    "Fillet": 4,
+    "Border": 0,
+    "BorderPad": 2,
+    "Filled": true,
+    "Outlined": false,
+    "TextColor": {
+      "R": 255,
+      "G": 255,
+      "B": 255,
+      "A": 255
+    },
+    "Color": {
+      "R": 64,
+      "G": 64,
+      "B": 64,
+      "A": 255
+    },
+    "HoverColor": {
+      "R": 96,
+      "G": 96,
+      "B": 96,
+      "A": 255
+    },
+    "ClickColor": {
+      "R": 0,
+      "G": 128,
+      "B": 128,
+      "A": 255
+    }
   }
 }

--- a/themes/FlatDark.json
+++ b/themes/FlatDark.json
@@ -321,5 +321,80 @@
       "B": 0,
       "A": 0
     }
+  },
+  "Dropdown": {
+    "Fillet": 4,
+    "Border": 0,
+    "BorderPad": 2,
+    "Filled": true,
+    "Outlined": false,
+    "TextColor": {
+      "R": 255,
+      "G": 255,
+      "B": 255,
+      "A": 255
+    },
+    "Color": {
+      "R": 64,
+      "G": 64,
+      "B": 64,
+      "A": 255
+    },
+    "HoverColor": {
+      "R": 96,
+      "G": 96,
+      "B": 96,
+      "A": 255
+    },
+    "ClickColor": {
+      "R": 0,
+      "G": 160,
+      "B": 160,
+      "A": 255
+    },
+    "DisabledColor": {
+      "R": 0,
+      "G": 0,
+      "B": 0,
+      "A": 0
+    },
+    "CheckedColor": {
+      "R": 0,
+      "G": 0,
+      "B": 0,
+      "A": 0
+    },
+    "MaxVisible": 5
+  },
+  "Tab": {
+    "Fillet": 4,
+    "Border": 0,
+    "BorderPad": 2,
+    "Filled": true,
+    "Outlined": false,
+    "TextColor": {
+      "R": 255,
+      "G": 255,
+      "B": 255,
+      "A": 255
+    },
+    "Color": {
+      "R": 64,
+      "G": 64,
+      "B": 64,
+      "A": 255
+    },
+    "HoverColor": {
+      "R": 96,
+      "G": 96,
+      "B": 96,
+      "A": 255
+    },
+    "ClickColor": {
+      "R": 0,
+      "G": 160,
+      "B": 160,
+      "A": 255
+    }
   }
 }

--- a/themes/FlatLight.json
+++ b/themes/FlatLight.json
@@ -321,5 +321,80 @@
       "B": 0,
       "A": 0
     }
+  },
+  "Dropdown": {
+    "Fillet": 4,
+    "Border": 0,
+    "BorderPad": 2,
+    "Filled": true,
+    "Outlined": false,
+    "TextColor": {
+      "R": 0,
+      "G": 0,
+      "B": 0,
+      "A": 255
+    },
+    "Color": {
+      "R": 240,
+      "G": 240,
+      "B": 240,
+      "A": 255
+    },
+    "HoverColor": {
+      "R": 220,
+      "G": 220,
+      "B": 220,
+      "A": 255
+    },
+    "ClickColor": {
+      "R": 0,
+      "G": 128,
+      "B": 192,
+      "A": 255
+    },
+    "DisabledColor": {
+      "R": 0,
+      "G": 0,
+      "B": 0,
+      "A": 0
+    },
+    "CheckedColor": {
+      "R": 0,
+      "G": 0,
+      "B": 0,
+      "A": 0
+    },
+    "MaxVisible": 5
+  },
+  "Tab": {
+    "Fillet": 4,
+    "Border": 0,
+    "BorderPad": 2,
+    "Filled": true,
+    "Outlined": false,
+    "TextColor": {
+      "R": 0,
+      "G": 0,
+      "B": 0,
+      "A": 255
+    },
+    "Color": {
+      "R": 224,
+      "G": 224,
+      "B": 224,
+      "A": 255
+    },
+    "HoverColor": {
+      "R": 220,
+      "G": 220,
+      "B": 220,
+      "A": 255
+    },
+    "ClickColor": {
+      "R": 0,
+      "G": 128,
+      "B": 192,
+      "A": 255
+    }
   }
 }

--- a/themes/FlatMonochromatic.json
+++ b/themes/FlatMonochromatic.json
@@ -166,5 +166,30 @@
       "B": 0,
       "A": 0
     }
+  },
+  "Dropdown": {
+    "Fillet": 4,
+    "Border": 0,
+    "BorderPad": 2,
+    "Filled": true,
+    "Outlined": false,
+    "TextColor": { "HSV": [210, 0.3, 0.9, 1] },
+    "Color": { "HSV": [210, 0.4, 0.65, 1] },
+    "HoverColor": { "HSV": [210, 0.3, 0.75, 1] },
+    "ClickColor": { "HSV": [210, 0.7, 0.6, 1] },
+    "DisabledColor": { "R": 0, "G": 0, "B": 0, "A": 0 },
+    "CheckedColor": { "R": 0, "G": 0, "B": 0, "A": 0 },
+    "MaxVisible": 5
+  },
+  "Tab": {
+    "Fillet": 4,
+    "Border": 0,
+    "BorderPad": 2,
+    "Filled": true,
+    "Outlined": false,
+    "TextColor": { "HSV": [210, 0.3, 0.9, 1] },
+    "Color": { "HSV": [210, 0.4, 0.7, 1] },
+    "HoverColor": { "HSV": [210, 0.3, 0.75, 1] },
+    "ClickColor": { "HSV": [210, 0.7, 0.6, 1] }
   }
 }

--- a/themes/FlatOpposed.json
+++ b/themes/FlatOpposed.json
@@ -321,5 +321,80 @@
       "B": 0,
       "A": 0
     }
+  },
+  "Dropdown": {
+    "Fillet": 4,
+    "Border": 0,
+    "BorderPad": 2,
+    "Filled": true,
+    "Outlined": false,
+    "TextColor": {
+      "R": 255,
+      "G": 255,
+      "B": 255,
+      "A": 255
+    },
+    "Color": {
+      "R": 30,
+      "G": 30,
+      "B": 150,
+      "A": 255
+    },
+    "HoverColor": {
+      "R": 40,
+      "G": 40,
+      "B": 170,
+      "A": 255
+    },
+    "ClickColor": {
+      "R": 240,
+      "G": 140,
+      "B": 0,
+      "A": 255
+    },
+    "DisabledColor": {
+      "R": 0,
+      "G": 0,
+      "B": 0,
+      "A": 0
+    },
+    "CheckedColor": {
+      "R": 0,
+      "G": 0,
+      "B": 0,
+      "A": 0
+    },
+    "MaxVisible": 5
+  },
+  "Tab": {
+    "Fillet": 4,
+    "Border": 0,
+    "BorderPad": 2,
+    "Filled": true,
+    "Outlined": false,
+    "TextColor": {
+      "R": 255,
+      "G": 255,
+      "B": 255,
+      "A": 255
+    },
+    "Color": {
+      "R": 30,
+      "G": 30,
+      "B": 150,
+      "A": 255
+    },
+    "HoverColor": {
+      "R": 40,
+      "G": 40,
+      "B": 170,
+      "A": 255
+    },
+    "ClickColor": {
+      "R": 240,
+      "G": 140,
+      "B": 0,
+      "A": 255
+    }
   }
 }

--- a/themes/OutlinedDark.json
+++ b/themes/OutlinedDark.json
@@ -316,5 +316,80 @@
       "B": 0,
       "A": 0
     }
+  },
+  "Dropdown": {
+    "Fillet": 4,
+    "Border": 0,
+    "BorderPad": 2,
+    "Filled": true,
+    "Outlined": false,
+    "TextColor": {
+      "R": 255,
+      "G": 255,
+      "B": 255,
+      "A": 255
+    },
+    "Color": {
+      "R": 64,
+      "G": 64,
+      "B": 64,
+      "A": 255
+    },
+    "HoverColor": {
+      "R": 96,
+      "G": 96,
+      "B": 96,
+      "A": 255
+    },
+    "ClickColor": {
+      "R": 0,
+      "G": 160,
+      "B": 160,
+      "A": 255
+    },
+    "DisabledColor": {
+      "R": 0,
+      "G": 0,
+      "B": 0,
+      "A": 0
+    },
+    "CheckedColor": {
+      "R": 0,
+      "G": 0,
+      "B": 0,
+      "A": 0
+    },
+    "MaxVisible": 5
+  },
+  "Tab": {
+    "Fillet": 4,
+    "Border": 0,
+    "BorderPad": 2,
+    "Filled": true,
+    "Outlined": false,
+    "TextColor": {
+      "R": 255,
+      "G": 255,
+      "B": 255,
+      "A": 255
+    },
+    "Color": {
+      "R": 64,
+      "G": 64,
+      "B": 64,
+      "A": 255
+    },
+    "HoverColor": {
+      "R": 96,
+      "G": 96,
+      "B": 96,
+      "A": 255
+    },
+    "ClickColor": {
+      "R": 0,
+      "G": 160,
+      "B": 160,
+      "A": 255
+    }
   }
 }

--- a/themes/OutlinedLight.json
+++ b/themes/OutlinedLight.json
@@ -322,5 +322,80 @@
       "B": 0,
       "A": 0
     }
+  },
+  "Dropdown": {
+    "Fillet": 4,
+    "Border": 0,
+    "BorderPad": 2,
+    "Filled": true,
+    "Outlined": false,
+    "TextColor": {
+      "R": 0,
+      "G": 0,
+      "B": 0,
+      "A": 255
+    },
+    "Color": {
+      "R": 240,
+      "G": 240,
+      "B": 240,
+      "A": 255
+    },
+    "HoverColor": {
+      "R": 220,
+      "G": 220,
+      "B": 220,
+      "A": 255
+    },
+    "ClickColor": {
+      "R": 0,
+      "G": 128,
+      "B": 192,
+      "A": 255
+    },
+    "DisabledColor": {
+      "R": 0,
+      "G": 0,
+      "B": 0,
+      "A": 0
+    },
+    "CheckedColor": {
+      "R": 0,
+      "G": 0,
+      "B": 0,
+      "A": 0
+    },
+    "MaxVisible": 5
+  },
+  "Tab": {
+    "Fillet": 4,
+    "Border": 0,
+    "BorderPad": 2,
+    "Filled": true,
+    "Outlined": false,
+    "TextColor": {
+      "R": 0,
+      "G": 0,
+      "B": 0,
+      "A": 255
+    },
+    "Color": {
+      "R": 224,
+      "G": 224,
+      "B": 224,
+      "A": 255
+    },
+    "HoverColor": {
+      "R": 220,
+      "G": 220,
+      "B": 220,
+      "A": 255
+    },
+    "ClickColor": {
+      "R": 0,
+      "G": 128,
+      "B": 192,
+      "A": 255
+    }
   }
 }

--- a/themes/OutlinedMonochromatic.json
+++ b/themes/OutlinedMonochromatic.json
@@ -370,5 +370,30 @@
       "B": 0,
       "A": 0
     }
+  },
+  "Dropdown": {
+    "Fillet": 4,
+    "Border": 0,
+    "BorderPad": 2,
+    "Filled": true,
+    "Outlined": false,
+    "TextColor": { "HSV": [210, 0.3, 0.9, 1] },
+    "Color": { "HSV": [210, 0.4, 0.65, 1] },
+    "HoverColor": { "HSV": [210, 0.3, 0.75, 1] },
+    "ClickColor": { "HSV": [210, 0.7, 0.6, 1] },
+    "DisabledColor": { "R": 0, "G": 0, "B": 0, "A": 0 },
+    "CheckedColor": { "R": 0, "G": 0, "B": 0, "A": 0 },
+    "MaxVisible": 5
+  },
+  "Tab": {
+    "Fillet": 4,
+    "Border": 0,
+    "BorderPad": 2,
+    "Filled": true,
+    "Outlined": false,
+    "TextColor": { "HSV": [210, 0.3, 0.9, 1] },
+    "Color": { "HSV": [210, 0.4, 0.7, 1] },
+    "HoverColor": { "HSV": [210, 0.3, 0.75, 1] },
+    "ClickColor": { "HSV": [210, 0.7, 0.6, 1] }
   }
 }

--- a/themes/OutlinedOpposed.json
+++ b/themes/OutlinedOpposed.json
@@ -316,5 +316,80 @@
       "B": 0,
       "A": 0
     }
+  },
+  "Dropdown": {
+    "Fillet": 4,
+    "Border": 0,
+    "BorderPad": 2,
+    "Filled": true,
+    "Outlined": false,
+    "TextColor": {
+      "R": 255,
+      "G": 255,
+      "B": 255,
+      "A": 255
+    },
+    "Color": {
+      "R": 30,
+      "G": 30,
+      "B": 150,
+      "A": 255
+    },
+    "HoverColor": {
+      "R": 40,
+      "G": 40,
+      "B": 170,
+      "A": 255
+    },
+    "ClickColor": {
+      "R": 240,
+      "G": 140,
+      "B": 0,
+      "A": 255
+    },
+    "DisabledColor": {
+      "R": 0,
+      "G": 0,
+      "B": 0,
+      "A": 0
+    },
+    "CheckedColor": {
+      "R": 0,
+      "G": 0,
+      "B": 0,
+      "A": 0
+    },
+    "MaxVisible": 5
+  },
+  "Tab": {
+    "Fillet": 4,
+    "Border": 0,
+    "BorderPad": 2,
+    "Filled": true,
+    "Outlined": false,
+    "TextColor": {
+      "R": 255,
+      "G": 255,
+      "B": 255,
+      "A": 255
+    },
+    "Color": {
+      "R": 30,
+      "G": 30,
+      "B": 150,
+      "A": 255
+    },
+    "HoverColor": {
+      "R": 40,
+      "G": 40,
+      "B": 170,
+      "A": 255
+    },
+    "ClickColor": {
+      "R": 240,
+      "G": 140,
+      "B": 0,
+      "A": 255
+    }
   }
 }

--- a/util.go
+++ b/util.go
@@ -35,9 +35,9 @@ func (parent *windowData) addItemTo(item *itemData) {
 func (win *windowData) getMainRect() rect {
 	return rect{
 		X0: win.getPosition().X,
-		Y0: win.getPosition().Y + (win.GetTitleSize()) + 1,
+		Y0: win.getPosition().Y + win.GetTitleSize(),
 		X1: win.getPosition().X + win.GetSize().X,
-		Y1: win.getPosition().Y + win.GetSize().Y - (win.GetTitleSize()),
+		Y1: win.getPosition().Y + win.GetSize().Y,
 	}
 }
 


### PR DESCRIPTION
## Summary
- fix window clipping area height calculation
- colorize dropdown options and tab labels using `TextColor`
- add tab style support in themes
- include dropdown and tab styles in theme JSONs

## Testing
- `./scripts/setup.sh`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68754d631c78832aafcc568394184778