### PR TITLE
Add MarkOpen function

### DIFF
--- a/util_test.go
+++ b/util_test.go
@@ -108,3 +108,20 @@ func TestSetSliderValue(t *testing.T) {
 		t.Errorf("int slider got %v", item.Value)
 	}
 }
+
+func TestMarkOpen(t *testing.T) {
+	win1 := &windowData{Title: "win1", Open: true}
+	win2 := &windowData{Title: "win2", Open: false}
+	windows = []*windowData{win2, win1}
+	activeWindow = win1
+	win2.MarkOpen()
+	if !win2.Open {
+		t.Errorf("expected window to be open")
+	}
+	if activeWindow != win2 {
+		t.Errorf("expected active window to be win2")
+	}
+	if len(windows) != 2 || windows[1] != win2 {
+		t.Errorf("window order incorrect: %v", windows)
+	}
+}

--- a/window.go
+++ b/window.go
@@ -77,20 +77,20 @@ func (target *windowData) AddWindow(toBack bool) {
 		applyThemeToWindow(target)
 	}
 
-        // Closed windows shouldn't steal focus, so add them to the back by
-        // default and don't update the active window.
-        if !target.Open {
-                toBack = true
-        }
+	// Closed windows shouldn't steal focus, so add them to the back by
+	// default and don't update the active window.
+	if !target.Open {
+		toBack = true
+	}
 
-        if !toBack {
-                windows = append(windows, target)
-                if target.PinTo == PIN_TOP_LEFT {
-                        activeWindow = target
-                }
-        } else {
-                windows = append([]*windowData{target}, windows...)
-        }
+	if !toBack {
+		windows = append(windows, target)
+		if target.PinTo == PIN_TOP_LEFT {
+			activeWindow = target
+		}
+	} else {
+		windows = append([]*windowData{target}, windows...)
+	}
 }
 
 // Remove window from window list, if found.
@@ -212,6 +212,12 @@ func NewText(item *itemData) *itemData {
 		mergeData(&newItem, item)
 	}
 	return &newItem
+}
+
+// MarkOpen sets the window as open and brings it forward.
+func (target *windowData) MarkOpen() {
+	target.Open = true
+	target.BringForward()
 }
 
 // Bring a window to the front


### PR DESCRIPTION
## Summary
- add `MarkOpen` method to bring a window forward when opening
- test the new method

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6875eb93638c832a87a9c7c8b7d92c8b