### PR TITLE
Refactor layouts and constants

### DIFF
--- a/color_wheel.go
+++ b/color_wheel.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"image/color"
+	"math"
+
+	"github.com/hajimehoshi/ebiten/v2"
+)
+
+// ColorWheelImage creates an Ebiten image containing a color wheel of the given size.
+// The wheel ranges 0-359 degrees with white on the outside, fully saturated color
+// at the midpoint and black at the center.
+func ColorWheelImage(size int) *ebiten.Image {
+	if size <= 0 {
+		return ebiten.NewImage(1, 1)
+	}
+	img := ebiten.NewImage(size, size)
+	r := float64(size) / 2
+	mid := r * 0.5
+	for y := 0; y < size; y++ {
+		for x := 0; x < size; x++ {
+			dx := float64(x) - r
+			dy := float64(y) - r
+			dist := math.Hypot(dx, dy)
+			if dist > r {
+				img.Set(x, y, color.Transparent)
+				continue
+			}
+			ang := math.Atan2(dy, dx) * 180 / math.Pi
+			if ang < 0 {
+				ang += 360
+			}
+			var col color.RGBA
+			if dist <= mid {
+				// from black to full color
+				v := dist / mid
+				col = hsvaToRGBA(ang, 1, v, 1)
+			} else {
+				// from full color to white
+				t := (dist - mid) / (r - mid)
+				col = hsvaToRGBA(ang, 1-t, 1, 1)
+			}
+			img.Set(x, y, col)
+		}
+	}
+	return img
+}

--- a/const.go
+++ b/const.go
@@ -1,0 +1,12 @@
+package main
+
+const (
+	MinWinSizeX = 192
+	MinWinSizeY = 64
+
+	DefaultTabWidth  = 128
+	DefaultTabHeight = 24
+
+	CornerSize = 14
+	Tol        = 2
+)

--- a/glob.go
+++ b/glob.go
@@ -34,13 +34,7 @@ func init() {
 	whiteImage.Fill(color.White)
 }
 
-const (
-	minWinSizeX = 192
-	minWinSizeY = 64
-
-	defaultTabWidth  = 128
-	defaultTabHeight = 24
-)
+// constants moved to const.go
 
 type Game struct {
 }

--- a/glob_test.go
+++ b/glob_test.go
@@ -29,11 +29,3 @@ var (
 )
 
 type Game struct{}
-
-const (
-	minWinSizeX = 192
-	minWinSizeY = 64
-
-	defaultTabWidth  = 128
-	defaultTabHeight = 24
-)

