### PR TITLE
Add theme documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ go build -o demo ./cmd/demo
 
 ## Customization
 
-The library loads the built in `AccentDark` color theme, `RoundHybrid` layout and a default font automatically. To use your own files enable `eui.AutoReload` and load them explicitly:
+The library loads the built in `AccentDark` color theme, `RoundHybrid` layout and a default font automatically. Additional examples live under [`eui/themes`](eui/themes). Use `eui.ListThemes()` and `eui.ListLayouts()` to see the names that are available. To try a different look enable `eui.AutoReload` and load files explicitly:
 
 ```go
 // var ttf []byte
@@ -48,6 +48,8 @@ The library loads the built in `AccentDark` color theme, `RoundHybrid` layout an
 // _ = eui.LoadTheme("MyTheme")
 // _ = eui.LoadLayout("MyLayout")
 ```
+
+See [themes/README.md](eui/themes/README.md) for a list of the bundled schemes and details on creating your own.
 
 ## Project Layout
 

--- a/api.md
+++ b/api.md
@@ -73,8 +73,8 @@ It is currently in a pre‑alpha state and the API may change at any time.
 - `SetFontSource(src *text.GoTextFaceSource)`
 - `FontSource() *text.GoTextFaceSource`
 - `EnsureFontSource(ttf []byte) error`
-- `ListThemes() ([]string, error)`
-- `ListLayouts() ([]string, error)`
+- `ListThemes() ([]string, error)` – list the bundled color theme names
+- `ListLayouts() ([]string, error)` – list the bundled layout theme names
 - `CurrentThemeName() string`
 - `SetCurrentThemeName(name string)`
 - `CurrentLayoutName() string`

--- a/eui/themes/README.md
+++ b/eui/themes/README.md
@@ -1,0 +1,92 @@
+# Themes
+
+This directory holds the built-in color and layout themes used by EUI. Themes are JSON files that control the appearance and spacing of all widgets. You can load them at runtime or create your own variants.
+
+## Color Themes
+
+Color themes live under `themes/colors`. Each file defines a `Colors` map followed by style blocks for each widget type. Colors may be written as `#RRGGBBAA` hexadecimal strings or as HSV triples (`h,s,v`). Entries in the `Colors` map can be referenced by name in later fields.
+
+### Structure
+
+```json
+{
+  "Comment": "Optional description",
+  "Colors": {
+    "background": "210,0.16,0.15",
+    "panel": "214.3,0.15,0.19",
+    "accent": "200.6,0.74,0.91"
+  },
+  "Window": {
+    "Padding": 8,
+    "BGColor": "background",
+    "TitleBGColor": "panel",
+    "ActiveColor": "accent"
+  },
+  "Button": { "TextColor": "accent", "Color": "panel" },
+  ...
+  "RecommendedLayout": "RoundHybrid"
+}
+```
+
+Each widget block (`Window`, `Button`, `Text`, `Checkbox`, `Radio`, `Input`, `Slider`, `Dropdown`, `Tab`) accepts the following fields:
+
+- `TextColor` – color used for text labels
+- `Color` – main background fill
+- `HoverColor` – color when the pointer is over the widget
+- `ClickColor` – color when the widget is clicked
+- `OutlineColor` – color of the outline if enabled
+- `DisabledColor` – color when the widget is disabled
+- `SelectedColor` – color for selected state (tabs, sliders, dropdowns)
+- `MaxVisible` – for dropdowns, the maximum visible entries
+
+The `Window` block also supports `TitleColor`, `TitleBGColor`, `BorderColor`, `SizeTabColor`, `DragbarColor`, `HoverTitleColor`, `HoverColor`, `ActiveColor` and `TitleTextColor`.
+
+`RecommendedLayout` hints at a layout theme that pairs well with the color scheme.
+
+## Layout Themes
+
+Layout themes are stored in `themes/layout`. They modify padding, border radius and other geometry.
+
+### Structure
+
+```json
+{
+  "SliderValueGap": 16,
+  "DropdownArrowPad": 8,
+  "TextPadding": 8,
+  "Fillet": { "Button": 8, "Input": 4 },
+  "Border": { "Button": 1 },
+  "BorderPad": { "Button": 4 },
+  "Filled": { "Button": true },
+  "Outlined": { "Button": true },
+  "ActiveOutline": { "Tab": true }
+}
+```
+
+- `SliderValueGap` – space between the slider knob and value text
+- `DropdownArrowPad` – padding before the dropdown arrow icon
+- `TextPadding` – internal padding used by text widgets
+- `Fillet` – corner rounding radius per widget
+- `Border` – border width around widgets
+- `BorderPad` – space between the border and widget content
+- `Filled` – whether the widget background is filled
+- `Outlined` – whether an outline is drawn
+- `ActiveOutline` – highlight outline when active (tabs)
+
+## Built-in Themes
+
+Color themes:
+`AccentDark`, `AccentLight`, `Black`, `ConcreteGray`, `CorporateBlue`, `ForestMist`, `HighContrast`, `NeonNight`, `OceanWave`, `SlateNight`, `SoftNeutral`, `SolarFlare`.
+
+Layout themes:
+`CleanLines`, `MinimalFade`, `MinimalPro`, `MonoEdge`, `NeoRounded`, `RoundFlat`, `RoundHybrid`, `RoundOutline`, `SharpEdge`, `SoftRound`, `SolidBlock`, `SquareFlat`, `SquareOutline`, `ThinOutline`.
+
+Use `eui.ListThemes()` and `eui.ListLayouts()` to get these names at runtime.
+
+## Creating Your Own
+
+1. Copy an existing file from `colors` or `layout` as a starting point.
+2. Adjust the values or add new color names in the `Colors` map.
+3. Save the file under the appropriate directory with a new name.
+4. Call `eui.LoadTheme("YourTheme")` and `eui.LoadLayout("YourLayout")` to apply them. Enabling `eui.AutoReload` helps when iterating on your design.
+


### PR DESCRIPTION
## Summary
- document built‑in color and layout themes
- add extensive theming guide under `eui/themes`
- reference the new guide from the main README
- clarify API docs for theme listing helpers

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687ca7067b1c832ab1cc09fc27ca26eb