### PR TITLE
Move accent line below tabs

### DIFF
--- a/render.go
+++ b/render.go
@@ -258,7 +258,7 @@ func (item *itemData) drawFlows(parent *itemData, offset point, clip rect, scree
 		drawOffset = pointAdd(drawOffset, point{Y: tabHeight})
 		vector.DrawFilledRect(subImg,
 			offset.X,
-			offset.Y,
+			offset.Y+tabHeight-3*uiScale,
 			item.GetSize().X,
 			3*uiScale,
 			item.ClickColor,


### PR DESCRIPTION
## Summary
- move the tab accent line to appear between tabs and the flow content

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6875ad659a58832a926f3386fff72f5f