### PR TITLE
Improve theme readability

### DIFF
--- a/color_hsv.go
+++ b/color_hsv.go
@@ -111,6 +111,7 @@ func (c *Color) UnmarshalJSON(data []byte) error {
 	}
 	var s string
 	if err := json.Unmarshal(data, &s); err == nil {
+		s = strings.TrimSpace(s)
 		if nc, ok := namedColors[strings.ToLower(s)]; ok {
 			*c = nc
 			return nil

--- a/glob_test.go
+++ b/glob_test.go
@@ -23,6 +23,9 @@ var (
 
 	whiteImage    interface{}
 	whiteSubImage interface{}
+
+	currentTheme     *Theme
+	currentThemeName string
 )
 
 type Game struct{}
@@ -30,4 +33,7 @@ type Game struct{}
 const (
 	minWinSizeX = 192
 	minWinSizeY = 64
+
+	defaultTabWidth  = 128
+	defaultTabHeight = 24
 )

--- a/themes/AccentDark.json
+++ b/themes/AccentDark.json
@@ -1,31 +1,29 @@
 {
   "Comment": "Colors use #RRGGBBAA or h,s,v",
   "Colors": {
-    "c1": "#202326ff",
-    "c2": "#292c30ff",
-    "c3": "#ffffffff",
-    "c4": "#1d1f22ff",
-    "c5": "#505050ff",
-    "c6": "#3daee9ff",
-    "c7": "#404040ff",
-    "c8": "#606060ff",
-    "c9": "#00000000",
-    "c10": "#3daee900"
+    "background": "210.0,0.16,0.15",
+    "panel": "214.3,0.15,0.19",
+    "text": "0.0,0.00,1.00",
+    "outline": "216.0,0.15,0.13",
+    "button": "0.0,0.00,0.25",
+    "hover": "0.0,0.00,0.38",
+    "accent": "200.6,0.74,0.91",
+    "disabled": "0.0,0.00,0.00,0.00"
   },
   "Window": {
     "Border": 0,
     "Outlined": false,
     "Padding": 8,
-    "BGColor": "c1",
-    "TitleBGColor": "c2",
-    "TitleColor": "c3",
-    "BorderColor": "c2",
-    "SizeTabColor": "c4",
-    "DragbarColor": "c2",
-    "HoverTitleColor": "c3",
-    "HoverColor": "c5",
-    "ActiveColor": "c6",
-    "TitleTextColor": "c3"
+    "BGColor": "background",
+    "TitleBGColor": "panel",
+    "TitleColor": "text",
+    "BorderColor": "panel",
+    "SizeTabColor": "outline",
+    "DragbarColor": "panel",
+    "HoverTitleColor": "text",
+    "HoverColor": "hover",
+    "ActiveColor": "accent",
+    "TitleTextColor": "text"
   },
   "Button": {
     "Fillet": 10,
@@ -33,12 +31,12 @@
     "BorderPad": 4,
     "Filled": true,
     "Outlined": false,
-    "TextColor": "c3",
-    "Color": "c7",
-    "HoverColor": "c8",
-    "ClickColor": "c6",
-    "DisabledColor": "c9",
-    "CheckedColor": "c9"
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "DisabledColor": "disabled",
+    "CheckedColor": "disabled"
   },
   "Text": {
     "Fillet": 0,
@@ -46,12 +44,12 @@
     "BorderPad": 4,
     "Filled": false,
     "Outlined": false,
-    "TextColor": "c3",
-    "Color": "c9",
-    "HoverColor": "c9",
-    "ClickColor": "c10",
-    "DisabledColor": "c9",
-    "CheckedColor": "c9"
+    "TextColor": "text",
+    "Color": "disabled",
+    "HoverColor": "disabled",
+    "ClickColor": "accent",
+    "DisabledColor": "disabled",
+    "CheckedColor": "disabled"
   },
   "Checkbox": {
     "Fillet": 8,
@@ -59,12 +57,12 @@
     "BorderPad": 4,
     "Filled": true,
     "Outlined": false,
-    "TextColor": "c3",
-    "Color": "c7",
-    "HoverColor": "c8",
-    "ClickColor": "c6",
-    "DisabledColor": "c9",
-    "CheckedColor": "c9"
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "DisabledColor": "disabled",
+    "CheckedColor": "disabled"
   },
   "Radio": {
     "Fillet": 8,
@@ -72,12 +70,12 @@
     "BorderPad": 4,
     "Filled": true,
     "Outlined": false,
-    "TextColor": "c3",
-    "Color": "c7",
-    "HoverColor": "c8",
-    "ClickColor": "c6",
-    "DisabledColor": "c9",
-    "CheckedColor": "c9"
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "DisabledColor": "disabled",
+    "CheckedColor": "disabled"
   },
   "Input": {
     "Fillet": 4,
@@ -85,12 +83,12 @@
     "BorderPad": 2,
     "Filled": true,
     "Outlined": false,
-    "TextColor": "c3",
-    "Color": "c7",
-    "HoverColor": "c8",
-    "ClickColor": "c6",
-    "DisabledColor": "c9",
-    "CheckedColor": "c9"
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "DisabledColor": "disabled",
+    "CheckedColor": "disabled"
   },
   "Slider": {
     "Fillet": 4,
@@ -98,12 +96,12 @@
     "BorderPad": 2,
     "Filled": true,
     "Outlined": false,
-    "TextColor": "c3",
-    "Color": "c7",
-    "HoverColor": "c8",
-    "ClickColor": "c6",
-    "DisabledColor": "c9",
-    "CheckedColor": "c9"
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "DisabledColor": "disabled",
+    "CheckedColor": "disabled"
   },
   "Dropdown": {
     "Fillet": 4,
@@ -111,12 +109,12 @@
     "BorderPad": 2,
     "Filled": true,
     "Outlined": false,
-    "TextColor": "c3",
-    "Color": "c7",
-    "HoverColor": "c8",
-    "ClickColor": "c6",
-    "DisabledColor": "c9",
-    "CheckedColor": "c9",
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "DisabledColor": "disabled",
+    "CheckedColor": "disabled",
     "MaxVisible": 5
   },
   "Tab": {
@@ -125,10 +123,10 @@
     "BorderPad": 8,
     "Filled": true,
     "Outlined": false,
-    "TextColor": "c3",
-    "Color": "c7",
-    "HoverColor": "c8",
-    "ClickColor": "c6"
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent"
   },
   "RecommendedLayout": "Default"
 }

--- a/themes/AccentLight.json
+++ b/themes/AccentLight.json
@@ -1,33 +1,30 @@
 {
   "Comment": "Colors use #RRGGBBAA or h,s,v",
   "Colors": {
-    "c1": "#eff0f1ff",
-    "c2": "#dee0e2ff",
-    "c3": "#232629ff",
-    "c4": "#e3e5e7ff",
-    "c5": "#ffffffff",
-    "c6": "#505050ff",
-    "c7": "#3daee9ff",
-    "c8": "#404040ff",
-    "c9": "#606060ff",
-    "c10": "#00000000",
-    "c11": "#c0c0c0ff"
+    "background": "210.0,0.01,0.95",
+    "panel": "210.0,0.02,0.89",
+    "text": "0.0,0.00,0.00",
+    "outline": "210.0,0.15,0.16",
+    "button": "210.0,0.02,0.91",
+    "hover": "0.0,0.00,0.75",
+    "accent": "200.6,0.74,0.91",
+    "disabled": "0.0,0.00,0.00,0.00"
   },
   "RecommendedLayout": "Default",
   "Window": {
     "Border": 0,
     "Outlined": false,
     "Padding": 8,
-    "BGColor": "c1",
-    "TitleBGColor": "c2",
-    "TitleColor": "c3",
-    "BorderColor": "c2",
-    "SizeTabColor": "c4",
-    "DragbarColor": "c2",
-    "HoverTitleColor": "c5",
-    "HoverColor": "c6",
-    "ActiveColor": "c7",
-    "TitleTextColor": "c3"
+    "BGColor": "background",
+    "TitleBGColor": "panel",
+    "TitleColor": "text",
+    "BorderColor": "panel",
+    "SizeTabColor": "button",
+    "DragbarColor": "panel",
+    "HoverTitleColor": "text",
+    "HoverColor": "hover",
+    "ActiveColor": "accent",
+    "TitleTextColor": "text"
   },
   "Button": {
     "Fillet": 10,
@@ -35,12 +32,12 @@
     "BorderPad": 4,
     "Filled": true,
     "Outlined": false,
-    "TextColor": "c5",
-    "Color": "c8",
-    "HoverColor": "c9",
-    "ClickColor": "c7",
-    "DisabledColor": "c10",
-    "CheckedColor": "c10"
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "DisabledColor": "disabled",
+    "CheckedColor": "disabled"
   },
   "Text": {
     "Fillet": 0,
@@ -48,12 +45,12 @@
     "BorderPad": 4,
     "Filled": false,
     "Outlined": false,
-    "TextColor": "c5",
-    "Color": "c10",
-    "HoverColor": "c10",
-    "ClickColor": "c10",
-    "DisabledColor": "c10",
-    "CheckedColor": "c10"
+    "TextColor": "text",
+    "Color": "disabled",
+    "HoverColor": "disabled",
+    "ClickColor": "disabled",
+    "DisabledColor": "disabled",
+    "CheckedColor": "disabled"
   },
   "Checkbox": {
     "Fillet": 8,
@@ -61,12 +58,12 @@
     "BorderPad": 4,
     "Filled": true,
     "Outlined": false,
-    "TextColor": "c5",
-    "Color": "c8",
-    "HoverColor": "c9",
-    "ClickColor": "c8",
-    "DisabledColor": "c10",
-    "CheckedColor": "c10"
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "button",
+    "DisabledColor": "disabled",
+    "CheckedColor": "disabled"
   },
   "Radio": {
     "Fillet": 8,
@@ -74,12 +71,12 @@
     "BorderPad": 4,
     "Filled": true,
     "Outlined": false,
-    "TextColor": "c5",
-    "Color": "c8",
-    "HoverColor": "c9",
-    "ClickColor": "c8",
-    "DisabledColor": "c10",
-    "CheckedColor": "c10"
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "button",
+    "DisabledColor": "disabled",
+    "CheckedColor": "disabled"
   },
   "Input": {
     "Fillet": 4,
@@ -87,12 +84,12 @@
     "BorderPad": 2,
     "Filled": true,
     "Outlined": false,
-    "TextColor": "c5",
-    "Color": "c8",
-    "HoverColor": "c9",
-    "ClickColor": "c7",
-    "DisabledColor": "c10",
-    "CheckedColor": "c10"
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "DisabledColor": "disabled",
+    "CheckedColor": "disabled"
   },
   "Slider": {
     "Fillet": 4,
@@ -100,12 +97,12 @@
     "BorderPad": 2,
     "Filled": true,
     "Outlined": false,
-    "TextColor": "c5",
-    "Color": "c8",
-    "HoverColor": "c9",
-    "ClickColor": "c11",
-    "DisabledColor": "c10",
-    "CheckedColor": "c10"
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "hover",
+    "DisabledColor": "disabled",
+    "CheckedColor": "disabled"
   },
   "Dropdown": {
     "Fillet": 4,
@@ -113,12 +110,12 @@
     "BorderPad": 2,
     "Filled": true,
     "Outlined": false,
-    "TextColor": "c5",
-    "Color": "c8",
-    "HoverColor": "c9",
-    "ClickColor": "c7",
-    "DisabledColor": "c10",
-    "CheckedColor": "c10",
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "DisabledColor": "disabled",
+    "CheckedColor": "disabled",
     "MaxVisible": 5
   },
   "Tab": {
@@ -127,9 +124,9 @@
     "BorderPad": 8,
     "Filled": true,
     "Outlined": false,
-    "TextColor": "c5",
-    "Color": "c8",
-    "HoverColor": "c9",
-    "ClickColor": "c8"
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "button"
   }
 }

--- a/themes/FlatDark.json
+++ b/themes/FlatDark.json
@@ -1,32 +1,30 @@
 {
   "Comment": "Colors use #RRGGBBAA or h,s,v",
   "Colors": {
-    "c1": "#202020ff",
-    "c2": "#404040ff",
-    "c3": "#ffffffff",
-    "c4": "#303030ff",
-    "c5": "#505050ff",
-    "c6": "#00a0a0ff",
-    "c7": "#606060ff",
-    "c8": "#00000000",
-    "c9": "#c0c0c0ff",
-    "c10": "#a0a0a0ff"
+    "background": "0.0,0.00,0.13",
+    "panel": "0.0,0.00,0.25",
+    "text": "0.0,0.00,1.00",
+    "outline": "0.0,0.00,0.19",
+    "button": "0.0,0.00,0.31",
+    "accent": "180.0,1.00,0.63",
+    "hover": "0.0,0.00,0.38",
+    "disabled": "0.0,0.00,0.00,0.00"
   },
   "RecommendedLayout": "Default",
   "Window": {
     "Border": 0,
     "Outlined": false,
     "Padding": 8,
-    "BGColor": "c1",
-    "TitleBGColor": "c2",
-    "TitleColor": "c3",
-    "BorderColor": "c2",
-    "SizeTabColor": "c4",
-    "DragbarColor": "c2",
-    "HoverTitleColor": "c3",
-    "HoverColor": "c5",
-    "ActiveColor": "c6",
-    "TitleTextColor": "c3"
+    "BGColor": "background",
+    "TitleBGColor": "panel",
+    "TitleColor": "text",
+    "BorderColor": "panel",
+    "SizeTabColor": "outline",
+    "DragbarColor": "panel",
+    "HoverTitleColor": "text",
+    "HoverColor": "hover",
+    "ActiveColor": "accent",
+    "TitleTextColor": "text"
   },
   "Button": {
     "Fillet": 10,
@@ -34,12 +32,12 @@
     "BorderPad": 4,
     "Filled": true,
     "Outlined": false,
-    "TextColor": "c3",
-    "Color": "c2",
-    "HoverColor": "c7",
-    "ClickColor": "c6",
-    "DisabledColor": "c8",
-    "CheckedColor": "c8"
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "DisabledColor": "disabled",
+    "CheckedColor": "disabled"
   },
   "Text": {
     "Fillet": 0,
@@ -47,12 +45,12 @@
     "BorderPad": 4,
     "Filled": false,
     "Outlined": false,
-    "TextColor": "c3",
-    "Color": "c8",
-    "HoverColor": "c8",
-    "ClickColor": "c8",
-    "DisabledColor": "c8",
-    "CheckedColor": "c8"
+    "TextColor": "text",
+    "Color": "disabled",
+    "HoverColor": "disabled",
+    "ClickColor": "disabled",
+    "DisabledColor": "disabled",
+    "CheckedColor": "disabled"
   },
   "Checkbox": {
     "Fillet": 8,
@@ -60,12 +58,12 @@
     "BorderPad": 4,
     "Filled": true,
     "Outlined": false,
-    "TextColor": "c3",
-    "Color": "c2",
-    "HoverColor": "c7",
-    "ClickColor": "c2",
-    "DisabledColor": "c8",
-    "CheckedColor": "c8"
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "DisabledColor": "disabled",
+    "CheckedColor": "disabled"
   },
   "Radio": {
     "Fillet": 8,
@@ -73,12 +71,12 @@
     "BorderPad": 4,
     "Filled": true,
     "Outlined": false,
-    "TextColor": "c3",
-    "Color": "c2",
-    "HoverColor": "c7",
-    "ClickColor": "c2",
-    "DisabledColor": "c8",
-    "CheckedColor": "c8"
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "DisabledColor": "disabled",
+    "CheckedColor": "disabled"
   },
   "Input": {
     "Fillet": 4,
@@ -86,12 +84,12 @@
     "BorderPad": 2,
     "Filled": true,
     "Outlined": false,
-    "TextColor": "c3",
-    "Color": "c2",
-    "HoverColor": "c7",
-    "ClickColor": "c6",
-    "DisabledColor": "c8",
-    "CheckedColor": "c8"
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "DisabledColor": "disabled",
+    "CheckedColor": "disabled"
   },
   "Slider": {
     "Fillet": 4,
@@ -99,12 +97,12 @@
     "BorderPad": 2,
     "Filled": true,
     "Outlined": false,
-    "TextColor": "c3",
-    "Color": "c2",
-    "HoverColor": "c7",
-    "ClickColor": "c9",
-    "DisabledColor": "c8",
-    "CheckedColor": "c8"
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "DisabledColor": "disabled",
+    "CheckedColor": "disabled"
   },
   "Dropdown": {
     "Fillet": 4,
@@ -112,12 +110,12 @@
     "BorderPad": 2,
     "Filled": true,
     "Outlined": false,
-    "TextColor": "c3",
-    "Color": "c2",
-    "HoverColor": "c7",
-    "ClickColor": "c6",
-    "DisabledColor": "c8",
-    "CheckedColor": "c8",
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "DisabledColor": "disabled",
+    "CheckedColor": "disabled",
     "MaxVisible": 5
   },
   "Tab": {
@@ -126,9 +124,9 @@
     "BorderPad": 8,
     "Filled": true,
     "Outlined": false,
-    "TextColor": "c3",
-    "Color": "c2",
-    "HoverColor": "c7",
-    "ClickColor": "c10"
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent"
   }
 }


### PR DESCRIPTION
## Summary
- rename color names in all theme JSON files
- convert theme color values to HSV format
- lighten AccentLight theme buttons and text

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6875a026d88c832a9805e7451198fb7b