### PR TITLE
Fix color wheel swatch overlap

### DIFF
--- a/color_wheel.go
+++ b/color_wheel.go
@@ -16,7 +16,8 @@ func ColorWheelImage(size int) *ebiten.Image {
 	}
 	img := ebiten.NewImage(size, size)
 	r := float64(size) / 2
-	offsets := []float64{0.25, 0.75}
+	// Use a 4x4 grid of subpixel samples for smoother edges
+	offsets := []float64{0.125, 0.375, 0.625, 0.875}
 	for y := 0; y < size; y++ {
 		for x := 0; x < size; x++ {
 			var rr, gg, bb, aa float64

--- a/defaults.go
+++ b/defaults.go
@@ -179,7 +179,7 @@ var defaultDropdown = &itemData{
 
 var defaultColorWheel = &itemData{
 	ItemType:      ITEM_COLORWHEEL,
-	Size:          point{X: 128, Y: 128},
+	Size:          point{X: 160, Y: 128},
 	Position:      point{X: 4, Y: 4},
 	Margin:        4,
 	OnColorChange: nil,

--- a/input.go
+++ b/input.go
@@ -498,15 +498,25 @@ func (item *itemData) colorAt(mpos point) (Color, bool) {
 	if item.Label != "" {
 		offsetY = (item.FontSize*uiScale + 2) + currentLayout.TextPadding
 	}
-	cx := item.DrawRect.X0 + size.X/2
-	cy := item.DrawRect.Y0 + offsetY + size.Y/2
+	wheelSize := size.Y
+	if wheelSize > size.X {
+		wheelSize = size.X
+	}
+	radius := wheelSize / 2
+	cx := item.DrawRect.X0 + radius
+	cy := item.DrawRect.Y0 + offsetY + radius
 	dx := float64(mpos.X - cx)
 	dy := float64(mpos.Y - cy)
-	r := float64(size.X) / 2
+	r := float64(radius)
 	dist := math.Hypot(dx, dy)
-	if dist > r {
+
+	if !item.DrawRect.containsPoint(mpos) {
 		return Color{}, false
 	}
+	if dist > r {
+		dist = r
+	}
+
 	ang := math.Atan2(dy, dx) * 180 / math.Pi
 	if ang < 0 {
 		ang += 360

--- a/render.go
+++ b/render.go
@@ -816,15 +816,20 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 
 	} else if item.ItemType == ITEM_COLORWHEEL {
 
-		if item.Image == nil || item.Image.Bounds().Dx() != int(maxSize.X) {
-			item.Image = ColorWheelImage(int(maxSize.X))
+		wheelSize := maxSize.Y
+		if wheelSize > maxSize.X {
+			wheelSize = maxSize.X
+		}
+
+		if item.Image == nil || item.Image.Bounds().Dx() != int(wheelSize) {
+			item.Image = ColorWheelImage(int(wheelSize))
 		}
 		op := &ebiten.DrawImageOptions{}
 		op.GeoM.Translate(float64(offset.X), float64(offset.Y))
 		subImg.DrawImage(item.Image, op)
 
 		h, _, v, _ := rgbaToHSVA(color.RGBA(item.WheelColor))
-		radius := maxSize.X / 2
+		radius := wheelSize / 2
 		cx := offset.X + radius
 		cy := offset.Y + radius
 		px := cx + float32(math.Cos(h*math.Pi/180))*radius*float32(v)
@@ -832,11 +837,11 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 		vector.DrawFilledCircle(subImg, px, py, 4*uiScale, color.Black, true)
 		vector.DrawFilledCircle(subImg, px, py, 2*uiScale, color.White, true)
 
-		sw := maxSize.X / 5
+		sw := wheelSize / 5
 		if sw < 10*uiScale {
 			sw = 10 * uiScale
 		}
-		sx := offset.X + maxSize.X - sw - 4*uiScale
+		sx := offset.X + wheelSize + 4*uiScale
 		sy := offset.Y + maxSize.Y - sw - 4*uiScale
 		drawFilledRect(subImg, sx, sy, sw, sw, color.RGBA(item.WheelColor), true)
 		strokeRect(subImg, sx, sy, sw, sw, 1, color.Black, true)

--- a/theme_selector.go
+++ b/theme_selector.go
@@ -82,7 +82,7 @@ func makeThemeSelector() *windowData {
 		mainFlow.addItemTo(ldd)
 	}
 
-	cw := NewColorWheel(&itemData{Size: point{X: 128, Y: 128}})
+	cw := NewColorWheel(&itemData{Size: point{X: 160, Y: 128}})
 	mainFlow.addItemTo(cw)
 
 	satSlider = NewSlider(&itemData{Label: "Color Intensity", Size: point{X: 128, Y: 24}, MinValue: 0, MaxValue: 1, FontSize: 8})


### PR DESCRIPTION
## Summary
- update default color wheel layout
- enlarge wheel for swatch spacing
- increase edge anti-aliasing
- allow drag tracking outside the wheel

## Testing
- `./scripts/setup.sh`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6879cb071858832a83e465617b845ae3