### PR TITLE
Improve color wheel and add labels

### DIFF
--- a/color_wheel.go
+++ b/color_wheel.go
@@ -8,15 +8,14 @@ import (
 )
 
 // ColorWheelImage creates an Ebiten image containing a color wheel of the given size.
-// The wheel ranges 0-359 degrees with white on the outside, fully saturated color
-// at the midpoint and black at the center.
+// The wheel ranges 0-359 degrees with black at the center and fully saturated
+// color on the outer edge.
 func ColorWheelImage(size int) *ebiten.Image {
 	if size <= 0 {
 		return ebiten.NewImage(1, 1)
 	}
 	img := ebiten.NewImage(size, size)
 	r := float64(size) / 2
-	mid := r * 0.5
 	for y := 0; y < size; y++ {
 		for x := 0; x < size; x++ {
 			dx := float64(x) - r
@@ -30,16 +29,13 @@ func ColorWheelImage(size int) *ebiten.Image {
 			if ang < 0 {
 				ang += 360
 			}
-			var col color.RGBA
-			if dist <= mid {
-				// from black to full color
-				v := dist / mid
-				col = hsvaToRGBA(ang, 1, v, 1)
-			} else {
-				// from full color to white
-				t := (dist - mid) / (r - mid)
-				col = hsvaToRGBA(ang, 1-t, 1, 1)
+			v := dist / r
+			if v < 0 {
+				v = 0
+			} else if v > 1 {
+				v = 1
 			}
+			col := hsvaToRGBA(ang, 1, v, 1)
 			img.Set(x, y, col)
 		}
 	}

--- a/input.go
+++ b/input.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"image/color"
 	"math"
 	"time"
 
@@ -476,9 +475,13 @@ func (item *itemData) setSliderValue(mpos point) {
 }
 
 func (item *itemData) colorAt(mpos point) (Color, bool) {
-	size := item.GetSize()
+	size := point{X: item.Size.X * uiScale, Y: item.Size.Y * uiScale}
+	offsetY := float32(0)
+	if item.Label != "" {
+		offsetY = (item.FontSize*uiScale + 2) + currentLayout.TextPadding
+	}
 	cx := item.DrawRect.X0 + size.X/2
-	cy := item.DrawRect.Y0 + size.Y/2
+	cy := item.DrawRect.Y0 + offsetY + size.Y/2
 	dx := float64(mpos.X - cx)
 	dy := float64(mpos.Y - cy)
 	r := float64(size.X) / 2
@@ -486,19 +489,17 @@ func (item *itemData) colorAt(mpos point) (Color, bool) {
 	if dist > r {
 		return Color{}, false
 	}
-	mid := r * 0.5
 	ang := math.Atan2(dy, dx) * 180 / math.Pi
 	if ang < 0 {
 		ang += 360
 	}
-	var col color.RGBA
-	if dist <= mid {
-		v := dist / mid
-		col = hsvaToRGBA(ang, 1, v, 1)
-	} else {
-		t := (dist - mid) / (r - mid)
-		col = hsvaToRGBA(ang, 1-t, 1, 1)
+	v := dist / r
+	if v < 0 {
+		v = 0
+	} else if v > 1 {
+		v = 1
 	}
+	col := hsvaToRGBA(ang, 1, v, 1)
 	return Color(col), true
 }
 

--- a/render.go
+++ b/render.go
@@ -432,6 +432,22 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 	}
 	subImg := screen.SubImage(item.DrawRect.getRectangle()).(*ebiten.Image)
 
+	if item.Label != "" {
+		textSize := (item.FontSize * uiScale) + 2
+		face := &text.GoTextFace{Source: mplusFaceSource, Size: float64(textSize)}
+		loo := text.LayoutOptions{PrimaryAlign: text.AlignStart, SecondaryAlign: text.AlignCenter}
+		tdop := ebiten.DrawImageOptions{}
+		tdop.GeoM.Translate(float64(offset.X), float64(offset.Y+textSize/2))
+		top := &text.DrawOptions{DrawImageOptions: tdop, LayoutOptions: loo}
+		top.ColorScale.ScaleWithColor(dimColor(item.TextColor, dimFactor))
+		text.Draw(subImg, item.Label, face, top)
+		offset.Y += textSize + currentLayout.TextPadding
+		maxSize.Y -= textSize + currentLayout.TextPadding
+		if maxSize.Y < 0 {
+			maxSize.Y = 0
+		}
+	}
+
 	if item.ItemType == ITEM_CHECKBOX {
 
 		bThick := float32(1.0)

--- a/showcase.go
+++ b/showcase.go
@@ -36,15 +36,15 @@ func makeShowcaseWindow() *windowData {
 	mainFlow.addItemTo(radioA)
 	mainFlow.addItemTo(radioB)
 
-	slider := NewSlider(&itemData{Size: point{X: 180, Y: 24}, MinValue: 0, MaxValue: 100, IntOnly: false, FontSize: 8})
+	slider := NewSlider(&itemData{Label: "Float Slider", Size: point{X: 180, Y: 24}, MinValue: 0, MaxValue: 100, IntOnly: false, FontSize: 8})
 	mainFlow.addItemTo(slider)
-	intSlider := NewSlider(&itemData{Size: point{X: 180, Y: 24}, MinValue: 0, MaxValue: 10, IntOnly: true, FontSize: 8})
+	intSlider := NewSlider(&itemData{Label: "Int Slider", Size: point{X: 180, Y: 24}, MinValue: 0, MaxValue: 10, IntOnly: true, FontSize: 8})
 	mainFlow.addItemTo(intSlider)
 
-	input := NewInput(&itemData{Text: "Text Field", Size: point{X: 180, Y: 24}, FontSize: 8})
+	input := NewInput(&itemData{Label: "Text Field", Text: "", Size: point{X: 180, Y: 24}, FontSize: 8})
 	mainFlow.addItemTo(input)
 
-	dropdown := NewDropdown(&itemData{Size: point{X: 180, Y: 24}, FontSize: 8})
+	dropdown := NewDropdown(&itemData{Label: "Select Option", Size: point{X: 180, Y: 24}, FontSize: 8})
 	dropdown.Options = []string{"First", "Second", "Third", "Fourth"}
 	dropdown.HoverIndex = -1
 	mainFlow.addItemTo(dropdown)

--- a/struct.go
+++ b/struct.go
@@ -60,6 +60,7 @@ type itemData struct {
 	// Name is used when the item is part of a tabbed flow
 	Name      string
 	Text      string
+	Label     string
 	Position  point
 	Size      point
 	Alignment alignType

--- a/theme_selector.go
+++ b/theme_selector.go
@@ -61,7 +61,7 @@ func makeThemeSelector() *windowData {
 	cw := NewColorWheel(&itemData{Size: point{X: 128, Y: 128}})
 	mainFlow.addItemTo(cw)
 
-	satSlider = NewSlider(&itemData{Size: point{X: 128, Y: 24}, MinValue: 0, MaxValue: 1, FontSize: 8})
+	satSlider = NewSlider(&itemData{Label: "Color Intensity", Size: point{X: 128, Y: 24}, MinValue: 0, MaxValue: 1, FontSize: 8})
 	satSlider.Value = float32(accentSaturation)
 	satSlider.Action = func() {
 		SetAccentSaturation(float64(satSlider.Value))

--- a/util.go
+++ b/util.go
@@ -303,7 +303,12 @@ func (win *windowData) GetPos() point {
 }
 
 func (item *itemData) GetSize() point {
-	return point{X: item.Size.X * uiScale, Y: item.Size.Y * uiScale}
+	sz := point{X: item.Size.X * uiScale, Y: item.Size.Y * uiScale}
+	if item.Label != "" {
+		textSize := (item.FontSize * uiScale) + 2
+		sz.Y += textSize + currentLayout.TextPadding
+	}
+	return sz
 }
 
 func (item *itemData) GetPos() point {


### PR DESCRIPTION
## Summary
- switch color wheel gradient to fade from black in the center to color on the edge
- support optional labels on UI items
- display labels in the showcase and theme selector examples

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6876d3a6ca80832a928f4b6e15ec24e0