### PR TITLE
Add per-widget outline colors

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -41,10 +41,11 @@ var defaultButton = &itemData{
 	Border:    0,
 	BorderPad: 4,
 
-	TextColor:  NewColor(255, 255, 255, 255),
-	Color:      NewColor(48, 48, 48, 255),
-	HoverColor: NewColor(96, 96, 96, 255),
-	ClickColor: NewColor(0, 160, 160, 255),
+	TextColor:    NewColor(255, 255, 255, 255),
+	Color:        NewColor(48, 48, 48, 255),
+	HoverColor:   NewColor(96, 96, 96, 255),
+	ClickColor:   NewColor(0, 160, 160, 255),
+	OutlineColor: NewColor(48, 48, 48, 255),
 }
 
 var defaultText = &itemData{
@@ -76,10 +77,11 @@ var defaultCheckbox = &itemData{
 	Border:    0,
 	BorderPad: 4,
 
-	TextColor:  NewColor(255, 255, 255, 255),
-	Color:      NewColor(48, 48, 48, 255),
-	HoverColor: NewColor(96, 96, 96, 255),
-	ClickColor: NewColor(0, 160, 160, 255),
+	TextColor:    NewColor(255, 255, 255, 255),
+	Color:        NewColor(48, 48, 48, 255),
+	HoverColor:   NewColor(96, 96, 96, 255),
+	ClickColor:   NewColor(0, 160, 160, 255),
+	OutlineColor: NewColor(0, 160, 160, 255),
 }
 
 var defaultInput = &itemData{
@@ -96,10 +98,11 @@ var defaultInput = &itemData{
 	Border:    0,
 	BorderPad: 2,
 
-	TextColor:  NewColor(255, 255, 255, 255),
-	Color:      NewColor(48, 48, 48, 255),
-	HoverColor: NewColor(96, 96, 96, 255),
-	ClickColor: NewColor(0, 160, 160, 255),
+	TextColor:    NewColor(255, 255, 255, 255),
+	Color:        NewColor(48, 48, 48, 255),
+	HoverColor:   NewColor(96, 96, 96, 255),
+	ClickColor:   NewColor(0, 160, 160, 255),
+	OutlineColor: NewColor(0, 160, 160, 255),
 }
 
 var defaultRadio = &itemData{
@@ -119,10 +122,11 @@ var defaultRadio = &itemData{
 	Border:    0,
 	BorderPad: 4,
 
-	TextColor:  NewColor(255, 255, 255, 255),
-	Color:      NewColor(48, 48, 48, 255),
-	HoverColor: NewColor(96, 96, 96, 255),
-	ClickColor: NewColor(0, 160, 160, 255),
+	TextColor:    NewColor(255, 255, 255, 255),
+	Color:        NewColor(48, 48, 48, 255),
+	HoverColor:   NewColor(96, 96, 96, 255),
+	ClickColor:   NewColor(0, 160, 160, 255),
+	OutlineColor: NewColor(0, 160, 160, 255),
 }
 
 var defaultSlider = &itemData{
@@ -145,10 +149,11 @@ var defaultSlider = &itemData{
 	Border:    0,
 	BorderPad: 2,
 
-	TextColor:  NewColor(255, 255, 255, 255),
-	Color:      NewColor(48, 48, 48, 255),
-	HoverColor: NewColor(96, 96, 96, 255),
-	ClickColor: NewColor(0, 160, 160, 255),
+	TextColor:    NewColor(255, 255, 255, 255),
+	Color:        NewColor(48, 48, 48, 255),
+	HoverColor:   NewColor(96, 96, 96, 255),
+	ClickColor:   NewColor(0, 160, 160, 255),
+	OutlineColor: NewColor(0, 160, 160, 255),
 }
 
 var defaultDropdown = &itemData{
@@ -164,11 +169,12 @@ var defaultDropdown = &itemData{
 	Border:    0,
 	BorderPad: 2,
 
-	TextColor:  NewColor(255, 255, 255, 255),
-	Color:      NewColor(48, 48, 48, 255),
-	HoverColor: NewColor(96, 96, 96, 255),
-	ClickColor: NewColor(0, 160, 160, 255),
-	MaxVisible: 5,
+	TextColor:    NewColor(255, 255, 255, 255),
+	Color:        NewColor(48, 48, 48, 255),
+	HoverColor:   NewColor(96, 96, 96, 255),
+	ClickColor:   NewColor(0, 160, 160, 255),
+	OutlineColor: NewColor(0, 160, 160, 255),
+	MaxVisible:   5,
 }
 
 var defaultColorWheel = &itemData{
@@ -192,6 +198,7 @@ var defaultTab = &itemData{
 	Color:         NewColor(64, 64, 64, 255),
 	HoverColor:    NewColor(96, 96, 96, 255),
 	ClickColor:    NewColor(0, 160, 160, 255),
+	OutlineColor:  NewColor(0, 160, 160, 255),
 }
 
 // base copies preserve the initial defaults so that LoadTheme can reset

--- a/render.go
+++ b/render.go
@@ -337,7 +337,7 @@ func (item *itemData) drawFlows(parent *itemData, offset point, clip rect, scree
 				strokeTabShape(subImg,
 					point{X: x, Y: offset.Y},
 					point{X: w, Y: tabHeight},
-					dimColor(item.Color, dimFactor),
+					dimColor(item.OutlineColor, dimFactor),
 					item.Fillet*uiScale,
 					item.BorderPad*uiScale,
 					border,
@@ -375,7 +375,7 @@ func (item *itemData) drawFlows(parent *itemData, offset point, clip rect, scree
 			item.GetSize().X,
 			item.GetSize().Y-tabHeight,
 			1,
-			dimColor(item.Color, dimFactor),
+			dimColor(item.OutlineColor, dimFactor),
 			false)
 		activeContents = item.Tabs[item.ActiveTab].Contents
 	} else {
@@ -489,7 +489,7 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 
 		bThick := item.Border * uiScale
 		itemColor := item.Color
-		bColor := item.ClickColor
+		bColor := item.OutlineColor
 		if item.Checked {
 			itemColor = item.ClickColor
 			bColor = item.Color
@@ -553,7 +553,7 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 
 		bThick := item.Border * uiScale
 		itemColor := item.Color
-		bColor := item.ClickColor
+		bColor := item.OutlineColor
 		if item.Checked {
 			itemColor = item.ClickColor
 			bColor = item.Color
@@ -873,7 +873,7 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 			Position: offset,
 			Fillet:   item.Fillet,
 			Filled:   false,
-			Color:    item.Color,
+			Color:    item.OutlineColor,
 			Border:   item.Border * uiScale,
 		})
 	}

--- a/struct.go
+++ b/struct.go
@@ -107,7 +107,7 @@ type itemData struct {
 	AuxSpace          float32
 
 	TextColor, Color, HoverColor,
-	ClickColor, DisabledColor, CheckedColor Color
+	ClickColor, OutlineColor, DisabledColor, CheckedColor Color
 
 	Action        func()
 	OnColorChange func(Color)

--- a/theme.go
+++ b/theme.go
@@ -183,12 +183,19 @@ func applyAccentColor() {
 	}
 	currentTheme.Window.ActiveColor = col
 	currentTheme.Button.ClickColor = col
+	currentTheme.Button.OutlineColor = col
 	currentTheme.Checkbox.ClickColor = col
+	currentTheme.Checkbox.OutlineColor = col
 	currentTheme.Radio.ClickColor = col
+	currentTheme.Radio.OutlineColor = col
 	currentTheme.Input.ClickColor = col
+	currentTheme.Input.OutlineColor = col
 	currentTheme.Slider.ClickColor = col
+	currentTheme.Slider.OutlineColor = col
 	currentTheme.Dropdown.ClickColor = col
+	currentTheme.Dropdown.OutlineColor = col
 	currentTheme.Tab.ClickColor = col
+	currentTheme.Tab.OutlineColor = col
 	applyThemeToAll()
 	updateColorWheels(col)
 }
@@ -259,6 +266,7 @@ func copyItemStyle(dst, src *itemData) {
 	dst.Color = src.Color
 	dst.HoverColor = src.HoverColor
 	dst.ClickColor = src.ClickColor
+	dst.OutlineColor = src.OutlineColor
 	dst.DisabledColor = src.DisabledColor
 	dst.CheckedColor = src.CheckedColor
 	if src.MaxVisible != 0 {

--- a/themes/colors/AccentDark.json
+++ b/themes/colors/AccentDark.json
@@ -28,6 +28,7 @@
     "Color": "button",
     "HoverColor": "hover",
     "ClickColor": "accent",
+    "OutlineColor": "outline",
     "DisabledColor": "disabled",
     "CheckedColor": "disabled"
   },
@@ -36,6 +37,7 @@
     "Color": "disabled",
     "HoverColor": "disabled",
     "ClickColor": "accent",
+    "OutlineColor": "outline",
     "DisabledColor": "disabled",
     "CheckedColor": "disabled"
   },
@@ -44,6 +46,7 @@
     "Color": "button",
     "HoverColor": "hover",
     "ClickColor": "accent",
+    "OutlineColor": "outline",
     "DisabledColor": "disabled",
     "CheckedColor": "disabled"
   },
@@ -52,6 +55,7 @@
     "Color": "button",
     "HoverColor": "hover",
     "ClickColor": "accent",
+    "OutlineColor": "outline",
     "DisabledColor": "disabled",
     "CheckedColor": "disabled"
   },
@@ -60,6 +64,7 @@
     "Color": "button",
     "HoverColor": "hover",
     "ClickColor": "accent",
+    "OutlineColor": "outline",
     "DisabledColor": "disabled",
     "CheckedColor": "disabled"
   },
@@ -68,6 +73,7 @@
     "Color": "button",
     "HoverColor": "hover",
     "ClickColor": "accent",
+    "OutlineColor": "outline",
     "DisabledColor": "disabled",
     "CheckedColor": "disabled"
   },
@@ -76,6 +82,7 @@
     "Color": "button",
     "HoverColor": "hover",
     "ClickColor": "accent",
+    "OutlineColor": "outline",
     "DisabledColor": "disabled",
     "CheckedColor": "disabled",
     "MaxVisible": 5
@@ -84,7 +91,8 @@
     "TextColor": "text",
     "Color": "button",
     "HoverColor": "hover",
-    "ClickColor": "accent"
+    "ClickColor": "accent",
+    "OutlineColor": "outline"
   },
   "RecommendedLayout": "Default"
 }

--- a/themes/colors/AccentLight.json
+++ b/themes/colors/AccentLight.json
@@ -29,6 +29,7 @@
     "Color": "button",
     "HoverColor": "hover",
     "ClickColor": "accent",
+    "OutlineColor": "outline",
     "DisabledColor": "disabled",
     "CheckedColor": "disabled"
   },
