### PR TITLE
Fix autosize height to include titlebar

### DIFF
--- a/util.go
+++ b/util.go
@@ -396,9 +396,9 @@ func (win *windowData) updateAutoSize() {
 	if req.X > size.X {
 		size.X = req.X
 	}
-	if req.Y+win.GetTitleSize() > size.Y {
-		size.Y = req.Y + win.GetTitleSize()
-	}
+
+	// Always include the titlebar height in the calculated size
+	size.Y = req.Y + win.GetTitleSize()
 	if size.X > float32(screenWidth) {
 		size.X = float32(screenWidth)
 	}


### PR DESCRIPTION
## Summary
- fix window auto size height to always include titlebar height

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68769ef19e90832a938944e2ec507f7f