### PR TITLE
Add new modern color and layout themes

### DIFF
--- a/eui/themes/colors/ConcreteGray.json
+++ b/eui/themes/colors/ConcreteGray.json
@@ -1,0 +1,100 @@
+{
+  "Comment": "Sleek gray palette with blue accent",
+  "Colors": {
+    "background": "220,0.05,0.20",
+    "panel": "220,0.05,0.25",
+    "text": "0,0,1",
+    "outline": "210,0.10,0.50",
+    "button": "220,0.05,0.30",
+    "hover": "220,0.05,0.40",
+    "accent": "210,0.60,0.70",
+    "disabled": "220,0.05,0.25"
+  },
+  "Window": {
+    "Padding": 8,
+    "BGColor": "background",
+    "TitleBGColor": "panel",
+    "TitleColor": "text",
+    "BorderColor": "panel",
+    "SizeTabColor": "outline",
+    "DragbarColor": "panel",
+    "HoverTitleColor": "text",
+    "HoverColor": "hover",
+    "ActiveColor": "accent",
+    "TitleTextColor": "text"
+  },
+  "Button": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Text": {
+    "TextColor": "text",
+    "Color": "disabled",
+    "HoverColor": "disabled",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Checkbox": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Radio": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Input": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Slider": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SliderFilled": "accent",
+    "SelectedColor": "disabled"
+  },
+  "Dropdown": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "accent",
+    "MaxVisible": 5
+  },
+  "Tab": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "SelectedColor": "hover"
+  },
+  "RecommendedLayout": "CleanLines"
+}

--- a/eui/themes/colors/CorporateBlue.json
+++ b/eui/themes/colors/CorporateBlue.json
@@ -1,0 +1,100 @@
+{
+  "Comment": "Modern business style blue theme",
+  "Colors": {
+    "background": "210,0.30,0.95",
+    "panel": "210,0.25,0.90",
+    "text": "0,0,0",
+    "outline": "210,0.50,0.50",
+    "button": "210,0.30,0.80",
+    "hover": "210,0.30,0.85",
+    "accent": "200,0.80,0.65",
+    "disabled": "210,0.15,0.80"
+  },
+  "Window": {
+    "Padding": 8,
+    "BGColor": "background",
+    "TitleBGColor": "panel",
+    "TitleColor": "text",
+    "BorderColor": "panel",
+    "SizeTabColor": "outline",
+    "DragbarColor": "panel",
+    "HoverTitleColor": "text",
+    "HoverColor": "hover",
+    "ActiveColor": "accent",
+    "TitleTextColor": "text"
+  },
+  "Button": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Text": {
+    "TextColor": "text",
+    "Color": "disabled",
+    "HoverColor": "disabled",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Checkbox": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Radio": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Input": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Slider": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SliderFilled": "accent",
+    "SelectedColor": "disabled"
+  },
+  "Dropdown": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "accent",
+    "MaxVisible": 5
+  },
+  "Tab": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "SelectedColor": "hover"
+  },
+  "RecommendedLayout": "MinimalPro"
+}

--- a/eui/themes/colors/ForestMist.json
+++ b/eui/themes/colors/ForestMist.json
@@ -1,0 +1,100 @@
+{
+  "Comment": "Dark forest greens with a misty accent",
+  "Colors": {
+    "background": "150,0.25,0.14",
+    "panel": "150,0.20,0.18",
+    "text": "0,0,1",
+    "outline": "140,0.40,0.35",
+    "button": "150,0.30,0.30",
+    "hover": "150,0.30,0.45",
+    "accent": "120,0.60,0.70",
+    "disabled": "150,0.15,0.22"
+  },
+  "Window": {
+    "Padding": 8,
+    "BGColor": "background",
+    "TitleBGColor": "panel",
+    "TitleColor": "text",
+    "BorderColor": "panel",
+    "SizeTabColor": "outline",
+    "DragbarColor": "panel",
+    "HoverTitleColor": "text",
+    "HoverColor": "hover",
+    "ActiveColor": "accent",
+    "TitleTextColor": "text"
+  },
+  "Button": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Text": {
+    "TextColor": "text",
+    "Color": "disabled",
+    "HoverColor": "disabled",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Checkbox": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Radio": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Input": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Slider": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SliderFilled": "accent",
+    "SelectedColor": "disabled"
+  },
+  "Dropdown": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "accent",
+    "MaxVisible": 5
+  },
+  "Tab": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "SelectedColor": "hover"
+  },
+  "RecommendedLayout": "SoftRound"
+}