@@ -37,6 +38,7 @@
     "Color": "disabled",
     "HoverColor": "disabled",
     "ClickColor": "disabled",
+    "OutlineColor": "outline",
     "DisabledColor": "disabled",
     "CheckedColor": "disabled"
   },
@@ -45,6 +47,7 @@
     "Color": "button",
     "HoverColor": "hover",
     "ClickColor": "button",
+    "OutlineColor": "outline",
     "DisabledColor": "disabled",
     "CheckedColor": "disabled"
   },
@@ -53,6 +56,7 @@
     "Color": "button",
     "HoverColor": "hover",
     "ClickColor": "button",
+    "OutlineColor": "outline",
     "DisabledColor": "disabled",
     "CheckedColor": "disabled"
   },
@@ -61,6 +65,7 @@
     "Color": "button",
     "HoverColor": "hover",
     "ClickColor": "accent",
+    "OutlineColor": "outline",
     "DisabledColor": "disabled",
     "CheckedColor": "disabled"
   },
@@ -69,6 +74,7 @@
     "Color": "button",
     "HoverColor": "hover",
     "ClickColor": "hover",
+    "OutlineColor": "outline",
     "DisabledColor": "disabled",
     "CheckedColor": "disabled"
   },
@@ -77,6 +83,7 @@
     "Color": "button",
     "HoverColor": "hover",
     "ClickColor": "accent",
