### PR TITLE
Improve color wheel appearance

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -177,6 +177,7 @@ var defaultColorWheel = &itemData{
 	Position:      point{X: 4, Y: 4},
 	Margin:        4,
 	OnColorChange: nil,
+	SelectedColor: NewColor(255, 0, 0, 255),
 }
 
 var defaultTab = &itemData{

--- a/input.go
+++ b/input.go
@@ -339,6 +339,7 @@ func (item *itemData) clickItem(mpos point, click bool) bool {
 		item.Clicked = time.Now()
 		if item.ItemType == ITEM_COLORWHEEL {
 			if col, ok := item.colorAt(mpos); ok {
+				item.SelectedColor = col
 				if item.OnColorChange != nil {
 					item.OnColorChange(col)
 				} else {
@@ -391,6 +392,7 @@ func (item *itemData) clickItem(mpos point, click bool) bool {
 		item.Hovered = true
 		if item.ItemType == ITEM_COLORWHEEL && ebiten.IsMouseButtonPressed(ebiten.MouseButton0) {
 			if col, ok := item.colorAt(mpos); ok {
+				item.SelectedColor = col
 				if item.OnColorChange != nil {
 					item.OnColorChange(col)
 				} else {

--- a/render.go
+++ b/render.go
@@ -817,6 +817,24 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 		op.GeoM.Translate(float64(offset.X), float64(offset.Y))
 		subImg.DrawImage(item.Image, op)
 
+		h, _, v, _ := rgbaToHSVA(color.RGBA(item.SelectedColor))
+		radius := maxSize.X / 2
+		cx := offset.X + radius
+		cy := offset.Y + radius
+		px := cx + float32(math.Cos(h*math.Pi/180))*radius*float32(v)
+		py := cy + float32(math.Sin(h*math.Pi/180))*radius*float32(v)
+		vector.DrawFilledCircle(subImg, px, py, 4*uiScale, color.Black, true)
+		vector.DrawFilledCircle(subImg, px, py, 2*uiScale, color.White, true)
+
+		sw := maxSize.X / 5
+		if sw < 10*uiScale {
+			sw = 10 * uiScale
+		}
+		sx := offset.X + maxSize.X - sw - 4*uiScale
+		sy := offset.Y + maxSize.Y - sw - 4*uiScale
+		drawFilledRect(subImg, sx, sy, sw, sw, color.RGBA(item.SelectedColor), true)
+		strokeRect(subImg, sx, sy, sw, sw, 1, color.Black, true)
+
 	} else if item.ItemType == ITEM_TEXT {
 
 		textSize := (item.FontSize * uiScale) + 2

--- a/struct.go
+++ b/struct.go
@@ -111,6 +111,7 @@ type itemData struct {
 
 	Action        func()
 	OnColorChange func(Color)
+	SelectedColor Color
 	Contents      []*itemData
 
 	// Tabs allows a flow to contain multiple tabbed flows. Only the

--- a/window.go
+++ b/window.go
@@ -199,6 +199,9 @@ func NewColorWheel(item *itemData) *itemData {
 	if item != nil {
 		mergeData(&newItem, item)
 	}
+	if ac, ok := namedColors["accent"]; ok && newItem.SelectedColor == (Color{}) {
+		newItem.SelectedColor = ac
+	}
 	return &newItem
 }
 


### PR DESCRIPTION
## Summary
- add `SelectedColor` to track color wheel selection
- store selected color during interactions
- create accent-based default for color wheels
- draw selection indicator and swatch in color wheel
- apply antialiasing when generating color wheel image

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68788cbbea3c832a92715929f56d0af5