### PR TITLE
Fix color swatch visibility

### DIFF
--- a/theme_selector.go
+++ b/theme_selector.go
@@ -82,10 +82,13 @@ func makeThemeSelector() *windowData {
 		mainFlow.addItemTo(ldd)
 	}
 
-	cw := NewColorWheel(&itemData{Size: point{X: 128, Y: 128}})
+	// Widen the color wheel widget slightly so that the swatch drawn to the
+	// right of the wheel is within the window's bounds.
+	cw := NewColorWheel(&itemData{Size: point{X: 160, Y: 128}})
 	mainFlow.addItemTo(cw)
 
-	satSlider = NewSlider(&itemData{Label: "Color Intensity", Size: point{X: 128, Y: 24}, MinValue: 0, MaxValue: 1, FontSize: 8})
+	// Match the slider width to the widened color wheel for consistent layout.
+	satSlider = NewSlider(&itemData{Label: "Color Intensity", Size: point{X: 160, Y: 24}, MinValue: 0, MaxValue: 1, FontSize: 8})
 	satSlider.Value = float32(accentSaturation)
 	satSlider.Action = func() {
 		SetAccentSaturation(float64(satSlider.Value))


### PR DESCRIPTION
## Summary
- ensure the color swatch of the color wheel fits inside the themes window by increasing the widget width
- match the color intensity slider width with the updated color wheel width

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6879c8650544832a8260460cfc68a560