### PR TITLE
Add layout dropdown and tab outline

### DIFF
--- a/layout.go
+++ b/layout.go
@@ -3,7 +3,11 @@ package main
 import (
 	"embed"
 	"encoding/json"
+	"io/fs"
+	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 )
 
 //go:embed themes/layout/*.json
@@ -184,4 +188,25 @@ func applyLayoutToTheme(th *Theme) {
 	th.Tab.BorderPad = currentLayout.BorderPad.Tab
 	th.Tab.Filled = currentLayout.Filled.Tab
 	th.Tab.Outlined = currentLayout.Outlined.Tab
+}
+
+// listLayouts returns the available layout theme names from the themes directory
+func listLayouts() ([]string, error) {
+	entries, err := fs.ReadDir(embeddedLayouts, "themes/layout")
+	if err != nil {
+		entries, err = os.ReadDir("themes/layout")
+		if err != nil {
+			return nil, err
+		}
+	}
+	names := []string{}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := strings.TrimSuffix(e.Name(), filepath.Ext(e.Name()))
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names, nil
 }

--- a/theme_selector.go
+++ b/theme_selector.go
@@ -20,8 +20,8 @@ func makeThemeSelector() *windowData {
 		Closable:  true,
 		// Give the dropdown room to fully render by accounting for the
 		// title bar height and the control's size. Extra height is for
-		// the saturation slider.
-		Size:     point{X: 192, Y: 224},
+		// additional layout selection controls.
+		Size:     point{X: 192, Y: 248},
 		Position: point{X: 4, Y: 4},
 		Open:     true,
 	})
@@ -29,6 +29,10 @@ func makeThemeSelector() *windowData {
 	win.addItemTo(mainFlow)
 
 	var satSlider *itemData
+	layoutNames, lerr := listLayouts()
+	if lerr != nil {
+		log.Printf("listLayouts error: %v", lerr)
+	}
 
 	dd := NewDropdown(&itemData{Size: point{X: 150, Y: 24}, FontSize: 8})
 	dd.Options = names
@@ -57,6 +61,30 @@ func makeThemeSelector() *windowData {
 	}
 	dd.HoverIndex = -1
 	mainFlow.addItemTo(dd)
+
+	if len(layoutNames) > 0 {
+		ldd := NewDropdown(&itemData{Size: point{X: 150, Y: 24}, FontSize: 8})
+		ldd.Options = layoutNames
+		for i, n := range layoutNames {
+			if n == currentLayoutName {
+				ldd.Selected = i
+				break
+			}
+		}
+		ldd.OnSelect = func(idx int) {
+			currentLayoutName = layoutNames[idx]
+			if err := LoadLayout(currentLayoutName); err != nil {
+				log.Printf("LoadLayout error: %v", err)
+			}
+		}
+		ldd.OnHover = func(idx int) {
+			if err := LoadLayout(layoutNames[idx]); err != nil {
+				log.Printf("LoadLayout error: %v", err)
+			}
+		}
+		ldd.HoverIndex = -1
+		mainFlow.addItemTo(ldd)
+	}
 
 	cw := NewColorWheel(&itemData{Size: point{X: 128, Y: 128}})
 	mainFlow.addItemTo(cw)


### PR DESCRIPTION
## Summary
- support enumerating layout themes
- add layout dropdown selector in theme window
- outline tab shapes when tab outlines are enabled
- align outlines and rounded edges to pixel grid

## Testing
- `./scripts/setup.sh`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68772177b6e0832a9ecb44fdd3d8f170