### PR TITLE
Add tab accent option and slider thumb outline

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -193,7 +193,7 @@ var defaultTab = &itemData{
 	Border:        0,
 	BorderPad:     2,
 	Fillet:        4,
-	ActiveOutline: false,
+	ActiveOutline: true,
 	TextColor:     NewColor(255, 255, 255, 255),
 	Color:         NewColor(64, 64, 64, 255),
 	HoverColor:    NewColor(96, 96, 96, 255),

--- a/layout.go
+++ b/layout.go
@@ -43,11 +43,12 @@ type LayoutTheme struct {
 	DropdownArrowPad float32
 	TextPadding      float32
 
-	Fillet    LayoutNumbers
-	Border    LayoutNumbers
-	BorderPad LayoutNumbers
-	Filled    LayoutBools
-	Outlined  LayoutBools
+	Fillet        LayoutNumbers
+	Border        LayoutNumbers
+	BorderPad     LayoutNumbers
+	Filled        LayoutBools
+	Outlined      LayoutBools
+	ActiveOutline LayoutBools
 }
 
 var defaultLayout = &LayoutTheme{
@@ -108,6 +109,9 @@ var defaultLayout = &LayoutTheme{
 		Slider:   false,
 		Dropdown: false,
 		Tab:      false,
+	},
+	ActiveOutline: LayoutBools{
+		Tab: true,
 	},
 }
 
@@ -193,6 +197,7 @@ func applyLayoutToTheme(th *Theme) {
 	th.Tab.BorderPad = currentLayout.BorderPad.Tab
 	th.Tab.Filled = currentLayout.Filled.Tab
 	th.Tab.Outlined = currentLayout.Outlined.Tab
+	th.Tab.ActiveOutline = currentLayout.ActiveOutline.Tab
 }
 
 // listLayouts returns the available layout theme names from the themes directory

--- a/render.go
+++ b/render.go
@@ -750,12 +750,21 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 		}
 		strokeLine(subImg, trackStart, trackY, knobCenter, trackY, 2*uiScale, filledCol, true)
 		strokeLine(subImg, knobCenter, trackY, trackStart+trackWidth, trackY, 2*uiScale, itemColor, true)
+		knobRect := point{X: knobCenter - knobW/2, Y: offset.Y + (maxSize.Y-knobH)/2}
 		drawRoundRect(subImg, &roundRect{
 			Size:     pointScaleMul(item.AuxSize),
-			Position: point{X: knobCenter - knobW/2, Y: offset.Y + (maxSize.Y-knobH)/2},
+			Position: knobRect,
 			Fillet:   item.Fillet,
 			Filled:   true,
 			Color:    item.Color,
+		})
+		drawRoundRect(subImg, &roundRect{
+			Size:     pointScaleMul(item.AuxSize),
+			Position: knobRect,
+			Fillet:   item.Fillet,
+			Filled:   false,
+			Border:   1 * uiScale,
+			Color:    item.OutlineColor,
 		})
 
 		// value text drawn to the right of the slider track

--- a/themes/layout/RoundFlat.json
+++ b/themes/layout/RoundFlat.json
@@ -56,5 +56,8 @@
     "Slider": false,
     "Dropdown": false,
     "Tab": false
+  },
+  "ActiveOutline": {
+    "Tab": true
   }
 }

--- a/themes/layout/RoundHybrid.json
+++ b/themes/layout/RoundHybrid.json
@@ -56,5 +56,8 @@
     "Slider": true,
     "Dropdown": true,
     "Tab": true
+  },
+  "ActiveOutline": {
+    "Tab": true
   }
 }

--- a/themes/layout/RoundOutline.json
+++ b/themes/layout/RoundOutline.json
@@ -56,5 +56,8 @@
     "Slider": false,
     "Dropdown": true,
     "Tab": false
+  },
+  "ActiveOutline": {
+    "Tab": true
   }
 }

--- a/themes/layout/SquareFlat.json
+++ b/themes/layout/SquareFlat.json
@@ -56,5 +56,8 @@
     "Slider": false,
     "Dropdown": false,
     "Tab": false
+  },
+  "ActiveOutline": {
+    "Tab": true
   }
 }

--- a/themes/layout/SquareOutline.json
+++ b/themes/layout/SquareOutline.json
@@ -56,5 +56,8 @@
     "Slider": false,
     "Dropdown": true,
     "Tab": false
+  },
+  "ActiveOutline": {
+    "Tab": true
   }
 }


### PR DESCRIPTION
## Summary
- outline slider thumbs with the widget's outline color
- add `ActiveOutline` bool group to layouts
- enable tab accent by default in default layouts

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6879d427faac832aa6d42708239bab5b