### PR TITLE
Fix slider track width consistency

### DIFF
--- a/const.go
+++ b/const.go
@@ -12,6 +12,11 @@ const (
 	CornerSize = 14
 	Tol        = 2
 
+	// sliderMaxLabel defines the formatted text used to measure the value
+	// field of sliders. Using a constant ensures int and float sliders have
+	// identical track lengths regardless of their numeric ranges.
+	sliderMaxLabel = "100.00"
+
 	// InactiveDim controls the opacity of the black overlay drawn over
 	// inactive windows. Values range from 0.0 (no dimming) to 1.0 (fully
 	// black)

--- a/input.go
+++ b/input.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"math"
 	"time"
 
@@ -464,7 +463,9 @@ func subUncheckRadio(list []*itemData, group string, except *itemData) {
 func (item *itemData) setSliderValue(mpos point) {
 	// Determine the width of the slider track accounting for the
 	// displayed value text to the right of the knob.
-	maxLabel := fmt.Sprintf("%.2f", item.MaxValue)
+	// Measure against a consistent label width so sliders with
+	// different ranges have identical track lengths.
+	maxLabel := sliderMaxLabel
 	textSize := (item.FontSize * uiScale) + 2
 	face := &text.GoTextFace{Source: mplusFaceSource, Size: float64(textSize)}
 	maxW, _ := text.Measure(maxLabel, face, 0)

--- a/render.go
+++ b/render.go
@@ -714,8 +714,10 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 
 		// Prepare value text and measure the largest value label so the
 		// slider track remains consistent length
+		// Use a constant max label width so all sliders have the
+		// same track length regardless of their numeric range.
 		valueText := fmt.Sprintf("%.2f", item.Value)
-		maxLabel := fmt.Sprintf("%.2f", item.MaxValue)
+		maxLabel := sliderMaxLabel
 		if item.IntOnly {
 			// Pad the integer value so the value field width matches
 			// the float slider which reserves space for two decimal

--- a/util_test.go
+++ b/util_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"fmt"
 	"image/color"
 	"math"
 	"testing"
@@ -116,7 +115,7 @@ func TestSetSliderValue(t *testing.T) {
 	item := &itemData{MinValue: 0, MaxValue: 10, AuxSize: point{X: 8}, AuxSpace: 4}
 	item.DrawRect = rect{X0: 0, Y0: 0, X1: 100, Y1: 20}
 	item.setSliderValue(point{X: 42})
-	maxLabel := fmt.Sprintf("%.2f", item.MaxValue)
+	maxLabel := sliderMaxLabel
 	textSize := (item.FontSize * uiScale) + 2
 	face := &text.GoTextFace{Source: mplusFaceSource, Size: float64(textSize)}
 	maxW, _ := text.Measure(maxLabel, face, 0)
@@ -143,7 +142,9 @@ func TestSetSliderValue(t *testing.T) {
 
 func sliderTrackWidth(item *itemData) float32 {
 	maxSize := item.GetSize()
-	maxLabel := fmt.Sprintf("%.2f", item.MaxValue)
+	// Use a fixed label width when measuring so sliders with
+	// different ranges have equal track lengths.
+	maxLabel := sliderMaxLabel
 	textSize := (item.FontSize * uiScale) + 2
 	face := &text.GoTextFace{Source: mplusFaceSource, Size: float64(textSize)}
 	maxW, _ := text.Measure(maxLabel, face, 0)
@@ -168,6 +169,7 @@ func TestSliderTrackLengthMatch(t *testing.T) {
 	floatTrack := sliderTrackWidth(base)
 
 	intSlider := *base
+	intSlider.MaxValue = 10
 	intSlider.IntOnly = true
 	intTrack := sliderTrackWidth(&intSlider)
 


### PR DESCRIPTION
## Summary
- use a constant label when measuring slider track width
- make sliders with different ranges share the same track length
- update unit tests for consistent slider sizing

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68789c3fc544832a9ca2c2d2ba9ad828