### PR TITLE
Fix theme color usage and interactions

### DIFF
--- a/input.go
+++ b/input.go
@@ -282,6 +282,7 @@ func (item *itemData) clickFlows(mpos point, click bool) bool {
 				tab.Hovered = true
 				if click {
 					activeItem = tab
+					tab.Clicked = time.Now()
 					item.ActiveTab = i
 				}
 				return true

--- a/render.go
+++ b/render.go
@@ -302,7 +302,9 @@ func (item *itemData) drawFlows(parent *itemData, offset point, clip rect, scree
 				w = float32(DefaultTabWidth) * uiScale
 			}
 			col := item.Color
-			if i == item.ActiveTab {
+			if time.Since(tab.Clicked) < clickFlash {
+				col = item.ClickColor
+			} else if i == item.ActiveTab {
 				if !item.ActiveOutline {
 					col = item.SelectedColor
 				}
@@ -745,9 +747,6 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 		}
 		knobCenter := trackStart + float32(ratio)*trackWidth
 		filledCol := item.SelectedColor
-		if c, ok := namedColors["sliderfilled"]; ok {
-			filledCol = c
-		}
 		strokeLine(subImg, trackStart, trackY, knobCenter, trackY, 2*uiScale, filledCol, true)
 		strokeLine(subImg, knobCenter, trackY, trackStart+trackWidth, trackY, 2*uiScale, itemColor, true)
 		drawRoundRect(subImg, &roundRect{

--- a/theme.go
+++ b/theme.go
@@ -95,7 +95,20 @@ func LoadTheme(name string) error {
 	if err := json.Unmarshal(data, &th); err != nil {
 		return err
 	}
+	// Extract additional color fields not present in Theme struct
+	var extra struct {
+		Slider struct {
+			SliderFilled string `json:"SliderFilled"`
+		} `json:"Slider"`
+	}
+	_ = json.Unmarshal(data, &extra)
 	currentTheme = &th
+	if extra.Slider.SliderFilled != "" {
+		if col, err := resolveColor(extra.Slider.SliderFilled, tf.Colors, map[string]bool{"sliderfilled": true}); err == nil {
+			namedColors["sliderfilled"] = col
+			currentTheme.Slider.SelectedColor = col
+		}
+	}
 	currentThemeName = name
 	applyLayoutToTheme(currentTheme)
 	applyThemeToAll()
@@ -178,8 +191,11 @@ func applyAccentColor() {
 	currentTheme.Radio.ClickColor = col
 	currentTheme.Input.ClickColor = col
 	currentTheme.Slider.ClickColor = col
+	currentTheme.Slider.SelectedColor = col
 	currentTheme.Dropdown.ClickColor = col
+	currentTheme.Dropdown.SelectedColor = col
 	currentTheme.Tab.ClickColor = col
+	namedColors["sliderfilled"] = col
 	applyThemeToAll()
 	updateColorWheels(col)
 }


### PR DESCRIPTION
## Summary
- ensure dropdowns, sliders and tabs update when accent color changes
- parse SliderFilled color from theme files
- make slider track use theme's filled color
- flash tabs on click like buttons

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6879d349a608832a92349952788ccefd