--- a/eui/themes/colors/HighContrast.json
+++ b/eui/themes/colors/HighContrast.json
@@ -1,0 +1,100 @@
+{
+  "Comment": "Black and white with bold yellow accent",
+  "Colors": {
+    "background": "0,0,0",
+    "panel": "0,0,0.15",
+    "text": "0,0,1",
+    "outline": "0,0,1",
+    "button": "0,0,0.25",
+    "hover": "0,0,0.40",
+    "accent": "60,1,1",
+    "disabled": "0,0,0.30"
+  },
+  "Window": {
+    "Padding": 8,
+    "BGColor": "background",
+    "TitleBGColor": "panel",
+    "TitleColor": "text",
+    "BorderColor": "panel",
+    "SizeTabColor": "outline",
+    "DragbarColor": "panel",
+    "HoverTitleColor": "text",
+    "HoverColor": "hover",
+    "ActiveColor": "accent",
+    "TitleTextColor": "text"
+  },
+  "Button": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Text": {
+    "TextColor": "text",
+    "Color": "disabled",
+    "HoverColor": "disabled",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Checkbox": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Radio": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Input": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Slider": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SliderFilled": "accent",
+    "SelectedColor": "disabled"
+  },
+  "Dropdown": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "accent",
+    "MaxVisible": 5
+  },
+  "Tab": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "SelectedColor": "hover"
+  },
+  "RecommendedLayout": "SolidBlock"
+}

--- a/eui/themes/colors/SlateNight.json
+++ b/eui/themes/colors/SlateNight.json
@@ -1,0 +1,100 @@
+{
+  "Comment": "Refined dark slate with muted purple accent",
+  "Colors": {
+    "background": "230,0.20,0.12",
+    "panel": "230,0.18,0.18",
+    "text": "0,0,1",
+    "outline": "230,0.12,0.40",
+    "button": "230,0.22,0.28",
+    "hover": "230,0.22,0.40",
+    "accent": "260,0.50,0.70",
+    "disabled": "230,0.15,0.20"
+  },
+  "Window": {
+    "Padding": 8,
+    "BGColor": "background",
+    "TitleBGColor": "panel",
+    "TitleColor": "text",
+    "BorderColor": "panel",
+    "SizeTabColor": "outline",
+    "DragbarColor": "panel",
+    "HoverTitleColor": "text",
+    "HoverColor": "hover",
+    "ActiveColor": "accent",
+    "TitleTextColor": "text"
+  },
+  "Button": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Text": {
+    "TextColor": "text",
+    "Color": "disabled",
+    "HoverColor": "disabled",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Checkbox": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Radio": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Input": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Slider": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SliderFilled": "accent",
+    "SelectedColor": "disabled"
+  },
+  "Dropdown": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "accent",
+    "MaxVisible": 5
+  },
+  "Tab": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "SelectedColor": "hover"
+  },
+  "RecommendedLayout": "MonoEdge"
+}

