### PR TITLE
Fix tab highlight geometry

### DIFF
--- a/render.go
+++ b/render.go
@@ -1178,10 +1178,8 @@ func strokeTabTop(screen *ebiten.Image, pos point, size point, col Color, fillet
 	fillet = float32(math.Round(float64(fillet)))
 
 	if fillet > 0 {
-		path.MoveTo(pos.X+slope, pos.Y+fillet)
-		path.QuadTo(pos.X+slope, pos.Y, pos.X+slope+fillet, pos.Y)
+		path.MoveTo(pos.X+slope+fillet, pos.Y)
 		path.LineTo(pos.X+size.X-slope-fillet, pos.Y)
-		path.QuadTo(pos.X+size.X-slope, pos.Y, pos.X+size.X-slope, pos.Y+fillet)
 	} else {
 		path.MoveTo(pos.X+slope, pos.Y)
 		path.LineTo(pos.X+size.X-slope, pos.Y)


### PR DESCRIPTION
## Summary
- remove curved highlight lines at tab corners

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687a13cde214832a888c298042eb9314