### PR TITLE
Fix outline drawing and tab click color

### DIFF
--- a/render.go
+++ b/render.go
@@ -500,7 +500,12 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 		}
 		drawRoundRect(subImg, &roundRect{
 			Size:     auxSize,
-			Position: offset, Fillet: item.Fillet, Filled: false, Color: bColor, Border: bThick * uiScale})
+			Position: offset,
+			Fillet:   item.Fillet,
+			Filled:   false,
+			Color:    bColor,
+			Border:   bThick,
+		})
 
 		if item.Checked {
 			cThick := 2 * uiScale
@@ -568,7 +573,7 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 			Fillet:   auxSize.X / 2,
 			Filled:   false,
 			Color:    bColor,
-			Border:   bThick * uiScale,
+			Border:   bThick,
 		})
 		if item.Checked {
 			inner := auxSize.X / 2.5

--- a/theme.go
+++ b/theme.go
@@ -179,7 +179,6 @@ func applyAccentColor() {
 	currentTheme.Input.ClickColor = col
 	currentTheme.Slider.ClickColor = col
 	currentTheme.Dropdown.ClickColor = col
-	currentTheme.Tab.ClickColor = col
 	applyThemeToAll()
 	updateColorWheels(col)
 }


### PR DESCRIPTION
## Summary
- respect custom tab color by not overriding the `Tab.ClickColor` when updating accent colors
- draw checkbox and radio button outlines using the configured border size

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6879beca2144832aa1ff34a520bb0450