### PR TITLE
Improve color wheel edge anti-aliasing

### DIFF
--- a/color_wheel.go
+++ b/color_wheel.go
@@ -17,20 +17,21 @@ func ColorWheelImage(size int) *ebiten.Image {
 	img := ebiten.NewImage(size, size)
 	r := float64(size) / 2
 	// Use a 4x4 grid of subpixel samples for smoother edges
-	offsets := []float64{0.125, 0.375, 0.625, 0.875}
-	for y := 0; y < size; y++ {
-		for x := 0; x < size; x++ {
-			var rr, gg, bb, aa float64
-			var samples int
-			for _, oy := range offsets {
-				for _, ox := range offsets {
-					dx := float64(x) + ox - r
-					dy := float64(y) + oy - r
-					dist := math.Hypot(dx, dy)
-					if dist > r {
-						continue
-					}
-					ang := math.Atan2(dy, dx) * 180 / math.Pi
+       offsets := []float64{0.125, 0.375, 0.625, 0.875}
+       maxSamples := len(offsets) * len(offsets)
+       for y := 0; y < size; y++ {
+               for x := 0; x < size; x++ {
+                       var rr, gg, bb, aa float64
+                       var coverage int
+                       for _, oy := range offsets {
+                               for _, ox := range offsets {
+                                       dx := float64(x) + ox - r
+                                       dy := float64(y) + oy - r
+                                       dist := math.Hypot(dx, dy)
+                                       if dist > r {
+                                               continue
+                                       }
+                                       ang := math.Atan2(dy, dx) * 180 / math.Pi
 					if ang < 0 {
 						ang += 360
 					}
@@ -40,25 +41,25 @@ func ColorWheelImage(size int) *ebiten.Image {
 					} else if v > 1 {
 						v = 1
 					}
-					col := hsvaToRGBA(ang, 1, v, 1)
-					rr += float64(col.R)
-					gg += float64(col.G)
-					bb += float64(col.B)
-					aa += float64(col.A)
-					samples++
-				}
-			}
-			if samples == 0 {
-				img.Set(x, y, color.Transparent)
-				continue
-			}
-			img.Set(x, y, color.RGBA{
-				R: uint8(rr / float64(samples)),
-				G: uint8(gg / float64(samples)),
-				B: uint8(bb / float64(samples)),
-				A: uint8(aa / float64(samples)),
-			})
-		}
-	}
+                                       col := hsvaToRGBA(ang, 1, v, 1)
+                                       rr += float64(col.R)
+                                       gg += float64(col.G)
+                                       bb += float64(col.B)
+                                       aa += float64(col.A)
+                                       coverage++
+                               }
+                       }
+                       if coverage == 0 {
+                               img.Set(x, y, color.Transparent)
+                               continue
+                       }
+                       img.Set(x, y, color.RGBA{
+                               R: uint8(rr / float64(maxSamples)),
+                               G: uint8(gg / float64(maxSamples)),
+                               B: uint8(bb / float64(maxSamples)),
+                               A: uint8(aa / float64(maxSamples)),
+                       })
+               }
+       }
 	return img
 }


### PR DESCRIPTION
## Summary
- fix alpha calculation for partially covered edge pixels in `ColorWheelImage`

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6879d20b6348832ab27daedf7371b1b6