### PR TITLE
Fix scroll thumb rounding

### DIFF
--- a/render.go
+++ b/render.go
@@ -965,6 +965,12 @@ func drawRoundRect(screen *ebiten.Image, rrect *roundRect) {
 		}
 	}
 
+	if fillet*2 > w {
+		fillet = w / 2
+	}
+	if fillet*2 > h {
+		fillet = h / 2
+	}
 	fillet = float32(math.Round(float64(fillet)))
 
 	path.MoveTo(x+fillet, y)

--- a/util_test.go
+++ b/util_test.go
@@ -239,6 +239,12 @@ func roundRectKeyPoints(rrect *roundRect) []point {
 			fillet = 0
 		}
 	}
+	if fillet*2 > w {
+		fillet = w / 2
+	}
+	if fillet*2 > h {
+		fillet = h / 2
+	}
 	fillet = float32(math.Round(float64(fillet)))
 	return []point{
 		{X: x + fillet, Y: y},
@@ -273,6 +279,19 @@ func TestRoundRectSymmetry(t *testing.T) {
 		if !checkMirror(pts[p[0]], pts[p[1]]) {
 			t.Errorf("points %d and %d not symmetrical: %+v vs %+v", p[0], p[1], pts[p[0]], pts[p[1]])
 		}
+	}
+}
+
+func TestRoundRectFilletClamp(t *testing.T) {
+	r := &roundRect{
+		Size:     point{X: 4, Y: 10},
+		Position: point{X: 1, Y: 1},
+		Fillet:   8,
+		Filled:   true,
+	}
+	pts := roundRectKeyPoints(r)
+	if pts[0].X != 3 || pts[1].X != 3 {
+		t.Errorf("fillet clamp failed: %+v", pts)
 	}
 }
 


### PR DESCRIPTION
## Summary
- clamp fillet values in `drawRoundRect` so corners stay rounded when sliders are thin
- test round rect clamp behavior

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...` *(fails: glfw: The GLFW library is not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_687888acab28832aa66e3ababfa67ae9