### PR TITLE
Improve vector rounding

### DIFF
--- a/render.go
+++ b/render.go
@@ -928,22 +928,26 @@ func drawRoundRect(screen *ebiten.Image, rrect *roundRect) {
 	)
 
 	// Align to pixel boundaries
-       aa := rrect.Fillet > 0
+	aa := rrect.Fillet > 0
 
-       x := float32(math.Floor(float64(rrect.Position.X)))
-       y := float32(math.Floor(float64(rrect.Position.Y)))
-       w := float32(math.Round(float64(rrect.Size.X)))
-       h := float32(math.Round(float64(rrect.Size.Y)))
-       fillet := rrect.Fillet
-       width := float32(math.Round(float64(rrect.Border)))
+	x := float32(math.Floor(float64(rrect.Position.X)))
+	y := float32(math.Floor(float64(rrect.Position.Y)))
+	w := float32(math.Round(float64(rrect.Size.X)))
+	h := float32(math.Round(float64(rrect.Size.Y)))
+	fillet := rrect.Fillet
+	width := float32(math.Round(float64(rrect.Border)))
+	off := float32(0)
+	if !rrect.Filled {
+		off = pixelOffset(width)
+	}
 
 	// When stroking, keep the outline fully inside the rectangle so
 	// sub-images do not clip the bottom and right edges.
