### PR TITLE
Reduce widget spacing and outline tabs

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -64,8 +64,8 @@ var defaultText = &itemData{
 var defaultCheckbox = &itemData{
 	Text:      "",
 	ItemType:  ITEM_CHECKBOX,
-	Size:      point{X: 128, Y: 32},
-	Position:  point{X: 4, Y: 4},
+	Size:      point{X: 128, Y: 24},
+	Position:  point{X: 4, Y: 2},
 	AuxSize:   point{X: 16, Y: 16},
 	AuxSpace:  4,
 	FontSize:  12,
@@ -107,8 +107,8 @@ var defaultInput = &itemData{
 var defaultRadio = &itemData{
 	Text:      "",
 	ItemType:  ITEM_RADIO,
-	Size:      point{X: 128, Y: 32},
-	Position:  point{X: 4, Y: 4},
+	Size:      point{X: 128, Y: 24},
+	Position:  point{X: 4, Y: 2},
 	AuxSize:   point{X: 16, Y: 16},
 	AuxSpace:  4,
 	FontSize:  12,
@@ -181,16 +181,17 @@ var defaultColorWheel = &itemData{
 }
 
 var defaultTab = &itemData{
-	ItemType:   ITEM_FLOW,
-	FontSize:   12,
-	Filled:     true,
-	Border:     0,
-	BorderPad:  2,
-	Fillet:     4,
-	TextColor:  Color(color.RGBA{R: 255, G: 255, B: 255, A: 255}),
-	Color:      Color(color.RGBA{R: 64, G: 64, B: 64, A: 255}),
-	HoverColor: Color(color.RGBA{R: 96, G: 96, B: 96, A: 255}),
-	ClickColor: Color(color.RGBA{R: 0, G: 160, B: 160, A: 255}),
+	ItemType:      ITEM_FLOW,
+	FontSize:      12,
+	Filled:        true,
+	Border:        0,
+	BorderPad:     2,
+	Fillet:        4,
+	ActiveOutline: false,
+	TextColor:     Color(color.RGBA{R: 255, G: 255, B: 255, A: 255}),
+	Color:         Color(color.RGBA{R: 64, G: 64, B: 64, A: 255}),
+	HoverColor:    Color(color.RGBA{R: 96, G: 96, B: 96, A: 255}),
+	ClickColor:    Color(color.RGBA{R: 0, G: 160, B: 160, A: 255}),
 }
 
 // base copies preserve the initial defaults so that LoadTheme can reset

--- a/example.go
+++ b/example.go
@@ -1,15 +1,15 @@
 package main
 
 func makeTestWindow() *windowData {
-       newWindow := NewWindow(
-               &windowData{
-                       TitleHeight: 24,
-                       Title:       "Test Window",
-                       Size:        point{X: 300, Y: 300},
-                       Position:    point{X: 8, Y: 8},
-                       AutoSize:    true,
-                       Open:        true,
-               })
+	newWindow := NewWindow(
+		&windowData{
+			TitleHeight: 24,
+			Title:       "Test Window",
+			Size:        point{X: 300, Y: 300},
+			Position:    point{X: 8, Y: 8},
+			AutoSize:    true,
+			Open:        true,
+		})
 
 	mainFlow := &itemData{
 		ItemType: ITEM_FLOW,
@@ -32,9 +32,9 @@ func makeTestWindow() *windowData {
 	leftText3 := NewText(&itemData{Text: "left panel item 3", Size: point{X: 100, Y: 32}, FontSize: 8})
 	leftButton1 := NewButton(&itemData{Text: "sprite button", Size: point{X: 64, Y: 64}, FontSize: 8, ImageName: "1"})
 	leftButton2 := NewButton(&itemData{Text: "text button", Size: point{X: 64, Y: 24}, FontSize: 8})
-	leftCheckbox1 := NewCheckbox(&itemData{Text: "Option 1", Size: point{X: 100, Y: 32}, FontSize: 8})
-	leftRadio1 := NewRadio(&itemData{Text: "Radio A", Size: point{X: 100, Y: 32}, FontSize: 8, RadioGroup: "grp1"})
-	leftRadio2 := NewRadio(&itemData{Text: "Radio B", Size: point{X: 100, Y: 32}, FontSize: 8, RadioGroup: "grp1"})
+	leftCheckbox1 := NewCheckbox(&itemData{Text: "Option 1", Size: point{X: 100, Y: 24}, FontSize: 8})
+	leftRadio1 := NewRadio(&itemData{Text: "Radio A", Size: point{X: 100, Y: 24}, FontSize: 8, RadioGroup: "grp1"})
+	leftRadio2 := NewRadio(&itemData{Text: "Radio B", Size: point{X: 100, Y: 24}, FontSize: 8, RadioGroup: "grp1"})
 	leftSlider1 := NewSlider(&itemData{Size: point{X: 96, Y: 20}, FontSize: 8, MinValue: 0, MaxValue: 10, IntOnly: true})
 	leftInput1 := NewInput(&itemData{Size: point{X: 96, Y: 20}, FontSize: 8})
 	leftFlow.addItemTo(leftText1)

--- a/render.go
+++ b/render.go
@@ -311,12 +311,23 @@ func (item *itemData) drawFlows(parent *itemData, offset point, clip rect, scree
 			}
 			col := item.Color
 			if i == item.ActiveTab {
-				col = item.ClickColor
+				if !item.ActiveOutline {
+					col = item.ClickColor
+				}
 			} else if tab.Hovered {
 				col = item.HoverColor
 			}
 			tab.Hovered = false
 			drawTabShape(subImg, point{X: x, Y: offset.Y}, point{X: w, Y: tabHeight}, dimColor(col, dimFactor), item.Fillet*uiScale, item.BorderPad*uiScale)
+			if item.ActiveOutline && i == item.ActiveTab {
+				vector.DrawFilledRect(subImg,
+					x,
+					offset.Y,
+					w,
+					3*uiScale,
+					dimColor(item.ClickColor, dimFactor),
+					false)
+			}
 			loo := text.LayoutOptions{PrimaryAlign: text.AlignCenter, SecondaryAlign: text.AlignCenter}
 			dop := ebiten.DrawImageOptions{}
 			dop.GeoM.Translate(float64(x+w/2), float64(offset.Y+tabHeight/2))

--- a/showcase.go
+++ b/showcase.go
@@ -28,11 +28,11 @@ func makeShowcaseWindow() *windowData {
 	btnText := NewButton(&itemData{Text: "Text Button", Size: point{X: 100, Y: 24}, FontSize: 8})
 	mainFlow.addItemTo(btnText)
 
-	chk := NewCheckbox(&itemData{Text: "Enable option", Size: point{X: 140, Y: 32}, FontSize: 8})
+	chk := NewCheckbox(&itemData{Text: "Enable option", Size: point{X: 140, Y: 24}, FontSize: 8})
 	mainFlow.addItemTo(chk)
 
-	radioA := NewRadio(&itemData{Text: "Choice A", RadioGroup: "grp1", Size: point{X: 140, Y: 32}, FontSize: 8})
-	radioB := NewRadio(&itemData{Text: "Choice B", RadioGroup: "grp1", Size: point{X: 140, Y: 32}, FontSize: 8})
+	radioA := NewRadio(&itemData{Text: "Choice A", RadioGroup: "grp1", Size: point{X: 140, Y: 24}, FontSize: 8})
+	radioB := NewRadio(&itemData{Text: "Choice B", RadioGroup: "grp1", Size: point{X: 140, Y: 24}, FontSize: 8})
 	mainFlow.addItemTo(radioA)
 	mainFlow.addItemTo(radioB)
 

--- a/struct.go
+++ b/struct.go
@@ -101,6 +101,7 @@ type itemData struct {
 	Fillet            float32
 	Border, BorderPad float32
 	Filled, Outlined  bool
+	ActiveOutline     bool
 	AuxSize           point
 	AuxSpace          float32
 

--- a/theme.go
+++ b/theme.go
@@ -232,6 +232,7 @@ func copyItemStyle(dst, src *itemData) {
 	dst.BorderPad = src.BorderPad
 	dst.Filled = src.Filled
 	dst.Outlined = src.Outlined
+	dst.ActiveOutline = src.ActiveOutline
 	dst.AuxSize = src.AuxSize
 	dst.AuxSpace = src.AuxSpace
 	dst.TextColor = src.TextColor


### PR DESCRIPTION
## Summary
- shrink default checkbox and radio sizes and adjust positions
- add `ActiveOutline` field for tab styles
- update example and showcase to match new widget sizes
- support outline mode when drawing tabs

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6876d31905f0832abfc322184779a36a