--- a/eui/themes/colors/SoftNeutral.json
+++ b/eui/themes/colors/SoftNeutral.json
@@ -1,0 +1,100 @@
+{
+  "Comment": "Light neutral tones with soft accent",
+  "Colors": {
+    "background": "40,0.10,0.97",
+    "panel": "40,0.08,0.92",
+    "text": "0,0,0",
+    "outline": "30,0.20,0.50",
+    "button": "40,0.08,0.85",
+    "hover": "40,0.08,0.90",
+    "accent": "30,0.50,0.70",
+    "disabled": "40,0.05,0.70"
+  },
+  "Window": {
+    "Padding": 8,
+    "BGColor": "background",
+    "TitleBGColor": "panel",
+    "TitleColor": "text",
+    "BorderColor": "panel",
+    "SizeTabColor": "outline",
+    "DragbarColor": "panel",
+    "HoverTitleColor": "text",
+    "HoverColor": "hover",
+    "ActiveColor": "accent",
+    "TitleTextColor": "text"
+  },
+  "Button": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Text": {
+    "TextColor": "text",
+    "Color": "disabled",
+    "HoverColor": "disabled",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Checkbox": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Radio": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Input": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "disabled"
+  },
+  "Slider": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SliderFilled": "accent",
+    "SelectedColor": "disabled"
+  },
+  "Dropdown": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "DisabledColor": "disabled",
+    "SelectedColor": "accent",
+    "MaxVisible": 5
+  },
+  "Tab": {
+    "TextColor": "text",
+    "Color": "button",
+    "HoverColor": "hover",
+    "ClickColor": "accent",
+    "OutlineColor": "outline",
+    "SelectedColor": "hover"
+  },
+  "RecommendedLayout": "ThinOutline"
+}

--- a/eui/themes/layout/CleanLines.json
+++ b/eui/themes/layout/CleanLines.json
@@ -1,0 +1,63 @@
+{
+  "SliderValueGap": 16,
+  "DropdownArrowPad": 6,
+  "TextPadding": 6,
+  "Fillet": {
+    "Window": 0,
+    "Button": 2,
+    "Text": 2,
+    "Checkbox": 2,
+    "Radio": 2,
+    "Input": 2,
+    "Slider": 2,
+    "Dropdown": 2,
+    "Tab": 2
+  },
+  "Border": {
+    "Window": 1,
+    "Button": 1,
+    "Text": 1,
+    "Checkbox": 1,
+    "Radio": 1,
+    "Input": 1,
+    "Slider": 1,
+    "Dropdown": 1,
+    "Tab": 1
+  },
+  "BorderPad": {
+    "Window": 4,
+    "Button": 4,
+    "Text": 4,
+    "Checkbox": 4,
+    "Radio": 4,
+    "Input": 4,
+    "Slider": 4,
+    "Dropdown": 4,
+    "Tab": 4
+  },
+  "Filled": {
+    "Window": true,
+    "Button": true,
+    "Text": true,
+    "Checkbox": true,
+    "Radio": true,
+    "Input": true,
+    "Slider": true,
+    "Dropdown": true,
+    "Tab": true
+  },
+  "Outlined": {
+    "Window": true,
+    "Button": true,
+    "Text": true,
+    "Checkbox": true,
+    "Radio": true,
+    "Input": true,
+    "Slider": true,
+    "Dropdown": true,
+    "Tab": true
+  },
+  "ActiveOutline": {
+    "Tab": true
+  }
+}

--- a/eui/themes/layout/MinimalPro.json
+++ b/eui/themes/layout/MinimalPro.json
@@ -1,0 +1,63 @@
+{
+  "SliderValueGap": 18,
+  "DropdownArrowPad": 8,
+  "TextPadding": 8,
+  "Fillet": {
+    "Window": 4,
+    "Button": 4,
+    "Text": 0,
+    "Checkbox": 4,
+    "Radio": 4,
+    "Input": 4,
+    "Slider": 4,
+    "Dropdown": 4,
+    "Tab": 4
+  },
+  "Border": {
+    "Window": 0,
+    "Button": 0,
+    "Text": 0,
+    "Checkbox": 0,
+    "Radio": 0,
+    "Input": 0,
+    "Slider": 0,
+    "Dropdown": 0,
+    "Tab": 0
+  },
+  "BorderPad": {
+    "Window": 4,
+    "Button": 4,
+    "Text": 4,
+    "Checkbox": 4,
+    "Radio": 4,
+    "Input": 4,
+    "Slider": 4,
+    "Dropdown": 4,
+    "Tab": 4
+  },
+  "Filled": {
+    "Window": true,
+    "Button": true,
+    "Text": true,
+    "Checkbox": true,
+    "Radio": true,
+    "Input": true,
+    "Slider": true,
+    "Dropdown": true,
+    "Tab": true
+  },
+  "Outlined": {
+    "Window": false,
+    "Button": false,
+    "Text": false,
+    "Checkbox": false,
+    "Radio": false,
+    "Input": false,
+    "Slider": false,
+    "Dropdown": false,
+    "Tab": false
+  },
+  "ActiveOutline": {
+    "Tab": true
+  }
+}

