### PR TITLE
Add color saturation slider

### DIFF
--- a/theme.go
+++ b/theme.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
+	"image/color"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -108,6 +109,10 @@ func LoadTheme(name string) error {
 	currentThemeName = name
 	applyLayoutToTheme(currentTheme)
 	applyThemeToAll()
+	if ac, ok := namedColors["accent"]; ok {
+		accentHue, accentSaturation, accentValue, accentAlpha = rgbaToHSVA(color.RGBA(ac))
+	}
+	applyAccentColor()
 	if tf.RecommendedLayout != "" {
 		_ = LoadLayout(tf.RecommendedLayout)
 	}
@@ -138,18 +143,33 @@ func listThemes() ([]string, error) {
 // SetAccentColor updates the accent color in the current theme and applies it
 // to all windows and widgets.
 func SetAccentColor(c Color) {
-	namedColors["accent"] = c
+	accentHue, _, accentValue, accentAlpha = rgbaToHSVA(color.RGBA(c))
+	applyAccentColor()
+}
+
+// SetAccentSaturation updates the saturation component of the accent color and
+// reapplies it to the current theme.
+func SetAccentSaturation(s float64) {
+	accentSaturation = clamp(s, 0, 1)
+	applyAccentColor()
+}
+
+// applyAccentColor composes the accent color from the stored HSV values and
+// updates all widgets.
+func applyAccentColor() {
+	col := Color(hsvaToRGBA(accentHue, accentSaturation, accentValue, accentAlpha))
+	namedColors["accent"] = col
 	if currentTheme == nil {
 		return
 	}
-	currentTheme.Window.ActiveColor = c
-	currentTheme.Button.ClickColor = c
-	currentTheme.Checkbox.ClickColor = c
-	currentTheme.Radio.ClickColor = c
-	currentTheme.Input.ClickColor = c
-	currentTheme.Slider.ClickColor = c
-	currentTheme.Dropdown.ClickColor = c
-	currentTheme.Tab.ClickColor = c
+	currentTheme.Window.ActiveColor = col
+	currentTheme.Button.ClickColor = col
+	currentTheme.Checkbox.ClickColor = col
+	currentTheme.Radio.ClickColor = col
+	currentTheme.Input.ClickColor = col
+	currentTheme.Slider.ClickColor = col
+	currentTheme.Dropdown.ClickColor = col
+	currentTheme.Tab.ClickColor = col
 	applyThemeToAll()
 }
 

--- a/theme_colors.go
+++ b/theme_colors.go
@@ -2,3 +2,12 @@ package main
 
 // namedColors holds theme-specific color mappings
 var namedColors map[string]Color
+
+// Variables tracking the accent color in HSV space. Saturation can be adjusted
+// independently via the theme selector slider.
+var (
+	accentHue        float64
+	accentSaturation float64 = 1
+	accentValue      float64
+	accentAlpha      float64 = 1
+)

--- a/theme_selector.go
+++ b/theme_selector.go
@@ -1,6 +1,8 @@
 package main
 
-import "log"
+import (
+	"log"
+)
 
 func makeThemeSelector() *windowData {
 	names, err := listThemes()
@@ -18,13 +20,16 @@ func makeThemeSelector() *windowData {
 		Resizable: false,
 		Closable:  false,
 		// Give the dropdown room to fully render by accounting for the
-		// title bar height and the control's size.
-		Size:     point{X: 192, Y: 160},
+		// title bar height and the control's size. Extra height is for
+		// the saturation slider.
+		Size:     point{X: 192, Y: 192},
 		Position: point{X: 4, Y: 4},
 		Open:     true,
 	})
 	mainFlow := &itemData{ItemType: ITEM_FLOW, Size: win.Size, FlowType: FLOW_VERTICAL}
 	win.addItemTo(mainFlow)
+
+	var satSlider *itemData
 
 	dd := NewDropdown(&itemData{Size: point{X: 150, Y: 24}, FontSize: 8})
 	dd.Options = names
@@ -39,10 +44,16 @@ func makeThemeSelector() *windowData {
 		if err := LoadTheme(currentThemeName); err != nil {
 			log.Printf("LoadTheme error: %v", err)
 		}
+		if satSlider != nil {
+			satSlider.Value = float32(accentSaturation)
+		}
 	}
 	dd.OnHover = func(idx int) {
 		if err := LoadTheme(names[idx]); err != nil {
 			log.Printf("LoadTheme error: %v", err)
+		}
+		if satSlider != nil {
+			satSlider.Value = float32(accentSaturation)
 		}
 	}
 	dd.HoverIndex = -1
@@ -50,6 +61,13 @@ func makeThemeSelector() *windowData {
 
 	cw := NewColorWheel(&itemData{Size: point{X: 128, Y: 128}})
 	mainFlow.addItemTo(cw)
+
+	satSlider = NewSlider(&itemData{Size: point{X: 128, Y: 24}, MinValue: 0, MaxValue: 1, FontSize: 8})
+	satSlider.Value = float32(accentSaturation)
+	satSlider.Action = func() {
+		SetAccentSaturation(float64(satSlider.Value))
+	}
+	mainFlow.addItemTo(satSlider)
 
 	return win
 }


### PR DESCRIPTION
## Summary
- expand Theme selector window to fit new controls
- allow adjusting accent saturation via a new slider
- track accent color in HSV so saturation can be modified

## Testing
- `./scripts/setup.sh`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6875bc18bf60832a986fca052ed22f51