### PR TITLE
Use shader for soft drop shadows

### DIFF
--- a/render.go
+++ b/render.go
@@ -991,6 +991,11 @@ func drawDropShadow(screen *ebiten.Image, rrect *roundRect, size float32, col Co
         return
     }
 
+    if softShadowShader != nil {
+        drawSoftDropShadow(screen, rrect, size, col)
+        return
+    }
+
     shadow := *rrect
     shadow.Position.X += size
     shadow.Position.Y += size
@@ -1000,6 +1005,27 @@ func drawDropShadow(screen *ebiten.Image, rrect *roundRect, size float32, col Co
     shadow.Color = col
     shadow.Filled = true
     drawRoundRect(screen, &shadow)
+}
+
+// drawSoftDropShadow renders a soft drop shadow for the given rounded rectangle
+// using an Ebiten shader. The shadow fades outward by the specified size.
+func drawSoftDropShadow(screen *ebiten.Image, rrect *roundRect, size float32, col Color) {
+    w := int(rrect.Size.X + size*2)
+    h := int(rrect.Size.Y + size*2)
+    if w <= 0 || h <= 0 {
+        return
+    }
+
+    op := &ebiten.DrawRectShaderOptions{}
+    op.GeoM.Translate(float64(rrect.Position.X-size), float64(rrect.Position.Y-size))
+    op.Uniforms = map[string]any{
+        "RectSize":   []float32{rrect.Size.X, rrect.Size.Y},
+        "Fillet":     rrect.Fillet,
+        "ShadowSize": size,
+        "ShadowColor": []float32{float32(col.R) / 255, float32(col.G) / 255, float32(col.B) / 255, float32(col.A) / 255},
+    }
+
+    screen.DrawRectShader(w, h, softShadowShader, op)
 }
 
 func drawRoundRect(screen *ebiten.Image, rrect *roundRect) {

--- a/shaders/drop_shadow.kage
+++ b/shaders/drop_shadow.kage
@@ -1,9 +1,10 @@
 package main
 
-uniform RectSize vec2
-uniform Fillet float
-uniform ShadowSize float
-uniform ShadowColor vec4
+// Uniform inputs
+var RectSize vec2
+var Fillet float
+var ShadowSize float
+var ShadowColor vec4
 
 func roundRectSDF(p vec2, size vec2, r float) float {
     q := abs(p - size*0.5) - (size*0.5 - vec2(r, r))

--- a/shaders/drop_shadow.kage
+++ b/shaders/drop_shadow.kage
@@ -1,5 +1,7 @@
 package main
 
+//kage:unit pixels
+
 // Uniform inputs
 var RectSize vec2
 var Fillet float
@@ -7,16 +9,16 @@ var ShadowSize float
 var ShadowColor vec4
 
 func roundRectSDF(p vec2, size vec2, r float) float {
-    q := abs(p - size*0.5) - (size*0.5 - vec2(r, r))
-    return length(max(q, vec2(0.0, 0.0))) + min(max(q.x, q.y), 0.0) - r
+	q := abs(p-size*0.5) - (size*0.5 - vec2(r, r))
+	return length(max(q, vec2(0.0, 0.0))) + min(max(q.x, q.y), 0.0) - r
 }
 
-func Fragment(position vec4, texCoord vec2, col vec4) vec4 {
-    p := position.xy
-    d := roundRectSDF(p - vec2(ShadowSize, ShadowSize), RectSize, Fillet)
-    outside := min(max(d, 0.0), ShadowSize)
-    a := (ShadowSize - outside) / ShadowSize
-    a *= step(0.0, d)
-    a = smoothstep(0.0, 1.0, a)
-    return vec4(ShadowColor.rgb, ShadowColor.a * a)
+func Fragment(dstPos vec4, srcPos vec2, col vec4) vec4 {
+	p := dstPos.xy
+	d := roundRectSDF(p-vec2(ShadowSize, ShadowSize), RectSize, Fillet)
+	outside := min(max(d, 0.0), ShadowSize)
+	a := (ShadowSize - outside) / ShadowSize
+	a *= step(0.0, d)
+	a = smoothstep(0.0, 1.0, a)
+	return vec4(ShadowColor.rgb, ShadowColor.a*a)
 }

--- a/shaders/drop_shadow.kage
+++ b/shaders/drop_shadow.kage
@@ -1,0 +1,21 @@
+package main
+
+uniform RectSize vec2
+uniform Fillet float
+uniform ShadowSize float
+uniform ShadowColor vec4
+
+func roundRectSDF(p vec2, size vec2, r float) float {
+    q := abs(p - size*0.5) - (size*0.5 - vec2(r, r))
+    return length(max(q, vec2(0.0, 0.0))) + min(max(q.x, q.y), 0.0) - r
+}
+
+func Fragment(position vec4, texCoord vec2, col vec4) vec4 {
+    p := position.xy
+    d := roundRectSDF(p - vec2(ShadowSize, ShadowSize), RectSize, Fillet)
+    outside := min(max(d, 0.0), ShadowSize)
+    a := (ShadowSize - outside) / ShadowSize
+    a *= step(0.0, d)
+    a = smoothstep(0.0, 1.0, a)
+    return vec4(ShadowColor.rgb, ShadowColor.a * a)
+}

--- a/shadow_shader.go
+++ b/shadow_shader.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	_ "embed"
+
+	"github.com/hajimehoshi/ebiten/v2"
+)
+
+var softShadowShader *ebiten.Shader
+
+//go:embed shaders/drop_shadow.kage
+var softShadowShaderSrc []byte
+
+func init() {
+	var err error
+	softShadowShader, err = ebiten.NewShader(softShadowShaderSrc)
+	if err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
## Summary
- add `shadow_shader.go` and shader source `shaders/drop_shadow.kage`
- render drop shadows using a shader for a soft edge

## Testing
- `./scripts/setup.sh`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687aeb6b9ebc832aac37975e10db9e6f