### PR TITLE
Fix dropdown hit testing and add theme toggle

### DIFF
--- a/const.go
+++ b/const.go
@@ -9,4 +9,9 @@ const (
 
 	CornerSize = 14
 	Tol        = 2
+
+	// InactiveDim controls the opacity of the black overlay drawn over
+	// inactive windows. Values range from 0.0 (no dimming) to 1.0 (fully
+	// black). The default of 0.2 results in a 20% dimming effect.
+	InactiveDim = 0.2
 )

--- a/input.go
+++ b/input.go
@@ -135,8 +135,10 @@ func (g *Game) Update() error {
 		//Window items
 		win.clickWindowItems(mpos, click)
 
-		//Bring window forward on click, defer
-		if win.getWinRect().containsPoint(mpos) {
+		// Bring window forward on click if the cursor is over it or an
+		// expanded dropdown. Break so windows behind don't receive the
+		// event.
+		if win.getWinRect().containsPoint(mpos) || dropdownOpenContains(win.Contents, mpos) {
 			if click && activeWindow != win {
 				win.BringForward()
 			}

--- a/main.go
+++ b/main.go
@@ -15,7 +15,10 @@ import (
 	"github.com/hajimehoshi/ebiten/v2/text/v2"
 )
 
-var debugMode *bool
+var (
+	debugMode *bool
+	themeSel  *windowData
+)
 
 //go:embed data/fonts/NotoSans-Regular.ttf
 var notoTTF []byte
@@ -50,10 +53,30 @@ func main() {
 	showcase := makeShowcaseWindow()
 	showcase.AddWindow(false)
 
-	themeSel := makeThemeSelector()
+	themeSel = makeThemeSelector()
 	if themeSel != nil {
 		themeSel.AddWindow(false)
 	}
+
+	// Add a small pinned button to toggle the themes window
+	btnWin := NewWindow(&windowData{
+		TitleHeight: 0,
+		Size:        point{X: 84, Y: 32},
+		Position:    point{X: 4, Y: 4},
+		PinTo:       PIN_BOTTOM_RIGHT,
+		Open:        true,
+		Closable:    false,
+		Movable:     false,
+		Resizable:   false,
+	})
+	toggleBtn := NewButton(&itemData{Text: "Themes", Size: point{X: 80, Y: 24}, FontSize: 8})
+	toggleBtn.Action = func() {
+		if themeSel != nil {
+			themeSel.Open = !themeSel.Open
+		}
+	}
+	btnWin.addItemTo(toggleBtn)
+	btnWin.AddWindow(false)
 
 	err := loadIcons()
 	if err != nil {

--- a/render.go
+++ b/render.go
@@ -49,6 +49,13 @@ func (win *windowData) Draw(screen *ebiten.Image) {
 	//win.drawResizeTab(windowArea)
 	win.drawBorder(windowArea)
 	win.drawDebug(screen)
+
+	if activeWindow != win && InactiveDim > 0 {
+		r := win.getWinRect()
+		sub := screen.SubImage(r.getRectangle()).(*ebiten.Image)
+		alpha := uint8(float32(255) * float32(InactiveDim))
+		vector.DrawFilledRect(sub, 0, 0, r.X1-r.X0, r.Y1-r.Y0, color.RGBA{A: alpha}, false)
+	}
 }
 
 func (win *windowData) drawBG(screen *ebiten.Image) {


### PR DESCRIPTION
## Summary
- prevent click-through when dropdowns overlap other widgets
- dim inactive windows
- allow configuring dimming factor
- add a pinned button to toggle the Themes window

## Testing
- `./scripts/setup.sh`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6875c511e2fc832ab791ef49ef14a516