### PR TITLE
Fix scrollbars not hiding

### DIFF
--- a/input.go
+++ b/input.go
@@ -216,6 +216,16 @@ func (g *Game) Update() error {
 		}
 	}
 
+	// Refresh flow layouts so scroll bars update when content size changes
+	for _, win := range windows {
+		if win.Open {
+			win.resizeFlows()
+		}
+	}
+	for _, ov := range overlays {
+		ov.resizeFlow(ov.GetSize())
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- update flow layouts every frame after handling input
- this keeps scroll position in sync with content size so scrollbars hide when content fits

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68760957d740832a86128c49d32c86d8