### PR TITLE
Improve agent docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,20 @@
 # Agent Instructions
 
-To compile and test this project, run the setup script once to install system dependencies:
+Use the setup script once to install required system packages:
 
 ```sh
 ./scripts/setup.sh
 ```
 
-Then run the following checks before committing any changes:
+Before committing new changes run the following checks from the repository root:
 
 ```sh
 go vet ./...
 go build ./...
 ```
+
+Run `gofmt -w` on all Go source files you modify to keep formatting consistent.
+
+Update any relevant documentation (README.md, api.md, etc.) when behavior,
+commands or public APIs change so docs stay in sync with the code.
+

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ go vet ./...
 go build ./...
 ```
 
+Format modified Go files before committing:
+
+```sh
+gofmt -w <files>
+```
+
 ## Running the Demo
 
 The demonstration application lives under `cmd/demo`. You can run it directly using `go run` or build a binary:


### PR DESCRIPTION
## Summary
- document `gofmt` and doc updates in `AGENTS.md`
- add a matching note in the README

## Testing
- `./scripts/setup.sh` *(fails: `sudo: aptitude: command not found`)*
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687c9b09322c832ab8da9f6009cb18ee