### PR TITLE
Add new theme examples

### DIFF
--- a/eui/themes/colors/NeonNight.json
+++ b/eui/themes/colors/NeonNight.json
@@ -1,0 +1,100 @@
+{
+  "Comment": "Neon inspired dark theme",
+  "Colors": {
+    "background": "240,0.2,0.10",
+    "panel": "240,0.3,0.15",
+    "text": "0,0,1",
+    "outline": "300,1,0.9",
+    "button": "240,0.4,0.30",
+    "hover": "240,0.4,0.50",
+    "accent": "180,1,0.80",
+    "disabled": "0,0,0.30"
+  },
+  "Window": {
+    "Padding": 8,
+    "BGColor": "background",
+    "TitleBGColor": "panel",
+    "TitleColor": "text",
+    "BorderColor": "panel",
+    "SizeTabColor": "outline",
+    "DragbarColor": "panel",
+    "HoverTitleColor": "text",
+    "HoverColor": "hover",
+    "ActiveColor": "accent",
+    "TitleTextColor": "text"
+  },
+  "Button": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Text": {
+    "TextColor": "text",
+    "Color": "disabled",
+    "HoverColor": "disabled",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Checkbox": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Radio": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Input": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Slider": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SliderFilled": "accent",
+    "SelectedColor": "disabled"
+  },
+  "Dropdown": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "accent",
+    "MaxVisible": 5
+  },
+  "Tab": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "SelectedColor": "hover"
+  },
+  "RecommendedLayout": "NeoRounded"
+}

--- a/eui/themes/colors/OceanWave.json
+++ b/eui/themes/colors/OceanWave.json
@@ -1,0 +1,100 @@
+{
+  "Comment": "Cool blues with sea vibe",
+  "Colors": {
+    "background": "210,0.4,0.12",
+    "panel": "210,0.35,0.18",
+    "text": "0,0,1",
+    "outline": "190,0.65,0.60",
+    "button": "210,0.5,0.30",
+    "hover": "210,0.5,0.45",
+    "accent": "200,0.85,0.80",
+    "disabled": "210,0.15,0.25"
+  },
+  "Window": {
+    "Padding": 8,
+    "BGColor": "background",
+    "TitleBGColor": "panel",
+    "TitleColor": "text",
+    "BorderColor": "panel",
+    "SizeTabColor": "outline",
+    "DragbarColor": "panel",
+    "HoverTitleColor": "text",
+    "HoverColor": "hover",
+    "ActiveColor": "accent",
+    "TitleTextColor": "text"
+  },
+  "Button": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Text": {
+    "TextColor": "text",
+    "Color": "disabled",
+    "HoverColor": "disabled",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Checkbox": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Radio": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Input": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Slider": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SliderFilled": "accent",
+    "SelectedColor": "disabled"
+  },
+  "Dropdown": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "accent",
+    "MaxVisible": 5
+  },
+  "Tab": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "SelectedColor": "hover"
+  },
+  "RecommendedLayout": "MinimalFade"
+}

--- a/eui/themes/colors/SolarFlare.json
+++ b/eui/themes/colors/SolarFlare.json
@@ -1,0 +1,100 @@
+{
+  "Comment": "Warm orange/yellow theme",
+  "Colors": {
+    "background": "40,0.9,0.95",
+    "panel": "35,0.85,0.90",
+    "text": "0,0,0",
+    "outline": "25,1,0.40",
+    "button": "25,0.85,0.75",
+    "hover": "25,0.85,0.85",
+    "accent": "50,1,1",
+    "disabled": "0,0,0.4"
+  },
+  "Window": {
+    "Padding": 8,
+    "BGColor": "background",
+    "TitleBGColor": "panel",
+    "TitleColor": "text",
+    "BorderColor": "panel",
+    "SizeTabColor": "outline",
+    "DragbarColor": "panel",
+    "HoverTitleColor": "text",
+    "HoverColor": "hover",
+    "ActiveColor": "accent",
+    "TitleTextColor": "text"
+  },
+  "Button": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Text": {
+    "TextColor": "text",
+    "Color": "disabled",
+    "HoverColor": "disabled",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Checkbox": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Radio": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Input": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Slider": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SliderFilled": "accent",
+    "SelectedColor": "disabled"
+  },
+  "Dropdown": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "accent",
+    "MaxVisible": 5
+  },
+  "Tab": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "SelectedColor": "hover"
+  },
+  "RecommendedLayout": "SharpEdge"
+}

