### PR TITLE
Fix theme colors for sliders, tabs and drop-down menus

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -183,7 +183,7 @@ var defaultColorWheel = &itemData{
 	Position:      point{X: 4, Y: 4},
 	Margin:        4,
 	OnColorChange: nil,
-	SelectedColor: NewColor(255, 0, 0, 255),
+	WheelColor:    NewColor(255, 0, 0, 255),
 }
 
 var defaultTab = &itemData{

--- a/input.go
+++ b/input.go
@@ -340,7 +340,7 @@ func (item *itemData) clickItem(mpos point, click bool) bool {
 		item.Clicked = time.Now()
 		if item.ItemType == ITEM_COLORWHEEL {
 			if col, ok := item.colorAt(mpos); ok {
-				item.SelectedColor = col
+				item.WheelColor = col
 				if item.OnColorChange != nil {
 					item.OnColorChange(col)
 				} else {
@@ -393,7 +393,7 @@ func (item *itemData) clickItem(mpos point, click bool) bool {
 		item.Hovered = true
 		if item.ItemType == ITEM_COLORWHEEL && ebiten.IsMouseButtonPressed(ebiten.MouseButton0) {
 			if col, ok := item.colorAt(mpos); ok {
-				item.SelectedColor = col
+				item.WheelColor = col
 				if item.OnColorChange != nil {
 					item.OnColorChange(col)
 				} else {

--- a/render.go
+++ b/render.go
@@ -304,7 +304,7 @@ func (item *itemData) drawFlows(parent *itemData, offset point, clip rect, scree
 			col := item.Color
 			if i == item.ActiveTab {
 				if !item.ActiveOutline {
-					col = item.ClickColor
+					col = item.SelectedColor
 				}
 			} else if tab.Hovered {
 				col = item.HoverColor
@@ -339,7 +339,7 @@ func (item *itemData) drawFlows(parent *itemData, offset point, clip rect, scree
 					offset.Y,
 					w,
 					3*uiScale,
-					item.ClickColor,
+					item.SelectedColor,
 					false)
 			}
 			loo := text.LayoutOptions{PrimaryAlign: text.AlignCenter, SecondaryAlign: text.AlignCenter}
@@ -357,7 +357,7 @@ func (item *itemData) drawFlows(parent *itemData, offset point, clip rect, scree
 			offset.Y+tabHeight-3*uiScale,
 			item.GetSize().X,
 			3*uiScale,
-			item.ClickColor,
+			item.SelectedColor,
 			false)
 		strokeRect(subImg,
 			offset.X,
@@ -744,14 +744,18 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 			ratio = 1
 		}
 		knobCenter := trackStart + float32(ratio)*trackWidth
-		strokeLine(subImg, trackStart, trackY, knobCenter, trackY, 2*uiScale, item.ClickColor, true)
+		filledCol := item.SelectedColor
+		if c, ok := namedColors["sliderfilled"]; ok {
+			filledCol = c
+		}
+		strokeLine(subImg, trackStart, trackY, knobCenter, trackY, 2*uiScale, filledCol, true)
 		strokeLine(subImg, knobCenter, trackY, trackStart+trackWidth, trackY, 2*uiScale, itemColor, true)
 		drawRoundRect(subImg, &roundRect{
 			Size:     pointScaleMul(item.AuxSize),
 			Position: point{X: knobCenter - knobW/2, Y: offset.Y + (maxSize.Y-knobH)/2},
 			Fillet:   item.Fillet,
 			Filled:   true,
-			Color:    item.ClickColor,
+			Color:    item.Color,
 		})
 
 		// value text drawn to the right of the slider track
@@ -769,7 +773,7 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 
 		itemColor := item.Color
 		if item.Open {
-			itemColor = item.ClickColor
+			itemColor = item.SelectedColor
 		} else if item.Hovered {
 			item.Hovered = false
 			itemColor = item.HoverColor
@@ -819,7 +823,7 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 		op.GeoM.Translate(float64(offset.X), float64(offset.Y))
 		subImg.DrawImage(item.Image, op)
 
-		h, _, v, _ := rgbaToHSVA(color.RGBA(item.SelectedColor))
+		h, _, v, _ := rgbaToHSVA(color.RGBA(item.WheelColor))
 		radius := maxSize.X / 2
 		cx := offset.X + radius
 		cy := offset.Y + radius
@@ -834,7 +838,7 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 		}
 		sx := offset.X + maxSize.X - sw - 4*uiScale
 		sy := offset.Y + maxSize.Y - sw - 4*uiScale
-		drawFilledRect(subImg, sx, sy, sw, sw, color.RGBA(item.SelectedColor), true)
+		drawFilledRect(subImg, sx, sy, sw, sw, color.RGBA(item.WheelColor), true)
 		strokeRect(subImg, sx, sy, sw, sw, 1, color.Black, true)
 
 	} else if item.ItemType == ITEM_TEXT {
@@ -910,7 +914,7 @@ func drawDropdownOptions(item *itemData, offset point, clip rect, screen *ebiten
 	for i := first; i < first+visible && i < len(item.Options); i++ {
 		y := offY + float32(i-first)*optionH
 		if i == item.Selected || i == item.HoverIndex {
-			col := item.ClickColor
+			col := item.SelectedColor
 			if i == item.HoverIndex && i != item.Selected {
 				col = item.HoverColor
 			}

--- a/struct.go
+++ b/struct.go
@@ -107,11 +107,11 @@ type itemData struct {
 	AuxSpace          float32
 
 	TextColor, Color, HoverColor,
-	ClickColor, OutlineColor, DisabledColor, CheckedColor Color
+	ClickColor, OutlineColor, DisabledColor, SelectedColor Color
 
 	Action        func()
 	OnColorChange func(Color)
-	SelectedColor Color
+	WheelColor    Color
 	Contents      []*itemData
 
 	// Tabs allows a flow to contain multiple tabbed flows. Only the

--- a/theme.go
+++ b/theme.go
@@ -252,7 +252,7 @@ func copyItemStyle(dst, src *itemData) {
 	dst.ClickColor = src.ClickColor
 	dst.OutlineColor = src.OutlineColor
 	dst.DisabledColor = src.DisabledColor
-	dst.CheckedColor = src.CheckedColor
+	dst.SelectedColor = src.SelectedColor
 	if src.MaxVisible != 0 {
 		dst.MaxVisible = src.MaxVisible
 	}
@@ -294,7 +294,7 @@ func applyThemeToItem(it *itemData) {
 	}
 }
 
-// updateColorWheels sets the SelectedColor field of all color wheel widgets to
+// updateColorWheels sets the WheelColor field of all color wheel widgets to
 // the provided color.
 func updateColorWheels(col Color) {
 	for _, win := range windows {
@@ -308,7 +308,7 @@ func updateColorWheels(col Color) {
 func updateColorWheelList(items []*itemData, col Color) {
 	for _, it := range items {
 		if it.ItemType == ITEM_COLORWHEEL {
-			it.SelectedColor = col
+			it.WheelColor = col
 		}
 		updateColorWheelList(it.Contents, col)
 		for _, tab := range it.Tabs {

--- a/themes/colors/AccentDark.json
+++ b/themes/colors/AccentDark.json
@@ -30,7 +30,7 @@
     "ClickColor": "accent",
     "OutlineColor": "outline",
     "DisabledColor": "disabled",
-    "CheckedColor": "disabled"
+    "SelectedColor": "disabled"
   },
   "Text": {
     "TextColor": "text",
@@ -39,7 +39,7 @@
     "ClickColor": "accent",
     "OutlineColor": "outline",
     "DisabledColor": "disabled",
-    "CheckedColor": "disabled"
+    "SelectedColor": "disabled"
   },
   "Checkbox": {
     "TextColor": "text",
@@ -48,7 +48,7 @@
     "ClickColor": "accent",
     "OutlineColor": "outline",
     "DisabledColor": "disabled",
-    "CheckedColor": "disabled"
+    "SelectedColor": "disabled"
   },
   "Radio": {
     "TextColor": "text",
@@ -57,7 +57,7 @@
     "ClickColor": "accent",
     "OutlineColor": "outline",
     "DisabledColor": "disabled",
-    "CheckedColor": "disabled"
+    "SelectedColor": "disabled"
   },
   "Input": {
     "TextColor": "text",
@@ -66,7 +66,7 @@
     "ClickColor": "accent",
     "OutlineColor": "outline",
     "DisabledColor": "disabled",
-    "CheckedColor": "disabled"
+    "SelectedColor": "disabled"
   },
   "Slider": {
     "TextColor": "text",
@@ -75,7 +75,7 @@
     "ClickColor": "accent",
     "OutlineColor": "outline",
     "DisabledColor": "disabled",
-    "CheckedColor": "disabled"
+    "SelectedColor": "disabled"
   },
   "Dropdown": {
     "TextColor": "text",
@@ -84,7 +84,7 @@
     "ClickColor": "accent",
     "OutlineColor": "outline",
     "DisabledColor": "disabled",
-    "CheckedColor": "disabled",
+    "SelectedColor": "disabled",
     "MaxVisible": 5
   },
   "Tab": {
@@ -92,7 +92,8 @@
     "Color": "button",
     "HoverColor": "hover",
     "ClickColor": "accent",
-    "OutlineColor": "outline"
+    "OutlineColor": "outline",
+    "SelectedColor": "accent"
   },
   "RecommendedLayout": "RoundHybrid"
 }

--- a/themes/colors/AccentLight.json
+++ b/themes/colors/AccentLight.json
@@ -31,7 +31,7 @@
     "ClickColor": "accent",
     "OutlineColor": "outline",
     "DisabledColor": "disabled",
-    "CheckedColor": "disabled"
+    "SelectedColor": "disabled"
   },
   "Text": {
     "TextColor": "text",
@@ -40,7 +40,7 @@
     "ClickColor": "disabled",
     "OutlineColor": "outline",
     "DisabledColor": "disabled",
-    "CheckedColor": "disabled"
+    "SelectedColor": "disabled"
   },
   "Checkbox": {
     "TextColor": "text",
@@ -49,7 +49,7 @@
     "ClickColor": "button",
     "OutlineColor": "outline",
     "DisabledColor": "disabled",
-    "CheckedColor": "disabled"
+    "SelectedColor": "disabled"
   },
   "Radio": {
     "TextColor": "text",
@@ -58,7 +58,7 @@
     "ClickColor": "button",
     "OutlineColor": "outline",
     "DisabledColor": "disabled",
-    "CheckedColor": "disabled"
+    "SelectedColor": "disabled"
   },
   "Input": {
     "TextColor": "text",
@@ -67,7 +67,7 @@
     "ClickColor": "accent",
     "OutlineColor": "outline",
     "DisabledColor": "disabled",
-    "CheckedColor": "disabled"
+    "SelectedColor": "disabled"
   },
   "Slider": {
     "TextColor": "text",
@@ -76,7 +76,7 @@
     "ClickColor": "hover",
     "OutlineColor": "outline",
     "DisabledColor": "disabled",
-    "CheckedColor": "disabled"
+    "SelectedColor": "disabled"
   },
   "Dropdown": {
     "TextColor": "text",
@@ -85,7 +85,7 @@
     "ClickColor": "accent",
     "OutlineColor": "outline",
     "DisabledColor": "disabled",
-    "CheckedColor": "disabled",
+    "SelectedColor": "disabled",
     "MaxVisible": 5
   },
   "Tab": {
@@ -93,6 +93,7 @@
     "Color": "button",
     "HoverColor": "hover",
     "ClickColor": "button",
-    "OutlineColor": "outline"
+    "OutlineColor": "outline",
+    "SelectedColor": "button"
   }
 }

--- a/themes/colors/Black.json
+++ b/themes/colors/Black.json
@@ -31,7 +31,7 @@
     "ClickColor": "accent",
     "OutlineColor": "outline",
     "DisabledColor": "disabled",
-    "CheckedColor": "disabled"
+    "SelectedColor": "disabled"
   },
   "Text": {
     "TextColor": "text",
@@ -40,7 +40,7 @@
     "ClickColor": "disabled",
     "OutlineColor": "outline",
     "DisabledColor": "disabled",
-    "CheckedColor": "disabled"
+    "SelectedColor": "disabled"
   },
   "Checkbox": {
     "TextColor": "text",
@@ -49,7 +49,7 @@
     "ClickColor": "accent",
     "OutlineColor": "outline",
     "DisabledColor": "disabled",
-    "CheckedColor": "disabled"
+    "SelectedColor": "disabled"
   },
   "Radio": {
     "TextColor": "text",
@@ -58,7 +58,7 @@
     "ClickColor": "accent",
     "OutlineColor": "outline",
     "DisabledColor": "disabled",
-    "CheckedColor": "disabled"
+    "SelectedColor": "disabled"
   },
   "Input": {
     "TextColor": "text",
@@ -67,7 +67,7 @@
     "ClickColor": "accent",
     "OutlineColor": "outline",
     "DisabledColor": "disabled",
-    "CheckedColor": "disabled"
+    "SelectedColor": "disabled"
   },
   "Slider": {
     "TextColor": "text",
@@ -76,7 +76,7 @@
     "ClickColor": "accent",
     "OutlineColor": "outline",
     "DisabledColor": "disabled",
-    "CheckedColor": "disabled"
+    "SelectedColor": "disabled"
   },
   "Dropdown": {
     "TextColor": "text",
@@ -85,7 +85,7 @@
     "ClickColor": "accent",
     "OutlineColor": "outline",
     "DisabledColor": "disabled",
-    "CheckedColor": "disabled",
+    "SelectedColor": "disabled",
     "MaxVisible": 5
   },
   "Tab": {
@@ -93,6 +93,7 @@
     "Color": "button",
     "HoverColor": "hover",
     "ClickColor": "accent",
-    "OutlineColor": "outline"
+    "OutlineColor": "outline",
+    "SelectedColor": "accent"
   }
 }

--- a/window.go
+++ b/window.go
@@ -199,8 +199,8 @@ func NewColorWheel(item *itemData) *itemData {
 	if item != nil {
 		mergeData(&newItem, item)
 	}
-	if ac, ok := namedColors["accent"]; ok && newItem.SelectedColor == (Color{}) {
-		newItem.SelectedColor = ac
+	if ac, ok := namedColors["accent"]; ok && newItem.WheelColor == (Color{}) {
+		newItem.WheelColor = ac
 	}
 	return &newItem
 }


### PR DESCRIPTION
## Summary
- rename `CheckedColor` to `SelectedColor`
- support `WheelColor` for color wheel widgets
- use `SelectedColor` for tab highlights and dropdown states
- respect slider colors from themes
- update color themes to use `SelectedColor`

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6879c4a3d300832a88fc71a3abf8b545