### PR TITLE
Add auto reload for theme and layout

### DIFF
--- a/input.go
+++ b/input.go
@@ -20,6 +20,8 @@ var (
 
 func (g *Game) Update() error {
 
+	checkThemeLayoutMods()
+
 	mx, my := ebiten.CursorPosition()
 	mpos := point{X: float32(mx), Y: float32(my)}
 

--- a/layout.go
+++ b/layout.go
@@ -129,6 +129,7 @@ func LoadLayout(name string) error {
 		applyLayoutToTheme(currentTheme)
 		applyThemeToAll()
 	}
+	refreshLayoutMod()
 	return nil
 }
 

--- a/theme.go
+++ b/theme.go
@@ -116,6 +116,7 @@ func LoadTheme(name string) error {
 	if tf.RecommendedLayout != "" {
 		_ = LoadLayout(tf.RecommendedLayout)
 	}
+	refreshThemeMod()
 	return nil
 }
 

--- a/watchers.go
+++ b/watchers.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+var (
+	themeModTime  time.Time
+	layoutModTime time.Time
+	modCheckTime  time.Time
+)
+
+func init() {
+	modCheckTime = time.Now()
+	refreshThemeMod()
+	refreshLayoutMod()
+}
+
+func refreshThemeMod() {
+	path := filepath.Join("themes", "colors", currentThemeName+".json")
+	if info, err := os.Stat(path); err == nil {
+		themeModTime = info.ModTime()
+	} else {
+		themeModTime = time.Time{}
+	}
+}
+
+func refreshLayoutMod() {
+	path := filepath.Join("themes", "layout", currentLayoutName+".json")
+	if info, err := os.Stat(path); err == nil {
+		layoutModTime = info.ModTime()
+	} else {
+		layoutModTime = time.Time{}
+	}
+}
+
+func checkThemeLayoutMods() {
+	if time.Since(modCheckTime) < 500*time.Millisecond {
+		return
+	}
+	modCheckTime = time.Now()
+
+	path := filepath.Join("themes", "colors", currentThemeName+".json")
+	if info, err := os.Stat(path); err == nil {
+		if info.ModTime().After(themeModTime) {
+			if err := LoadTheme(currentThemeName); err != nil {
+				fmt.Printf("Auto reload theme error: %v\n", err)
+			}
+			themeModTime = info.ModTime()
+		}
+	}
+
+	path = filepath.Join("themes", "layout", currentLayoutName+".json")
+	if info, err := os.Stat(path); err == nil {
+		if info.ModTime().After(layoutModTime) {
+			if err := LoadLayout(currentLayoutName); err != nil {
+				fmt.Printf("Auto reload layout error: %v\n", err)
+			}
+			layoutModTime = info.ModTime()
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- watch theme and layout file modification time
- auto reload when files change (checked twice per second)

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6879a314b204832aa0e24353da504867