### PR TITLE
Equalize slider text width

### DIFF
--- a/render.go
+++ b/render.go
@@ -717,7 +717,11 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 		valueText := fmt.Sprintf("%.2f", item.Value)
 		maxLabel := fmt.Sprintf("%.2f", item.MaxValue)
 		if item.IntOnly {
-			valueText = fmt.Sprintf("%d", int(item.Value))
+			// Pad the integer value so the value field width matches
+			// the float slider which reserves space for two decimal
+			// places.
+			width := len(maxLabel)
+			valueText = fmt.Sprintf("%*d", width, int(item.Value))
 		}
 
 		textSize := (item.FontSize * uiScale) + 2


### PR DESCRIPTION
## Summary
- pad integer slider's value display so it uses the same width as the float slider

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6878921bf920832abe6a87800e6b66a2