+    "OutlineColor": "outline",
     "DisabledColor": "disabled",
     "CheckedColor": "disabled",
     "MaxVisible": 5
@@ -85,6 +92,7 @@
     "TextColor": "text",
     "Color": "button",
     "HoverColor": "hover",
-    "ClickColor": "button"
+    "ClickColor": "button",
+    "OutlineColor": "outline"
   }
 }

--- a/themes/colors/Black.json
+++ b/themes/colors/Black.json
@@ -29,6 +29,7 @@
     "Color": "button",
     "HoverColor": "hover",
     "ClickColor": "accent",
+    "OutlineColor": "outline",
     "DisabledColor": "disabled",
     "CheckedColor": "disabled"
   },
@@ -37,6 +38,7 @@
     "Color": "disabled",
     "HoverColor": "disabled",
     "ClickColor": "disabled",
+    "OutlineColor": "outline",
     "DisabledColor": "disabled",
     "CheckedColor": "disabled"
   },
@@ -45,6 +47,7 @@
     "Color": "button",
     "HoverColor": "hover",
     "ClickColor": "accent",
+    "OutlineColor": "outline",
     "DisabledColor": "disabled",
     "CheckedColor": "disabled"
   },
@@ -53,6 +56,7 @@
     "Color": "button",
     "HoverColor": "hover",
     "ClickColor": "accent",
+    "OutlineColor": "outline",
     "DisabledColor": "disabled",
     "CheckedColor": "disabled"
   },
@@ -61,6 +65,7 @@
     "Color": "button",
     "HoverColor": "hover",
     "ClickColor": "accent",
+    "OutlineColor": "outline",
     "DisabledColor": "disabled",
     "CheckedColor": "disabled"
   },
@@ -69,6 +74,7 @@
     "Color": "button",
     "HoverColor": "hover",
     "ClickColor": "accent",
+    "OutlineColor": "outline",
     "DisabledColor": "disabled",
     "CheckedColor": "disabled"
   },
@@ -77,6 +83,7 @@
     "Color": "button",
     "HoverColor": "hover",
     "ClickColor": "accent",
+    "OutlineColor": "outline",
     "DisabledColor": "disabled",
     "CheckedColor": "disabled",
     "MaxVisible": 5
@@ -85,6 +92,7 @@
     "TextColor": "text",
     "Color": "button",
     "HoverColor": "hover",
-    "ClickColor": "accent"
+    "ClickColor": "accent",
+    "OutlineColor": "outline"
   }
 }


### PR DESCRIPTION
## Summary
- support OutlineColor field on widgets for more theming control
- use OutlineColor when drawing outlines
- default outline color to theme "outline" color
- update theme JSON files with OutlineColor entries

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68798cf16adc832ab675d823c0dbd0dd