### PR TITLE
Adjust color swatch position

### DIFF
--- a/render.go
+++ b/render.go
@@ -832,7 +832,9 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 		if sw < 10*uiScale {
 			sw = 10 * uiScale
 		}
-		sx := offset.X + maxSize.X - sw - 4*uiScale
+		// Position the swatch to the right of the wheel so it never
+		// overlaps the color wheel itself.
+		sx := offset.X + maxSize.X + 4*uiScale
 		sy := offset.Y + maxSize.Y - sw - 4*uiScale
 		drawFilledRect(subImg, sx, sy, sw, sw, color.RGBA(item.SelectedColor), true)
 		strokeRect(subImg, sx, sy, sw, sw, 1, color.Black, true)


### PR DESCRIPTION
## Summary
- move color swatch to the right of the color wheel so it never overlaps

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6879c4eaf914832a8e582479c8659427