--- a/eui/themes/layout/MonoEdge.json
+++ b/eui/themes/layout/MonoEdge.json
@@ -1,0 +1,63 @@
+{
+  "SliderValueGap": 16,
+  "DropdownArrowPad": 8,
+  "TextPadding": 8,
+  "Fillet": {
+    "Window": 6,
+    "Button": 6,
+    "Text": 6,
+    "Checkbox": 6,
+    "Radio": 6,
+    "Input": 6,
+    "Slider": 6,
+    "Dropdown": 6,
+    "Tab": 6
+  },
+  "Border": {
+    "Window": 1,
+    "Button": 0,
+    "Text": 0,
+    "Checkbox": 0,
+    "Radio": 0,
+    "Input": 0,
+    "Slider": 0,
+    "Dropdown": 0,
+    "Tab": 0
+  },
+  "BorderPad": {
+    "Window": 4,
+    "Button": 4,
+    "Text": 4,
+    "Checkbox": 4,
+    "Radio": 4,
+    "Input": 4,
+    "Slider": 4,
+    "Dropdown": 4,
+    "Tab": 4
+  },
+  "Filled": {
+    "Window": true,
+    "Button": true,
+    "Text": true,
+    "Checkbox": true,
+    "Radio": true,
+    "Input": true,
+    "Slider": true,
+    "Dropdown": true,
+    "Tab": true
+  },
+  "Outlined": {
+    "Window": false,
+    "Button": false,
+    "Text": false,
+    "Checkbox": false,
+    "Radio": false,
+    "Input": false,
+    "Slider": false,
+    "Dropdown": false,
+    "Tab": false
+  },
+  "ActiveOutline": {
+    "Tab": true
+  }
+}

--- a/eui/themes/layout/SoftRound.json
+++ b/eui/themes/layout/SoftRound.json
@@ -1,0 +1,63 @@
+{
+  "SliderValueGap": 16,
+  "DropdownArrowPad": 8,
+  "TextPadding": 8,
+  "Fillet": {
+    "Window": 10,
+    "Button": 10,
+    "Text": 4,
+    "Checkbox": 10,
+    "Radio": 10,
+    "Input": 10,
+    "Slider": 10,
+    "Dropdown": 10,
+    "Tab": 10
+  },
+  "Border": {
+    "Window": 1,
+    "Button": 1,
+    "Text": 1,
+    "Checkbox": 1,
+    "Radio": 1,
+    "Input": 1,
+    "Slider": 1,
+    "Dropdown": 1,
+    "Tab": 1
+  },
+  "BorderPad": {
+    "Window": 4,
+    "Button": 4,
+    "Text": 4,
+    "Checkbox": 4,
+    "Radio": 4,
+    "Input": 4,
+    "Slider": 4,
+    "Dropdown": 4,
+    "Tab": 4
+  },
+  "Filled": {
+    "Window": true,
+    "Button": true,
+    "Text": true,
+    "Checkbox": true,
+    "Radio": true,
+    "Input": true,
+    "Slider": true,
+    "Dropdown": true,
+    "Tab": true
+  },
+  "Outlined": {
+    "Window": true,
+    "Button": true,
+    "Text": true,
+    "Checkbox": true,
+    "Radio": true,
+    "Input": true,
+    "Slider": true,
+    "Dropdown": true,
+    "Tab": true
+  },
+  "ActiveOutline": {
+    "Tab": true
+  }
+}

