### PR TITLE
Fix Autosize Padding

### DIFF
--- a/util.go
+++ b/util.go
@@ -392,13 +392,16 @@ func (win *windowData) contentBounds() point {
 
 func (win *windowData) updateAutoSize() {
 	req := win.contentBounds()
+	pad := win.Padding + win.BorderPad
+
 	size := win.GetSize()
-	if req.X > size.X {
-		size.X = req.X
+	needX := req.X + 2*pad
+	if needX > size.X {
+		size.X = needX
 	}
 
 	// Always include the titlebar height in the calculated size
-	size.Y = req.Y + win.GetTitleSize()
+	size.Y = req.Y + win.GetTitleSize() + 2*pad
 	if size.X > float32(screenWidth) {
 		size.X = float32(screenWidth)
 	}


### PR DESCRIPTION
## Summary
- add padding and border allowance in autosize logic

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6876bd254688832a91fbe8170ee37b31