### PR TITLE
Improve color parsing error message

### DIFF
--- a/color_hsv.go
+++ b/color_hsv.go
@@ -147,5 +147,5 @@ func (c *Color) UnmarshalJSON(data []byte) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("invalid color format")
+	return fmt.Errorf("invalid color format: %s", string(data))
 }


### PR DESCRIPTION
## Summary
- clarify color parser failure by including the invalid input in the error message

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68759bd9e554832ab0c070e16f266d18