### PR TITLE
Fix rounded rect symmetry

### DIFF
--- a/render.go
+++ b/render.go
@@ -938,8 +938,10 @@ func drawRoundRect(screen *ebiten.Image, rrect *roundRect) {
 
 	x := float32(math.Round(float64(rrect.Position.X))) + off
 	y := float32(math.Round(float64(rrect.Position.Y))) + off
-	w := float32(math.Round(float64(rrect.Size.X)))
-	h := float32(math.Round(float64(rrect.Size.Y)))
+	x1 := float32(math.Round(float64(rrect.Position.X+rrect.Size.X))) + off
+	y1 := float32(math.Round(float64(rrect.Position.Y+rrect.Size.Y))) + off
+	w := x1 - x
+	h := y1 - y
 	fillet := rrect.Fillet
 
 	// When stroking, keep the outline fully inside the rectangle so

--- a/util_test.go
+++ b/util_test.go
@@ -216,8 +216,10 @@ func roundRectKeyPoints(rrect *roundRect) []point {
 	}
 	x := float32(math.Round(float64(rrect.Position.X))) + off
 	y := float32(math.Round(float64(rrect.Position.Y))) + off
-	w := float32(math.Round(float64(rrect.Size.X)))
-	h := float32(math.Round(float64(rrect.Size.Y)))
+	x1 := float32(math.Round(float64(rrect.Position.X+rrect.Size.X))) + off
+	y1 := float32(math.Round(float64(rrect.Position.Y+rrect.Size.Y))) + off
+	w := x1 - x
+	h := y1 - y
 	fillet := rrect.Fillet
 	if !rrect.Filled && width > 0 {
 		inset := width / 2
@@ -258,7 +260,9 @@ func TestRoundRectSymmetry(t *testing.T) {
 		Filled:   true,
 	}
 	pts := roundRectKeyPoints(r)
-	mid := float32(math.Round(float64(r.Position.X))) + float32(math.Round(float64(r.Size.X)))/2
+	x := float32(math.Round(float64(r.Position.X)))
+	x1 := float32(math.Round(float64(r.Position.X + r.Size.X)))
+	mid := x + (x1-x)/2
 	checkMirror := func(a, b point) bool {
 		ax := a.X - mid
 		bx := b.X - mid


### PR DESCRIPTION
## Summary
- ensure rounding uses endpoints for consistent size
- adjust roundRectKeyPoints test helpers for new approach

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687866a458a8832a9149c45d0048dd99