### PR TITLE
Add window dimming control and theme editor

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -174,10 +174,11 @@ var defaultDropdown = &itemData{
 }
 
 var defaultColorWheel = &itemData{
-	ItemType: ITEM_COLORWHEEL,
-	Size:     point{X: 128, Y: 128},
-	Position: point{X: 4, Y: 4},
-	Margin:   4,
+	ItemType:      ITEM_COLORWHEEL,
+	Size:          point{X: 128, Y: 128},
+	Position:      point{X: 4, Y: 4},
+	Margin:        4,
+	OnColorChange: nil,
 }
 
 var defaultTab = &itemData{

--- a/input.go
+++ b/input.go
@@ -336,7 +336,11 @@ func (item *itemData) clickItem(mpos point, click bool) bool {
 		item.Clicked = time.Now()
 		if item.ItemType == ITEM_COLORWHEEL {
 			if col, ok := item.colorAt(mpos); ok {
-				SetAccentColor(col)
+				if item.OnColorChange != nil {
+					item.OnColorChange(col)
+				} else {
+					SetAccentColor(col)
+				}
 			}
 		}
 		if item.ItemType == ITEM_CHECKBOX {
@@ -384,7 +388,11 @@ func (item *itemData) clickItem(mpos point, click bool) bool {
 		item.Hovered = true
 		if item.ItemType == ITEM_COLORWHEEL && ebiten.IsMouseButtonPressed(ebiten.MouseButton0) {
 			if col, ok := item.colorAt(mpos); ok {
-				SetAccentColor(col)
+				if item.OnColorChange != nil {
+					item.OnColorChange(col)
+				} else {
+					SetAccentColor(col)
+				}
 			}
 		} else if item.ItemType == ITEM_DROPDOWN && item.Open {
 			optionH := item.GetSize().Y

--- a/layout.go
+++ b/layout.go
@@ -43,6 +43,9 @@ type LayoutTheme struct {
 	DropdownArrowPad float32
 	TextPadding      float32
 
+	WindowDim    bool
+	WindowDimVal float32
+
 	Fillet    LayoutNumbers
 	Border    LayoutNumbers
 	BorderPad LayoutNumbers
@@ -54,6 +57,8 @@ var defaultLayout = &LayoutTheme{
 	SliderValueGap:   16,
 	DropdownArrowPad: 8,
 	TextPadding:      4,
+	WindowDim:        true,
+	WindowDimVal:     0.20,
 	Fillet: LayoutNumbers{
 		Window:   4,
 		Button:   8,
@@ -125,6 +130,11 @@ func LoadLayout(name string) error {
 		return err
 	}
 	currentLayoutName = name
+	if currentLayout.WindowDim {
+		InactiveDim = float64(currentLayout.WindowDimVal)
+	} else {
+		InactiveDim = 0
+	}
 	if currentTheme != nil {
 		applyLayoutToTheme(currentTheme)
 		applyThemeToAll()

--- a/struct.go
+++ b/struct.go
@@ -109,8 +109,9 @@ type itemData struct {
 	TextColor, Color, HoverColor,
 	ClickColor, DisabledColor, CheckedColor Color
 
-	Action   func()
-	Contents []*itemData
+	Action        func()
+	OnColorChange func(Color)
+	Contents      []*itemData
 
 	// Tabs allows a flow to contain multiple tabbed flows. Only the
 	// flow referenced by ActiveTab will be drawn and receive input.

--- a/theme.go
+++ b/theme.go
@@ -140,6 +140,25 @@ func listThemes() ([]string, error) {
 	return names, nil
 }
 
+// SaveTheme writes the current theme to a JSON file with the given name.
+func SaveTheme(name string) error {
+	if name == "" {
+		return fmt.Errorf("theme name required")
+	}
+	data, err := json.MarshalIndent(currentTheme, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll("themes/colors", 0755); err != nil {
+		return err
+	}
+	file := filepath.Join("themes", "colors", name+".json")
+	if err := os.WriteFile(file, data, 0644); err != nil {
+		return err
+	}
+	return nil
+}
+
 // SetAccentColor updates the accent color in the current theme and applies it
 // to all windows and widgets.
 func SetAccentColor(c Color) {

--- a/theme_editor.go
+++ b/theme_editor.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"log"
+	"reflect"
+	"strings"
+)
+
+var themeEditor *windowData
+var themeSelectorDropdown *itemData
+
+func makeThemeEditor() *windowData {
+	win := NewWindow(&windowData{
+		Title:     "Theme Editor",
+		Movable:   true,
+		Resizable: true,
+		Closable:  true,
+		Size:      point{X: 220, Y: 400},
+		Position:  point{X: 8, Y: 40},
+		Open:      true,
+	})
+	mainFlow := &itemData{ItemType: ITEM_FLOW, Size: win.Size, FlowType: FLOW_VERTICAL, Scrollable: true}
+	win.addItemTo(mainFlow)
+
+	addEditors("", reflect.ValueOf(currentTheme).Elem(), mainFlow)
+
+	nameInput := NewInput(&itemData{Size: point{X: 160, Y: 24}, FontSize: 8})
+	mainFlow.addItemTo(nameInput)
+	saveBtn := NewButton(&itemData{Text: "Save", Size: point{X: 80, Y: 24}, FontSize: 8})
+	saveBtn.Action = func() {
+		if err := SaveTheme(strings.TrimSpace(nameInput.Text)); err != nil {
+			log.Printf("SaveTheme error: %v", err)
+		} else if themeSelectorDropdown != nil {
+			if names, err := listThemes(); err == nil {
+				themeSelectorDropdown.Options = names
+			}
+		}
+	}
+	mainFlow.addItemTo(saveBtn)
+
+	return win
+}
+
+func addEditors(prefix string, val reflect.Value, flow *itemData) {
+	t := val.Type()
+	for i := 0; i < val.NumField(); i++ {
+		f := val.Field(i)
+		ft := t.Field(i)
+		label := prefix + ft.Name
+		switch f.Kind() {
+		case reflect.Struct:
+			if ft.Type.Name() == "Color" {
+				colPtr := f.Addr().Interface().(*Color)
+				flow.addItemTo(NewText(&itemData{Text: label, FontSize: 8}))
+				cw := NewColorWheel(&itemData{Size: point{X: 64, Y: 64}})
+				cw.OnColorChange = func(c Color) {
+					*colPtr = c
+					applyThemeToAll()
+				}
+				flow.addItemTo(cw)
+			} else {
+				addEditors(label+" ", f, flow)
+			}
+		case reflect.Float32:
+			valPtr := f.Addr().Interface().(*float32)
+			sl := NewSlider(&itemData{Label: label, Size: point{X: 160, Y: 24}, MinValue: 0, MaxValue: 32, FontSize: 8})
+			sl.Value = *valPtr
+			sl.Action = func() {
+				*valPtr = sl.Value
+				applyThemeToAll()
+			}
+			flow.addItemTo(sl)
+		case reflect.Bool:
+			bptr := f.Addr().Interface().(*bool)
+			cb := NewCheckbox(&itemData{Label: label, Size: point{X: 160, Y: 24}, FontSize: 8})
+			cb.Checked = *bptr
+			cb.Action = func() {
+				*bptr = cb.Checked
+				applyThemeToAll()
+			}
+			flow.addItemTo(cb)
+		}
+	}
+}

--- a/theme_selector.go
+++ b/theme_selector.go
@@ -61,6 +61,7 @@ func makeThemeSelector() *windowData {
 	}
 	dd.HoverIndex = -1
 	mainFlow.addItemTo(dd)
+	themeSelectorDropdown = dd
 
 	if len(layoutNames) > 0 {
 		ldd := NewDropdown(&itemData{Size: point{X: 150, Y: 24}, FontSize: 8})
@@ -95,6 +96,18 @@ func makeThemeSelector() *windowData {
 		SetAccentSaturation(float64(satSlider.Value))
 	}
 	mainFlow.addItemTo(satSlider)
+
+	editBtn := NewButton(&itemData{Text: "Edit Theme", Size: point{X: 80, Y: 24}, FontSize: 8})
+	editBtn.Action = func() {
+		if themeEditor == nil {
+			themeEditor = makeThemeEditor()
+			themeEditor.AddWindow(false)
+		} else {
+			themeEditor.Open = true
+			themeEditor.BringForward()
+		}
+	}
+	mainFlow.addItemTo(editBtn)
 
 	return win
 }

--- a/themes/layout/RoundFlat.json
+++ b/themes/layout/RoundFlat.json
@@ -2,6 +2,8 @@
   "SliderValueGap": 16,
   "DropdownArrowPad": 8,
   "TextPadding": 8,
+  "WindowDim": true,
+  "WindowDimVal": 0.2,
   "Fillet": {
     "Window": 8,
     "Button": 8,

--- a/themes/layout/RoundOutline.json
+++ b/themes/layout/RoundOutline.json
@@ -2,6 +2,8 @@
   "SliderValueGap": 16,
   "DropdownArrowPad": 8,
   "TextPadding": 8,
+  "WindowDim": true,
+  "WindowDimVal": 0.2,
   "Fillet": {
     "Window": 8,
     "Button": 8,

--- a/themes/layout/SquareFlat.json
+++ b/themes/layout/SquareFlat.json
@@ -2,6 +2,8 @@
   "SliderValueGap": 16,
   "DropdownArrowPad": 8,
   "TextPadding": 8,
+  "WindowDim": true,
+  "WindowDimVal": 0.2,
   "Fillet": {
     "Window": 0,
     "Button": 0,

--- a/themes/layout/SquareOutline.json
+++ b/themes/layout/SquareOutline.json
@@ -2,6 +2,8 @@
   "SliderValueGap": 16,
   "DropdownArrowPad": 8,
   "TextPadding": 8,
+  "WindowDim": true,
+  "WindowDimVal": 0.2,
   "Fillet": {
     "Window": 0,
     "Button": 0,


### PR DESCRIPTION
## Summary
- allow layout config to control window dimming
- add `OnColorChange` callback for color wheels
- implement Theme Editor window with dynamic controls and saving
- update Theme Selector to open the editor
- add dimming fields to layout JSON files

## Testing
- `./scripts/setup.sh`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6877318ec9e0832a89fba3d6e9df90f9