### PR TITLE
Fix tab highlight shape

### DIFF
--- a/render.go
+++ b/render.go
@@ -1172,20 +1172,15 @@ func strokeTabTop(screen *ebiten.Image, pos point, size point, col Color, fillet
 	if slope <= 0 {
 		slope = size.Y / 4
 	}
-	if fillet < 0 {
+	if fillet <= 0 {
 		fillet = size.Y / 8
 	}
 	fillet = float32(math.Round(float64(fillet)))
 
-	if fillet > 0 {
-		path.MoveTo(pos.X+slope, pos.Y+fillet)
-		path.QuadTo(pos.X+slope, pos.Y, pos.X+slope+fillet, pos.Y)
-		path.LineTo(pos.X+size.X-slope-fillet, pos.Y)
-		path.QuadTo(pos.X+size.X-slope, pos.Y, pos.X+size.X-slope, pos.Y+fillet)
-	} else {
-		path.MoveTo(pos.X+slope, pos.Y)
-		path.LineTo(pos.X+size.X-slope, pos.Y)
-	}
+	path.MoveTo(pos.X+slope, pos.Y+fillet)
+	path.QuadTo(pos.X+slope, pos.Y, pos.X+slope+fillet, pos.Y)
+	path.LineTo(pos.X+size.X-slope-fillet, pos.Y)
+	path.QuadTo(pos.X+size.X-slope, pos.Y, pos.X+size.X-slope, pos.Y+fillet)
 
 	opv := &vector.StrokeOptions{Width: border}
 	vertices, indices = path.AppendVerticesAndIndicesForStroke(vertices[:0], indices[:0], opv)


### PR DESCRIPTION
## Summary
- revert tab highlight stroke to use existing fillet size

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687a0fcaa3e0832aa19d5694643fb780