### PR TITLE
Fix active window selection with pinned overlays

### DIFF
--- a/window.go
+++ b/window.go
@@ -79,7 +79,9 @@ func (target *windowData) AddWindow(toBack bool) {
 
 	if !toBack {
 		windows = append(windows, target)
-		activeWindow = target
+		if target.PinTo == PIN_TOP_LEFT {
+			activeWindow = target
+		}
 	} else {
 		windows = append([]*windowData{target}, windows...)
 	}


### PR DESCRIPTION
## Summary
- avoid setting activeWindow when opening pinned windows

## Testing
- `./scripts/setup.sh`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6875d01916b8832ab7280dc4731a48a1