### PR TITLE
Fix slider track width mismatch

### DIFF
--- a/input.go
+++ b/input.go
@@ -465,13 +465,6 @@ func (item *itemData) setSliderValue(mpos point) {
 	// Determine the width of the slider track accounting for the
 	// displayed value text to the right of the knob.
 	maxLabel := fmt.Sprintf("%.2f", item.MaxValue)
-	if item.IntOnly {
-		// Ensure the measured label width matches the padded integer
-		// value used during rendering so the slider track length
-		// calculation is consistent between float and integer sliders.
-		width := len(maxLabel)
-		maxLabel = fmt.Sprintf("%*d", width, int(item.MaxValue))
-	}
 	textSize := (item.FontSize * uiScale) + 2
 	face := &text.GoTextFace{Source: mplusFaceSource, Size: float64(textSize)}
 	maxW, _ := text.Measure(maxLabel, face, 0)

--- a/render.go
+++ b/render.go
@@ -719,12 +719,9 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 		if item.IntOnly {
 			// Pad the integer value so the value field width matches
 			// the float slider which reserves space for two decimal
-			// places. Apply the same padding to the max label so the
-			// reserved width for value text is identical between
-			// float and integer sliders.
+			// places.
 			width := len(maxLabel)
 			valueText = fmt.Sprintf("%*d", width, int(item.Value))
-			maxLabel = fmt.Sprintf("%*d", width, int(item.MaxValue))
 		}
 
 		textSize := (item.FontSize * uiScale) + 2

--- a/util_test.go
+++ b/util_test.go
@@ -141,6 +141,41 @@ func TestSetSliderValue(t *testing.T) {
 	}
 }
 
+func sliderTrackWidth(item *itemData) float32 {
+	maxSize := item.GetSize()
+	maxLabel := fmt.Sprintf("%.2f", item.MaxValue)
+	textSize := (item.FontSize * uiScale) + 2
+	face := &text.GoTextFace{Source: mplusFaceSource, Size: float64(textSize)}
+	maxW, _ := text.Measure(maxLabel, face, 0)
+	knobW := item.AuxSize.X * uiScale
+	width := maxSize.X - knobW - currentLayout.SliderValueGap - float32(maxW)
+	if width < 0 {
+		width = 0
+	}
+	return width
+}
+
+func TestSliderTrackLengthMatch(t *testing.T) {
+	if mplusFaceSource == nil {
+		s, err := text.NewGoTextFaceSource(bytes.NewReader(notoTTF))
+		if err != nil {
+			t.Fatalf("font init: %v", err)
+		}
+		mplusFaceSource = s
+	}
+
+	base := &itemData{Size: point{X: 180, Y: 24}, AuxSize: point{X: 8, Y: 16}, FontSize: 12, MaxValue: 100}
+	floatTrack := sliderTrackWidth(base)
+
+	intSlider := *base
+	intSlider.IntOnly = true
+	intTrack := sliderTrackWidth(&intSlider)
+
+	if math.Abs(float64(floatTrack-intTrack)) > 0.001 {
+		t.Errorf("track width mismatch: float %v int %v", floatTrack, intTrack)
+	}
+}
+
 func TestMarkOpen(t *testing.T) {
 	win1 := &windowData{Title: "win1", Open: true}
 	win2 := &windowData{Title: "win2", Open: false}


### PR DESCRIPTION
## Summary
- add regression test ensuring int and float slider tracks are same length
- fix slider drawing and input to use common label measurement

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687895bc2950832aa5ab098100939587