--- a/eui/themes/layout/MinimalFade.json
+++ b/eui/themes/layout/MinimalFade.json
@@ -1,0 +1,63 @@
+{
+  "SliderValueGap": 14,
+  "DropdownArrowPad": 4,
+  "TextPadding": 4,
+  "Fillet": {
+    "Window": 2,
+    "Button": 2,
+    "Text": 2,
+    "Checkbox": 2,
+    "Radio": 2,
+    "Input": 2,
+    "Slider": 2,
+    "Dropdown": 2,
+    "Tab": 2
+  },
+  "Border": {
+    "Window": 0,
+    "Button": 0,
+    "Text": 0,
+    "Checkbox": 0,
+    "Radio": 0,
+    "Input": 0,
+    "Slider": 0,
+    "Dropdown": 0,
+    "Tab": 0
+  },
+  "BorderPad": {
+    "Window": 0,
+    "Button": 2,
+    "Text": 2,
+    "Checkbox": 2,
+    "Radio": 2,
+    "Input": 2,
+    "Slider": 2,
+    "Dropdown": 2,
+    "Tab": 2
+  },
+  "Filled": {
+    "Window": true,
+    "Button": true,
+    "Text": true,
+    "Checkbox": true,
+    "Radio": true,
+    "Input": true,
+    "Slider": true,
+    "Dropdown": true,
+    "Tab": true
+  },
+  "Outlined": {
+    "Window": false,
+    "Button": false,
+    "Text": false,
+    "Checkbox": false,
+    "Radio": false,
+    "Input": false,
+    "Slider": false,
+    "Dropdown": false,
+    "Tab": false
+  },
+  "ActiveOutline": {
+    "Tab": true
+  }
+}

--- a/eui/themes/layout/NeoRounded.json
+++ b/eui/themes/layout/NeoRounded.json
@@ -1,0 +1,63 @@
+{
+  "SliderValueGap": 20,
+  "DropdownArrowPad": 10,
+  "TextPadding": 10,
+  "Fillet": {
+    "Window": 4,
+    "Button": 12,
+    "Text": 0,
+    "Checkbox": 12,
+    "Radio": 12,
+    "Input": 8,
+    "Slider": 8,
+    "Dropdown": 12,
+    "Tab": 12
+  },
+  "Border": {
+    "Window": 1,
+    "Button": 0,
+    "Text": 0,
+    "Checkbox": 0,
+    "Radio": 0,
+    "Input": 0,
+    "Slider": 0,
+    "Dropdown": 0,
+    "Tab": 0
+  },
+  "BorderPad": {
+    "Window": 0,
+    "Button": 6,
+    "Text": 6,
+    "Checkbox": 6,
+    "Radio": 6,
+    "Input": 6,
+    "Slider": 6,
+    "Dropdown": 6,
+    "Tab": 6
+  },
+  "Filled": {
+    "Window": true,
+    "Button": true,
+    "Text": false,
+    "Checkbox": true,
+    "Radio": true,
+    "Input": true,
+    "Slider": true,
+    "Dropdown": true,
+    "Tab": true
+  },
+  "Outlined": {
+    "Window": true,
+    "Button": false,
+    "Text": false,
+    "Checkbox": false,
+    "Radio": false,
+    "Input": false,
+    "Slider": false,
+    "Dropdown": false,
+    "Tab": false
+  },
+  "ActiveOutline": {
+    "Tab": true
+  }
+}

--- a/eui/themes/layout/SharpEdge.json
+++ b/eui/themes/layout/SharpEdge.json
@@ -1,0 +1,63 @@
+{
+  "SliderValueGap": 12,
+  "DropdownArrowPad": 6,
+  "TextPadding": 6,
+  "Fillet": {
+    "Window": 0,
+    "Button": 0,
+    "Text": 0,
+    "Checkbox": 0,
+    "Radio": 0,
+    "Input": 0,
+    "Slider": 0,
+    "Dropdown": 0,
+    "Tab": 0
+  },
+  "Border": {
+    "Window": 2,
+    "Button": 1,
+    "Text": 1,
+    "Checkbox": 1,
+    "Radio": 1,
+    "Input": 1,
+    "Slider": 0,
+    "Dropdown": 1,
+    "Tab": 1
+  },
+  "BorderPad": {
+    "Window": 0,
+    "Button": 5,
+    "Text": 5,
+    "Checkbox": 5,
+    "Radio": 5,
+    "Input": 5,
+    "Slider": 5,
+    "Dropdown": 5,
+    "Tab": 5
+  },
+  "Filled": {
+    "Window": false,
+    "Button": false,
+    "Text": false,
+    "Checkbox": false,
+    "Radio": false,
+    "Input": false,
+    "Slider": false,
+    "Dropdown": false,
+    "Tab": false
+  },
+  "Outlined": {
+    "Window": true,
+    "Button": true,
+    "Text": true,
+    "Checkbox": true,
+    "Radio": true,
+    "Input": true,
+    "Slider": true,
+    "Dropdown": true,
+    "Tab": true
+  },
+  "ActiveOutline": {
+    "Tab": true
+  }
+}


### PR DESCRIPTION
## Summary
- add three creative color themes: NeonNight, SolarFlare and OceanWave
- add three custom layout themes: NeoRounded, SharpEdge and MinimalFade

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687ca2dd50a4832a9e0a50e354cd94e6