--- a/layout.go
+++ b/layout.go
@@ -10,16 +10,65 @@ import (
 var embeddedLayouts embed.FS
 
 // LayoutTheme controls spacing and padding used by widgets.
+type LayoutNumbers struct {
+	Window   float32
+	Button   float32
+	Text     float32
+	Checkbox float32
+	Radio    float32
+	Input    float32
+	Slider   float32
+	Dropdown float32
+	Tab      float32
+}
+
 type LayoutTheme struct {
 	SliderValueGap   float32
 	DropdownArrowPad float32
 	TextPadding      float32
+
+	Fillet    LayoutNumbers
+	Border    LayoutNumbers
+	BorderPad LayoutNumbers
 }
 
 var defaultLayout = &LayoutTheme{
 	SliderValueGap:   16,
 	DropdownArrowPad: 8,
 	TextPadding:      4,
+	Fillet: LayoutNumbers{
+		Window:   4,
+		Button:   8,
+		Text:     0,
+		Checkbox: 8,
+		Radio:    8,
+		Input:    4,
+		Slider:   4,
+		Dropdown: 4,
+		Tab:      4,
+	},
+	Border: LayoutNumbers{
+		Window:   0,
+		Button:   0,
+		Text:     0,
+		Checkbox: 0,
+		Radio:    0,
+		Input:    0,
+		Slider:   0,
+		Dropdown: 0,
+		Tab:      0,
+	},
+	BorderPad: LayoutNumbers{
+		Window:   0,
+		Button:   4,
+		Text:     4,
+		Checkbox: 4,
+		Radio:    4,
+		Input:    2,
+		Slider:   2,
+		Dropdown: 2,
+		Tab:      2,
+	},
 }
 
 var (
@@ -36,5 +85,50 @@ func LoadLayout(name string) error {
 		return err
 	}
 	currentLayoutName = name
+	if currentTheme != nil {
+		applyLayoutToTheme(currentTheme)
+		applyThemeToAll()
+	}
 	return nil
+}
+
+func applyLayoutToTheme(th *Theme) {
+	if th == nil || currentLayout == nil {
+		return
+	}
+	th.Window.Fillet = currentLayout.Fillet.Window
+	th.Window.Border = currentLayout.Border.Window
+	th.Window.BorderPad = currentLayout.BorderPad.Window
+
+	th.Button.Fillet = currentLayout.Fillet.Button
+	th.Button.Border = currentLayout.Border.Button
+	th.Button.BorderPad = currentLayout.BorderPad.Button
+
+	th.Text.Fillet = currentLayout.Fillet.Text
+	th.Text.Border = currentLayout.Border.Text
+	th.Text.BorderPad = currentLayout.BorderPad.Text
+
+	th.Checkbox.Fillet = currentLayout.Fillet.Checkbox
+	th.Checkbox.Border = currentLayout.Border.Checkbox
+	th.Checkbox.BorderPad = currentLayout.BorderPad.Checkbox
+
+	th.Radio.Fillet = currentLayout.Fillet.Radio
+	th.Radio.Border = currentLayout.Border.Radio
+	th.Radio.BorderPad = currentLayout.BorderPad.Radio
+
+	th.Input.Fillet = currentLayout.Fillet.Input
+	th.Input.Border = currentLayout.Border.Input
+	th.Input.BorderPad = currentLayout.BorderPad.Input
+
+	th.Slider.Fillet = currentLayout.Fillet.Slider
+	th.Slider.Border = currentLayout.Border.Slider
+	th.Slider.BorderPad = currentLayout.BorderPad.Slider
+
+	th.Dropdown.Fillet = currentLayout.Fillet.Dropdown
+	th.Dropdown.Border = currentLayout.Border.Dropdown
+	th.Dropdown.BorderPad = currentLayout.BorderPad.Dropdown
+
+	th.Tab.Fillet = currentLayout.Fillet.Tab
+	th.Tab.Border = currentLayout.Border.Tab
+	th.Tab.BorderPad = currentLayout.BorderPad.Tab
 }

--- a/render.go
+++ b/render.go
@@ -224,7 +224,7 @@ func (item *itemData) drawFlows(parent *itemData, offset point, clip rect, scree
 			item.ActiveTab = 0
 		}
 
-		tabHeight := float32(defaultTabHeight) * uiScale
+		tabHeight := float32(DefaultTabHeight) * uiScale
 		if th := item.FontSize*uiScale + 4; th > tabHeight {
 			tabHeight = th
 		}
@@ -235,8 +235,8 @@ func (item *itemData) drawFlows(parent *itemData, offset point, clip rect, scree
 			face := &text.GoTextFace{Source: mplusFaceSource, Size: float64(textSize)}
 			tw, _ := text.Measure(tab.Name, face, 0)
 			w := float32(tw) + 8
-			if w < float32(defaultTabWidth)*uiScale {
-				w = float32(defaultTabWidth) * uiScale
+			if w < float32(DefaultTabWidth)*uiScale {
+				w = float32(DefaultTabWidth) * uiScale
 			}
 			col := item.Color
 			if i == item.ActiveTab {

--- a/theme.go
+++ b/theme.go
@@ -12,16 +12,17 @@ import (
 	"strings"
 )
 
-//go:embed themes/*.json
+//go:embed themes/colors/*.json
 var embeddedThemes embed.FS
 
 func init() {
-	data, err := embeddedThemes.ReadFile(filepath.Join("themes", "FlatDark.json"))
+	data, err := embeddedThemes.ReadFile(filepath.Join("themes", "colors", "FlatDark.json"))
 	if err == nil {
 		_ = json.Unmarshal(data, baseTheme)
 	}
 	currentTheme = baseTheme
 	currentThemeName = "FlatDark"
+	applyLayoutToTheme(currentTheme)
 }
 
 // Theme bundles all style information for windows and widgets.
@@ -74,9 +75,9 @@ func resolveColor(s string, colors map[string]string, seen map[string]bool) (Col
 // LoadTheme reads a theme JSON file from the themes directory and
 // sets it as the current theme without modifying existing windows.
 func LoadTheme(name string) error {
-	data, err := embeddedThemes.ReadFile(filepath.Join("themes", name+".json"))
+	data, err := embeddedThemes.ReadFile(filepath.Join("themes", "colors", name+".json"))
 	if err != nil {
-		file := filepath.Join("themes", name+".json")
+		file := filepath.Join("themes", "colors", name+".json")
 		data, err = os.ReadFile(file)
 		if err != nil {
 			return err
@@ -105,6 +106,7 @@ func LoadTheme(name string) error {
 	}
 	currentTheme = &th
 	currentThemeName = name
+	applyLayoutToTheme(currentTheme)
 	applyThemeToAll()
 	if tf.RecommendedLayout != "" {
 		_ = LoadLayout(tf.RecommendedLayout)
@@ -114,9 +116,9 @@ func LoadTheme(name string) error {
 
 // listThemes returns the available theme names from the themes directory
 func listThemes() ([]string, error) {
-	entries, err := fs.ReadDir(embeddedThemes, "themes")
+	entries, err := fs.ReadDir(embeddedThemes, "themes/colors")
 	if err != nil {
-		entries, err = os.ReadDir("themes")
+		entries, err = os.ReadDir("themes/colors")
 		if err != nil {
 			return nil, err
 		}

--- a/themes/colors/AccentDark.json
+++ b/themes/colors/AccentDark.json
@@ -1,18 +1,16 @@
 {
   "Comment": "Colors use #RRGGBBAA or h,s,v",
   "Colors": {
-    "background": "0.0,0.00,0.13",
-    "panel": "0.0,0.00,0.25",
+    "background": "210.0,0.16,0.15",
+    "panel": "214.3,0.15,0.19",
     "text": "0.0,0.00,1.00",
-    "outline": "0.0,0.00,0.19",
-    "button": "0.0,0.00,0.31",
-    "accent": "180.0,1.00,0.63",
+    "outline": "216.0,0.15,0.13",
+    "button": "0.0,0.00,0.25",
     "hover": "0.0,0.00,0.38",
+    "accent": "200.6,0.74,0.91",
     "disabled": "0.0,0.00,0.00,0.00"
   },
-  "RecommendedLayout": "Default",
   "Window": {
-    "Border": 0,
     "Outlined": false,
     "Padding": 8,
     "BGColor": "background",
@@ -27,9 +25,6 @@
     "TitleTextColor": "text"
   },
   "Button": {
-    "Fillet": 10,
-    "Border": 0,
-    "BorderPad": 4,
     "Filled": true,
     "Outlined": false,
     "TextColor": "text",
@@ -40,22 +35,16 @@
     "CheckedColor": "disabled"
   },
   "Text": {
-    "Fillet": 0,
-    "Border": 0,
-    "BorderPad": 4,
     "Filled": false,
     "Outlined": false,
     "TextColor": "text",
     "Color": "disabled",
     "HoverColor": "disabled",
-    "ClickColor": "disabled",
+    "ClickColor": "accent",
     "DisabledColor": "disabled",
     "CheckedColor": "disabled"
   },
   "Checkbox": {
-    "Fillet": 8,
-    "Border": 0,
-    "BorderPad": 4,
     "Filled": true,
     "Outlined": false,
     "TextColor": "text",
@@ -66,9 +55,6 @@
     "CheckedColor": "disabled"
   },
   "Radio": {
-    "Fillet": 8,
-    "Border": 0,
-    "BorderPad": 4,
     "Filled": true,
     "Outlined": false,
     "TextColor": "text",
@@ -79,9 +65,6 @@
     "CheckedColor": "disabled"
   },
   "Input": {
-    "Fillet": 4,
-    "Border": 0,
-    "BorderPad": 2,
     "Filled": true,
     "Outlined": false,
     "TextColor": "text",
@@ -92,9 +75,6 @@
     "CheckedColor": "disabled"
   },
   "Slider": {
-    "Fillet": 4,
-    "Border": 0,
-    "BorderPad": 2,
     "Filled": true,
     "Outlined": false,
     "TextColor": "text",
@@ -105,9 +85,6 @@
     "CheckedColor": "disabled"
   },
   "Dropdown": {
-    "Fillet": 4,
-    "Border": 0,
-    "BorderPad": 2,
     "Filled": true,
     "Outlined": false,
     "TextColor": "text",
@@ -119,14 +96,12 @@
     "MaxVisible": 5
   },
   "Tab": {
-    "Fillet": 8,
-    "Border": 0,
-    "BorderPad": 8,
     "Filled": true,
     "Outlined": false,
     "TextColor": "text",
     "Color": "button",
     "HoverColor": "hover",
     "ClickColor": "accent"
-  }
+  },
+  "RecommendedLayout": "Default"
 }

--- a/themes/colors/AccentLight.json
+++ b/themes/colors/AccentLight.json
@@ -12,7 +12,6 @@
   },
   "RecommendedLayout": "Default",
   "Window": {
-    "Border": 0,
     "Outlined": false,
     "Padding": 8,
     "BGColor": "background",
@@ -27,9 +26,6 @@
     "TitleTextColor": "text"
   },
   "Button": {
-    "Fillet": 10,
-    "Border": 0,
-    "BorderPad": 4,
     "Filled": true,
     "Outlined": false,
     "TextColor": "text",
@@ -40,9 +36,6 @@
     "CheckedColor": "disabled"
   },
   "Text": {
-    "Fillet": 0,
-    "Border": 0,
-    "BorderPad": 4,
     "Filled": false,
     "Outlined": false,
     "TextColor": "text",
@@ -53,9 +46,6 @@
     "CheckedColor": "disabled"
   },
   "Checkbox": {
-    "Fillet": 8,
-    "Border": 0,
-    "BorderPad": 4,
     "Filled": true,
     "Outlined": false,
     "TextColor": "text",
@@ -66,9 +56,6 @@
     "CheckedColor": "disabled"
   },
   "Radio": {
-    "Fillet": 8,
-    "Border": 0,
-    "BorderPad": 4,
     "Filled": true,
     "Outlined": false,
     "TextColor": "text",
@@ -79,9 +66,6 @@
     "CheckedColor": "disabled"
   },
   "Input": {
-    "Fillet": 4,
-    "Border": 0,
-    "BorderPad": 2,
     "Filled": true,
     "Outlined": false,
     "TextColor": "text",
@@ -92,9 +76,6 @@
     "CheckedColor": "disabled"
   },
   "Slider": {
-    "Fillet": 4,
-    "Border": 0,
-    "BorderPad": 2,
     "Filled": true,
     "Outlined": false,
     "TextColor": "text",
@@ -105,9 +86,6 @@
     "CheckedColor": "disabled"
   },
   "Dropdown": {
-    "Fillet": 4,
-    "Border": 0,
-    "BorderPad": 2,
     "Filled": true,
     "Outlined": false,
     "TextColor": "text",
@@ -119,9 +97,6 @@
     "MaxVisible": 5
   },
   "Tab": {
-    "Fillet": 8,
-    "Border": 0,
-    "BorderPad": 8,
     "Filled": true,
     "Outlined": false,
     "TextColor": "text",

--- a/themes/colors/FlatDark.json
+++ b/themes/colors/FlatDark.json
@@ -1,17 +1,17 @@
 {
   "Comment": "Colors use #RRGGBBAA or h,s,v",
   "Colors": {
-    "background": "210.0,0.16,0.15",
-    "panel": "214.3,0.15,0.19",
+    "background": "0.0,0.00,0.13",
+    "panel": "0.0,0.00,0.25",
     "text": "0.0,0.00,1.00",
-    "outline": "216.0,0.15,0.13",
-    "button": "0.0,0.00,0.25",
+    "outline": "0.0,0.00,0.19",
+    "button": "0.0,0.00,0.31",
+    "accent": "180.0,1.00,0.63",
     "hover": "0.0,0.00,0.38",
-    "accent": "200.6,0.74,0.91",
     "disabled": "0.0,0.00,0.00,0.00"
   },
+  "RecommendedLayout": "Default",
   "Window": {
-    "Border": 0,
     "Outlined": false,
     "Padding": 8,
     "BGColor": "background",
@@ -26,9 +26,6 @@
     "TitleTextColor": "text"
   },
   "Button": {
-    "Fillet": 10,
-    "Border": 0,
-    "BorderPad": 4,
     "Filled": true,
     "Outlined": false,
     "TextColor": "text",
@@ -39,22 +36,16 @@
     "CheckedColor": "disabled"
   },
   "Text": {
-    "Fillet": 0,
-    "Border": 0,
-    "BorderPad": 4,
     "Filled": false,
     "Outlined": false,
     "TextColor": "text",
     "Color": "disabled",
     "HoverColor": "disabled",
-    "ClickColor": "accent",
+    "ClickColor": "disabled",
     "DisabledColor": "disabled",
     "CheckedColor": "disabled"
   },
   "Checkbox": {
-    "Fillet": 8,
-    "Border": 0,
-    "BorderPad": 4,
     "Filled": true,
     "Outlined": false,
     "TextColor": "text",
@@ -65,9 +56,6 @@
     "CheckedColor": "disabled"
   },
   "Radio": {
-    "Fillet": 8,
-    "Border": 0,
-    "BorderPad": 4,
     "Filled": true,
     "Outlined": false,
     "TextColor": "text",
@@ -78,9 +66,6 @@
     "CheckedColor": "disabled"
   },
   "Input": {
-    "Fillet": 4,
-    "Border": 0,
-    "BorderPad": 2,
     "Filled": true,
     "Outlined": false,
     "TextColor": "text",
@@ -91,9 +76,6 @@
     "CheckedColor": "disabled"
   },
   "Slider": {
-    "Fillet": 4,
-    "Border": 0,
-    "BorderPad": 2,
     "Filled": true,
     "Outlined": false,
     "TextColor": "text",
@@ -104,9 +86,6 @@
     "CheckedColor": "disabled"
   },
   "Dropdown": {
-    "Fillet": 4,
-    "Border": 0,
-    "BorderPad": 2,
     "Filled": true,
     "Outlined": false,
     "TextColor": "text",
@@ -118,15 +97,11 @@
     "MaxVisible": 5
   },
   "Tab": {
-    "Fillet": 8,
-    "Border": 0,
-    "BorderPad": 8,
     "Filled": true,
     "Outlined": false,
     "TextColor": "text",
     "Color": "button",
     "HoverColor": "hover",
     "ClickColor": "accent"
-  },
-  "RecommendedLayout": "Default"
+  }
 }

--- a/themes/layout/Default.json
+++ b/themes/layout/Default.json
@@ -1,5 +1,38 @@
 {
   "SliderValueGap": 16,
   "DropdownArrowPad": 8,
-  "TextPadding": 4
+  "TextPadding": 4,
+  "Fillet": {
+    "Window": 4,
+    "Button": 8,
+    "Text": 0,
+    "Checkbox": 8,
+    "Radio": 8,
+    "Input": 4,
+    "Slider": 4,
+    "Dropdown": 4,
+    "Tab": 4
+  },
+  "Border": {
+    "Window": 0,
+    "Button": 0,
+    "Text": 0,
+    "Checkbox": 0,
+    "Radio": 0,
+    "Input": 0,
+    "Slider": 0,
+    "Dropdown": 0,
+    "Tab": 0
+  },
+  "BorderPad": {
+    "Window": 0,
+    "Button": 4,
+    "Text": 4,
+    "Checkbox": 4,
+    "Radio": 4,
+    "Input": 2,
+    "Slider": 2,
+    "Dropdown": 2,
+    "Tab": 2
+  }
 }

--- a/util.go
+++ b/util.go
@@ -104,13 +104,13 @@ func (win *windowData) setSize(size point) bool {
 		tooSmall = true
 	}
 
-	if size.X < minWinSizeX {
-		size.X = minWinSizeX
+	if size.X < MinWinSizeX {
+		size.X = MinWinSizeX
 		tooSmall = true
 	}
 
-	if size.Y < minWinSizeY {
-		size.Y = minWinSizeY
+	if size.Y < MinWinSizeY {
+		size.Y = MinWinSizeY
 		tooSmall = true
 	}
 
@@ -118,9 +118,6 @@ func (win *windowData) setSize(size point) bool {
 	win.resizeFlows()
 	return tooSmall
 }
-
-const cornerSize = 14
-const tol = 2
 
 func (win *windowData) getWindowPart(mpos point, click bool) dragType {
 
@@ -148,8 +145,8 @@ func (win *windowData) getWindowPart(mpos point, click bool) dragType {
 		return PART_NONE
 	}
 
-	t := tol * uiScale
-	cs := cornerSize * uiScale
+	t := Tol * uiScale
+	cs := CornerSize * uiScale
 
 	winRect := win.getWinRect()
 


### PR DESCRIPTION
## Summary
- centralize repeated constants in `const.go`
- move color themes into `themes/colors`
- expand layout theme to hold geometry options and apply them in code
- update default layout with border/fillet settings
- generate color wheel helper

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6875a85131a0832a885e0a525c662b13