### PR TITLE
Fix inactive window dim overlay position

### DIFF
--- a/render.go
+++ b/render.go
@@ -52,9 +52,8 @@ func (win *windowData) Draw(screen *ebiten.Image) {
 
 	if activeWindow != win && InactiveDim > 0 {
 		r := win.getWinRect()
-		sub := screen.SubImage(r.getRectangle()).(*ebiten.Image)
 		alpha := uint8(float32(255) * float32(InactiveDim))
-		vector.DrawFilledRect(sub, 0, 0, r.X1-r.X0, r.Y1-r.Y0, color.RGBA{A: alpha}, false)
+		vector.DrawFilledRect(screen, r.X0, r.Y0, r.X1-r.X0, r.Y1-r.Y0, color.RGBA{A: alpha}, false)
 	}
 }
 


### PR DESCRIPTION
## Summary
- ensure inactive window dim effect uses screen coordinates

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6875cd662790832a847e2df3ee1c1c07