### PR TITLE
Fix integer slider track width

### DIFF
--- a/input.go
+++ b/input.go
@@ -465,6 +465,13 @@ func (item *itemData) setSliderValue(mpos point) {
 	// Determine the width of the slider track accounting for the
 	// displayed value text to the right of the knob.
 	maxLabel := fmt.Sprintf("%.2f", item.MaxValue)
+	if item.IntOnly {
+		// Ensure the measured label width matches the padded integer
+		// value used during rendering so the slider track length
+		// calculation is consistent between float and integer sliders.
+		width := len(maxLabel)
+		maxLabel = fmt.Sprintf("%*d", width, int(item.MaxValue))
+	}
 	textSize := (item.FontSize * uiScale) + 2
 	face := &text.GoTextFace{Source: mplusFaceSource, Size: float64(textSize)}
 	maxW, _ := text.Measure(maxLabel, face, 0)

--- a/render.go
+++ b/render.go
@@ -719,9 +719,12 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 		if item.IntOnly {
 			// Pad the integer value so the value field width matches
 			// the float slider which reserves space for two decimal
-			// places.
+			// places. Apply the same padding to the max label so the
+			// reserved width for value text is identical between
+			// float and integer sliders.
 			width := len(maxLabel)
 			valueText = fmt.Sprintf("%*d", width, int(item.Value))
+			maxLabel = fmt.Sprintf("%*d", width, int(item.MaxValue))
 		}
 
 		textSize := (item.FontSize * uiScale) + 2


### PR DESCRIPTION
## Summary
- match slider width calculations for integer and float types
- adjust value measurement for consistent track length

## Testing
- `./scripts/setup.sh`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6878945341dc832a815162a23f60955d