### PR TITLE
Fix tab highlight clipping with large fillet

### DIFF
--- a/render.go
+++ b/render.go
@@ -340,7 +340,7 @@ func (item *itemData) drawFlows(parent *itemData, offset point, clip rect, scree
 					point{X: x, Y: offset.Y},
 					point{X: w, Y: tabHeight},
 					item.ClickColor,
-					0,
+					item.Fillet*uiScale,
 					item.BorderPad*uiScale,
 					3*uiScale,
 				)


### PR DESCRIPTION
## Summary
- correctly pass the tab fillet to the highlight drawing routine

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687a11e491ec832a9d84b1f48ce28dbf