-        if !rrect.Filled && width > 0 {
-                inset := width / 2
-                x += inset
-                y += inset
-                w -= width
+	if !rrect.Filled && width > 0 {
+		inset := width / 2
+		x += inset
+		y += inset
+		w -= width
 		h -= width
 		if w < 0 {
 			w = 0
@@ -951,14 +955,14 @@ func drawRoundRect(screen *ebiten.Image, rrect *roundRect) {
 		if h < 0 {
 			h = 0
 		}
-                if fillet > inset {
-                        fillet -= inset
-                } else {
-                        fillet = 0
-                }
-        }
+		if fillet > inset {
+			fillet -= inset
+		} else {
+			fillet = 0
+		}
+	}
 
-       fillet = float32(math.Round(float64(fillet)))
+	fillet = float32(math.Round(float64(fillet)))
 
 	path.MoveTo(x+fillet, y)
 	path.LineTo(x+w-fillet, y)
@@ -994,24 +998,20 @@ func drawRoundRect(screen *ebiten.Image, rrect *roundRect) {
 		vertices, indices = path.AppendVerticesAndIndicesForStroke(vertices[:0], indices[:0], opv)
 	}
 
-       col := dimColor(rrect.Color, dimFactor)
-       for i := range vertices {
-               vertices[i].DstX = float32(math.Floor(float64(vertices[i].DstX)))
-               vertices[i].DstY = float32(math.Floor(float64(vertices[i].DstY)))
-               if !rrect.Filled {
-                       vertices[i].DstX += 0.5
-                       vertices[i].DstY += 0.5
-               }
-               vertices[i].SrcX = 1
-               vertices[i].SrcY = 1
-               vertices[i].ColorR = float32(col.R) / 255
-               vertices[i].ColorG = float32(col.G) / 255
-               vertices[i].ColorB = float32(col.B) / 255
-               vertices[i].ColorA = float32(col.A) / 255
-       }
+	col := dimColor(rrect.Color, dimFactor)
+	for i := range vertices {
+		vertices[i].DstX = float32(math.Floor(float64(vertices[i].DstX))) + off
+		vertices[i].DstY = float32(math.Floor(float64(vertices[i].DstY))) + off
+		vertices[i].SrcX = 1
+		vertices[i].SrcY = 1
+		vertices[i].ColorR = float32(col.R) / 255
+		vertices[i].ColorG = float32(col.G) / 255
+		vertices[i].ColorB = float32(col.B) / 255
+		vertices[i].ColorA = float32(col.A) / 255
+	}
 
-       op := &ebiten.DrawTrianglesOptions{FillRule: ebiten.FillRuleNonZero, AntiAlias: aa}
-       screen.DrawTriangles(vertices, indices, whiteSubImage, op)
+	op := &ebiten.DrawTrianglesOptions{FillRule: ebiten.FillRuleNonZero, AntiAlias: aa}
+	screen.DrawTriangles(vertices, indices, whiteSubImage, op)
 }
 
 func drawTabShape(screen *ebiten.Image, pos point, size point, col Color, fillet float32, slope float32) {
@@ -1027,15 +1027,15 @@ func drawTabShape(screen *ebiten.Image, pos point, size point, col Color, fillet
 	size.X = float32(math.Round(float64(size.X)))
 	size.Y = float32(math.Round(float64(size.Y)))
 
-       origFillet := fillet
+	origFillet := fillet
 
-       if slope <= 0 {
-               slope = size.Y / 4
-       }
-       if fillet <= 0 {
-               fillet = size.Y / 8
-       }
-       fillet = float32(math.Round(float64(fillet)))
+	if slope <= 0 {
+		slope = size.Y / 4
+	}
+	if fillet <= 0 {
+		fillet = size.Y / 8
+	}
+	fillet = float32(math.Round(float64(fillet)))
 
 	path.MoveTo(pos.X, pos.Y+size.Y)
 	path.LineTo(pos.X+slope, pos.Y+size.Y)
@@ -1050,8 +1050,8 @@ func drawTabShape(screen *ebiten.Image, pos point, size point, col Color, fillet
 	vertices, indices = path.AppendVerticesAndIndicesForFilling(vertices[:0], indices[:0])
 	c := dimColor(col, dimFactor)
 	for i := range vertices {
-		vertices[i].DstX = float32(math.Floor(float64(vertices[i].DstX))) + 0.5
-		vertices[i].DstY = float32(math.Floor(float64(vertices[i].DstY))) + 0.5
+		vertices[i].DstX = float32(math.Floor(float64(vertices[i].DstX)))
+		vertices[i].DstY = float32(math.Floor(float64(vertices[i].DstY)))
 		vertices[i].SrcX = 1
 		vertices[i].SrcY = 1
 		vertices[i].ColorR = float32(c.R) / 255
@@ -1060,10 +1060,10 @@ func drawTabShape(screen *ebiten.Image, pos point, size point, col Color, fillet
 		vertices[i].ColorA = float32(c.A) / 255
 	}
 
-       op := &ebiten.DrawTrianglesOptions{}
-       op.FillRule = ebiten.FillRuleNonZero
-       op.AntiAlias = origFillet > 0
-       screen.DrawTriangles(vertices, indices, whiteSubImage, op)
+	op := &ebiten.DrawTrianglesOptions{}
+	op.FillRule = ebiten.FillRuleNonZero
+	op.AntiAlias = origFillet > 0
+	screen.DrawTriangles(vertices, indices, whiteSubImage, op)
 }
 
 func strokeTabShape(screen *ebiten.Image, pos point, size point, col Color, fillet float32, slope float32, border float32) {
@@ -1073,22 +1073,23 @@ func strokeTabShape(screen *ebiten.Image, pos point, size point, col Color, fill
 		indices  []uint16
 	)
 
-       origFillet := fillet
+	origFillet := fillet
 
-       // Align to pixel boundaries
-       pos.X = float32(math.Floor(float64(pos.X)))
-       pos.Y = float32(math.Floor(float64(pos.Y)))
-       size.X = float32(math.Round(float64(size.X)))
-       size.Y = float32(math.Round(float64(size.Y)))
-       border = float32(math.Round(float64(border)))
+	// Align to pixel boundaries
+	pos.X = float32(math.Floor(float64(pos.X)))
+	pos.Y = float32(math.Floor(float64(pos.Y)))
+	size.X = float32(math.Round(float64(size.X)))
+	size.Y = float32(math.Round(float64(size.Y)))
+	border = float32(math.Round(float64(border)))
+	off := pixelOffset(border)
 
-       if slope <= 0 {
-               slope = size.Y / 4
-       }
-       if fillet <= 0 {
-               fillet = size.Y / 8
-       }
-       fillet = float32(math.Round(float64(fillet)))
+	if slope <= 0 {
+		slope = size.Y / 4
+	}
+	if fillet <= 0 {
+		fillet = size.Y / 8
+	}
+	fillet = float32(math.Round(float64(fillet)))
 
 	path.MoveTo(pos.X, pos.Y+size.Y)
 	path.LineTo(pos.X+slope, pos.Y+size.Y)
@@ -1104,8 +1105,8 @@ func strokeTabShape(screen *ebiten.Image, pos point, size point, col Color, fill
 	vertices, indices = path.AppendVerticesAndIndicesForStroke(vertices[:0], indices[:0], opv)
 	c := dimColor(col, dimFactor)
 	for i := range vertices {
-		vertices[i].DstX = float32(math.Floor(float64(vertices[i].DstX))) + 0.5
-		vertices[i].DstY = float32(math.Floor(float64(vertices[i].DstY))) + 0.5
+		vertices[i].DstX = float32(math.Floor(float64(vertices[i].DstX))) + off
+		vertices[i].DstY = float32(math.Floor(float64(vertices[i].DstY))) + off
 		vertices[i].SrcX = 1
 		vertices[i].SrcY = 1
 		vertices[i].ColorR = float32(c.R) / 255
@@ -1114,8 +1115,8 @@ func strokeTabShape(screen *ebiten.Image, pos point, size point, col Color, fill
 		vertices[i].ColorA = float32(c.A) / 255
 	}
 
-       op := &ebiten.DrawTrianglesOptions{FillRule: ebiten.FillRuleNonZero, AntiAlias: origFillet > 0}
-       screen.DrawTriangles(vertices, indices, whiteSubImage, op)
+	op := &ebiten.DrawTrianglesOptions{FillRule: ebiten.FillRuleNonZero, AntiAlias: origFillet > 0}
+	screen.DrawTriangles(vertices, indices, whiteSubImage, op)
 }
 
 func drawTriangle(screen *ebiten.Image, pos point, size float32, col Color) {
@@ -1138,8 +1139,8 @@ func drawTriangle(screen *ebiten.Image, pos point, size float32, col Color) {
 	vertices, indices = path.AppendVerticesAndIndicesForFilling(vertices[:0], indices[:0])
 	c := dimColor(col, dimFactor)
 	for i := range vertices {
-		vertices[i].DstX = float32(math.Floor(float64(vertices[i].DstX))) + 0.5
-		vertices[i].DstY = float32(math.Floor(float64(vertices[i].DstY))) + 0.5
+		vertices[i].DstX = float32(math.Floor(float64(vertices[i].DstX)))
+		vertices[i].DstY = float32(math.Floor(float64(vertices[i].DstY)))
 		vertices[i].SrcX = 1
 		vertices[i].SrcY = 1
 		vertices[i].ColorR = float32(c.R) / 255

--- a/util.go
+++ b/util.go
@@ -9,6 +9,11 @@ import (
 	"github.com/hajimehoshi/ebiten/v2/vector"
 )
 
+var (
+	strokeLineFn = vector.StrokeLine
+	strokeRectFn = vector.StrokeRect
+)
+
 func (win *windowData) getWinRect() rect {
 	winPos := win.getPosition()
 	return rect{
@@ -540,22 +545,31 @@ func (win *windowData) resizeFlows() {
 	}
 }
 
+func pixelOffset(width float32) float32 {
+	if int(math.Round(float64(width)))%2 == 0 {
+		return 0
+	}
+	return 0.5
+}
+
 func strokeLine(dst *ebiten.Image, x0, y0, x1, y1, width float32, col color.Color, aa bool) {
-	x0 = float32(math.Floor(float64(x0))) + 0.5
-	y0 = float32(math.Floor(float64(y0))) + 0.5
-	x1 = float32(math.Floor(float64(x1))) + 0.5
-	y1 = float32(math.Floor(float64(y1))) + 0.5
 	width = float32(math.Round(float64(width)))
-	vector.StrokeLine(dst, x0, y0, x1, y1, width, col, aa)
+	off := pixelOffset(width)
+	x0 = float32(math.Floor(float64(x0))) + off
+	y0 = float32(math.Floor(float64(y0))) + off
+	x1 = float32(math.Floor(float64(x1))) + off
+	y1 = float32(math.Floor(float64(y1))) + off
+	strokeLineFn(dst, x0, y0, x1, y1, width, col, aa)
 }
 
 func strokeRect(dst *ebiten.Image, x, y, w, h, width float32, col color.Color, aa bool) {
-	x = float32(math.Floor(float64(x))) + 0.5
-	y = float32(math.Floor(float64(y))) + 0.5
+	width = float32(math.Round(float64(width)))
+	off := pixelOffset(width)
+	x = float32(math.Floor(float64(x))) + off
+	y = float32(math.Floor(float64(y))) + off
 	w = float32(math.Round(float64(w)))
 	h = float32(math.Round(float64(h)))
-	width = float32(math.Round(float64(width)))
-	vector.StrokeRect(dst, x, y, w, h, width, col, aa)
+	strokeRectFn(dst, x, y, w, h, width, col, aa)
 }
 
 func drawFilledRect(dst *ebiten.Image, x, y, w, h float32, col color.Color, aa bool) {

--- a/util_test.go
+++ b/util_test.go
@@ -1,6 +1,12 @@
 package main
 
-import "testing"
+import (
+	"image/color"
+	"testing"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/vector"
+)
 
 func TestWithinRange(t *testing.T) {
 	if !withinRange(1, 1.1, 0.2) {
@@ -163,5 +169,55 @@ func TestFlowContentBounds(t *testing.T) {
 	wantH := point{X: 25, Y: 30}
 	if got := hflow.contentBounds(); got != wantH {
 		t.Errorf("horizontal bounds got %+v want %+v", got, wantH)
+	}
+}
+
+func TestPixelOffset(t *testing.T) {
+	if off := pixelOffset(1); off != 0.5 {
+		t.Errorf("odd width offset got %v", off)
+	}
+	if off := pixelOffset(2); off != 0 {
+		t.Errorf("even width offset got %v", off)
+	}
+	if off := pixelOffset(3); off != 0.5 {
+		t.Errorf("odd width offset got %v", off)
+	}
+}
+
+func TestStrokeLineParams(t *testing.T) {
+	var x0, y0, w float32
+	strokeLineFn = func(dst *ebiten.Image, ax0, ay0, ax1, ay1, width float32, col color.Color, aa bool) {
+		x0, y0, w = ax0, ay0, width
+	}
+	defer func() { strokeLineFn = vector.StrokeLine }()
+
+	img := ebiten.NewImage(10, 10)
+	strokeLine(img, 1.3, 2.1, 5.8, 2.1, 1, color.White, false)
+	if x0 != 1.5 || y0 != 2.5 || w != 1 {
+		t.Errorf("odd width params %v %v %v", x0, y0, w)
+	}
+
+	strokeLine(img, 3.7, 4.2, 9.1, 4.2, 2, color.White, false)
+	if x0 != 3 || y0 != 4 || w != 2 {
+		t.Errorf("even width params %v %v %v", x0, y0, w)
+	}
+}
+
+func TestStrokeRectParams(t *testing.T) {
+	var x, y, bw float32
+	strokeRectFn = func(dst *ebiten.Image, ax, ay, aw, ah, width float32, col color.Color, aa bool) {
+		x, y, bw = ax, ay, width
+	}
+	defer func() { strokeRectFn = vector.StrokeRect }()
+
+	img := ebiten.NewImage(10, 10)
+	strokeRect(img, 1.3, 2.2, 5.6, 4.4, 3, color.White, false)
+	if x != 1.5 || y != 2.5 || bw != 3 {
+		t.Errorf("rect odd width params %v %v %v", x, y, bw)
+	}
+
+	strokeRect(img, 6.7, 1.4, 3.3, 2.8, 2, color.White, false)
+	if x != 6 || y != 1 || bw != 2 {
+		t.Errorf("rect even width params %v %v %v", x, y, bw)
 	}
 }


### PR DESCRIPTION
## Summary
- snap stroke coordinates to the pixel grid
- avoid half-pixel offset on even stroke widths
- expose stroke functions to tests
- add unit tests verifying rounding

## Testing
- `go vet ./...`
- `go build ./...`
- `EBITENGINE_HEADLESS=1 go test -c ./...`

------
https://chatgpt.com/codex/tasks/task_e_68781566827c832aba36e3af4c56b488