### PR TITLE
Fix rendering misalignment by rounding positions

### DIFF
--- a/render.go
+++ b/render.go
@@ -936,8 +936,8 @@ func drawRoundRect(screen *ebiten.Image, rrect *roundRect) {
 		off = pixelOffset(width)
 	}
 
-	x := float32(math.Floor(float64(rrect.Position.X))) + off
-	y := float32(math.Floor(float64(rrect.Position.Y))) + off
+	x := float32(math.Round(float64(rrect.Position.X))) + off
+	y := float32(math.Round(float64(rrect.Position.Y))) + off
 	w := float32(math.Round(float64(rrect.Size.X)))
 	h := float32(math.Round(float64(rrect.Size.Y)))
 	fillet := rrect.Fillet
@@ -1021,8 +1021,8 @@ func drawTabShape(screen *ebiten.Image, pos point, size point, col Color, fillet
 	)
 
 	// Align to pixel boundaries to avoid artifacts
-	pos.X = float32(math.Floor(float64(pos.X)))
-	pos.Y = float32(math.Floor(float64(pos.Y)))
+	pos.X = float32(math.Round(float64(pos.X)))
+	pos.Y = float32(math.Round(float64(pos.Y)))
 	size.X = float32(math.Round(float64(size.X)))
 	size.Y = float32(math.Round(float64(size.Y)))
 
@@ -1075,8 +1075,8 @@ func strokeTabShape(screen *ebiten.Image, pos point, size point, col Color, fill
 	// Align to pixel boundaries
 	border = float32(math.Round(float64(border)))
 	off := pixelOffset(border)
-	pos.X = float32(math.Floor(float64(pos.X))) + off
-	pos.Y = float32(math.Floor(float64(pos.Y))) + off
+	pos.X = float32(math.Round(float64(pos.X))) + off
+	pos.Y = float32(math.Round(float64(pos.Y))) + off
 	size.X = float32(math.Round(float64(size.X)))
 	size.Y = float32(math.Round(float64(size.Y)))
 
@@ -1122,8 +1122,8 @@ func drawTriangle(screen *ebiten.Image, pos point, size float32, col Color) {
 	)
 
 	// Quantize to pixel boundaries
-	pos.X = float32(math.Floor(float64(pos.X)))
-	pos.Y = float32(math.Floor(float64(pos.Y)))
+	pos.X = float32(math.Round(float64(pos.X)))
+	pos.Y = float32(math.Round(float64(pos.Y)))
 	size = float32(math.Round(float64(size)))
 
 	path.MoveTo(pos.X, pos.Y)

--- a/util.go
+++ b/util.go
@@ -555,26 +555,26 @@ func pixelOffset(width float32) float32 {
 func strokeLine(dst *ebiten.Image, x0, y0, x1, y1, width float32, col color.Color, aa bool) {
 	width = float32(math.Round(float64(width)))
 	off := pixelOffset(width)
-	x0 = float32(math.Floor(float64(x0))) + off
-	y0 = float32(math.Floor(float64(y0))) + off
-	x1 = float32(math.Floor(float64(x1))) + off
-	y1 = float32(math.Floor(float64(y1))) + off
+	x0 = float32(math.Round(float64(x0))) + off
+	y0 = float32(math.Round(float64(y0))) + off
+	x1 = float32(math.Round(float64(x1))) + off
+	y1 = float32(math.Round(float64(y1))) + off
 	strokeLineFn(dst, x0, y0, x1, y1, width, col, aa)
 }
 
 func strokeRect(dst *ebiten.Image, x, y, w, h, width float32, col color.Color, aa bool) {
 	width = float32(math.Round(float64(width)))
 	off := pixelOffset(width)
-	x = float32(math.Floor(float64(x))) + off
-	y = float32(math.Floor(float64(y))) + off
+	x = float32(math.Round(float64(x))) + off
+	y = float32(math.Round(float64(y))) + off
 	w = float32(math.Round(float64(w)))
 	h = float32(math.Round(float64(h)))
 	strokeRectFn(dst, x, y, w, h, width, col, aa)
 }
 
 func drawFilledRect(dst *ebiten.Image, x, y, w, h float32, col color.Color, aa bool) {
-	x = float32(math.Floor(float64(x)))
-	y = float32(math.Floor(float64(y)))
+	x = float32(math.Round(float64(x)))
+	y = float32(math.Round(float64(y)))
 	w = float32(math.Round(float64(w)))
 	h = float32(math.Round(float64(h)))
 	vector.DrawFilledRect(dst, x, y, w, h, col, aa)


### PR DESCRIPTION
## Summary
- quantize drawing coordinates using `math.Round`

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68785e84ac2c832ab25f56f7c4cca820