--- a/eui/themes/layout/SolidBlock.json
+++ b/eui/themes/layout/SolidBlock.json
@@ -1,0 +1,63 @@
+{
+  "SliderValueGap": 16,
+  "DropdownArrowPad": 8,
+  "TextPadding": 8,
+  "Fillet": {
+    "Window": 0,
+    "Button": 0,
+    "Text": 0,
+    "Checkbox": 0,
+    "Radio": 0,
+    "Input": 0,
+    "Slider": 0,
+    "Dropdown": 0,
+    "Tab": 0
+  },
+  "Border": {
+    "Window": 2,
+    "Button": 2,
+    "Text": 2,
+    "Checkbox": 2,
+    "Radio": 2,
+    "Input": 2,
+    "Slider": 2,
+    "Dropdown": 2,
+    "Tab": 2
+  },
+  "BorderPad": {
+    "Window": 4,
+    "Button": 4,
+    "Text": 4,
+    "Checkbox": 4,
+    "Radio": 4,
+    "Input": 4,
+    "Slider": 4,
+    "Dropdown": 4,
+    "Tab": 4
+  },
+  "Filled": {
+    "Window": true,
+    "Button": true,
+    "Text": true,
+    "Checkbox": true,
+    "Radio": true,
+    "Input": true,
+    "Slider": true,
+    "Dropdown": true,
+    "Tab": true
+  },
+  "Outlined": {
+    "Window": true,
+    "Button": true,
+    "Text": true,
+    "Checkbox": true,
+    "Radio": true,
+    "Input": true,
+    "Slider": true,
+    "Dropdown": true,
+    "Tab": true
+  },
+  "ActiveOutline": {
+    "Tab": true
+  }
+}

--- a/eui/themes/layout/ThinOutline.json
+++ b/eui/themes/layout/ThinOutline.json
@@ -1,0 +1,63 @@
+{
+  "SliderValueGap": 14,
+  "DropdownArrowPad": 6,
+  "TextPadding": 6,
+  "Fillet": {
+    "Window": 2,
+    "Button": 2,
+    "Text": 2,
+    "Checkbox": 2,
+    "Radio": 2,
+    "Input": 2,
+    "Slider": 2,
+    "Dropdown": 2,
+    "Tab": 2
+  },
+  "Border": {
+    "Window": 1,
+    "Button": 1,
+    "Text": 1,
+    "Checkbox": 1,
+    "Radio": 1,
+    "Input": 1,
+    "Slider": 1,
+    "Dropdown": 1,
+    "Tab": 1
+  },
+  "BorderPad": {
+    "Window": 3,
+    "Button": 3,
+    "Text": 3,
+    "Checkbox": 3,
+    "Radio": 3,
+    "Input": 3,
+    "Slider": 3,
+    "Dropdown": 3,
+    "Tab": 3
+  },
+  "Filled": {
+    "Window": true,
+    "Button": true,
+    "Text": true,
+    "Checkbox": true,
+    "Radio": true,
+    "Input": true,
+    "Slider": true,
+    "Dropdown": true,
+    "Tab": true
+  },
+  "Outlined": {
+    "Window": true,
+    "Button": true,
+    "Text": true,
+    "Checkbox": true,
+    "Radio": true,
+    "Input": true,
+    "Slider": true,
+    "Dropdown": true,
+    "Tab": true
+  },
+  "ActiveOutline": {
+    "Tab": true
+  }
+}


### PR DESCRIPTION
## Summary
- add 6 new color theme JSONs: ConcreteGray, CorporateBlue, ForestMist, SlateNight, SoftNeutral, HighContrast
- add 6 new layout JSONs: CleanLines, MinimalPro, SoftRound, MonoEdge, ThinOutline, SolidBlock

## Testing
- `./scripts/setup.sh`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687ca54601a0832a83566f938562a46c