### PR TITLE
Optimize font rendering

### DIFF
--- a/eui/fontcache.go
+++ b/eui/fontcache.go
@@ -1,0 +1,18 @@
+package eui
+
+import "github.com/hajimehoshi/ebiten/v2/text/v2"
+
+var faceCache = map[float64]*text.GoTextFace{}
+
+func textFace(size float32) *text.GoTextFace {
+	if mplusFaceSource == nil {
+		return &text.GoTextFace{Size: float64(size)}
+	}
+	s := float64(size)
+	if f, ok := faceCache[s]; ok {
+		return f
+	}
+	f := &text.GoTextFace{Source: mplusFaceSource, Size: s}
+	faceCache[s] = f
+	return f
+}

--- a/eui/input.go
+++ b/eui/input.go
@@ -469,7 +469,7 @@ func (item *itemData) setSliderValue(mpos point) {
 	// different ranges have identical track lengths.
 	maxLabel := sliderMaxLabel
 	textSize := (item.FontSize * uiScale) + 2
-	face := &text.GoTextFace{Source: mplusFaceSource, Size: float64(textSize)}
+	face := textFace(textSize)
 	maxW, _ := text.Measure(maxLabel, face, 0)
 
 	knobW := item.AuxSize.X * uiScale

--- a/eui/public.go
+++ b/eui/public.go
@@ -22,7 +22,10 @@ func SetScreenSize(w, h int) {
 func ScreenSize() (int, int) { return screenWidth, screenHeight }
 
 // SetFontSource sets the text face source used when rendering text.
-func SetFontSource(src *text.GoTextFaceSource) { mplusFaceSource = src }
+func SetFontSource(src *text.GoTextFaceSource) {
+	mplusFaceSource = src
+	faceCache = map[float64]*text.GoTextFace{}
+}
 
 // FontSource returns the current text face source.
 func FontSource() *text.GoTextFaceSource { return mplusFaceSource }
@@ -37,6 +40,7 @@ func EnsureFontSource(ttf []byte) error {
 		return err
 	}
 	mplusFaceSource = s
+	faceCache = map[float64]*text.GoTextFace{}
 	return nil
 }
 

--- a/eui/render.go
+++ b/eui/render.go
@@ -102,10 +102,7 @@ func (win *windowData) drawWinTitle(screen *ebiten.Image) {
 		screen.Fill(win.Theme.Window.TitleBGColor)
 
 		textSize := ((win.GetTitleSize()) / 2)
-		face := &text.GoTextFace{
-			Source: mplusFaceSource,
-			Size:   float64(textSize),
-		}
+		face := textFace(textSize)
 
 		skipTitleText := false
 		textWidth, textHeight := text.Measure(win.Title, face, 0)
@@ -306,7 +303,7 @@ func (item *itemData) drawFlows(win *windowData, parent *itemData, offset point,
 		x := offset.X
 		spacing := float32(4) * uiScale
 		for i, tab := range item.Tabs {
-			face := &text.GoTextFace{Source: mplusFaceSource, Size: float64(textSize)}
+			face := textFace(textSize)
 			tw, _ := text.Measure(tab.Name, face, 0)
 			w := float32(tw) + 8
 			if w < float32(defaultTabWidth)*uiScale {
@@ -510,7 +507,7 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 
 	if item.Label != "" {
 		textSize := (item.FontSize * uiScale) + 2
-		face := &text.GoTextFace{Source: mplusFaceSource, Size: float64(textSize)}
+		face := textFace(textSize)
 		loo := text.LayoutOptions{PrimaryAlign: text.AlignStart, SecondaryAlign: text.AlignCenter}
 		tdop := ebiten.DrawImageOptions{}
 		tdop.GeoM.Translate(float64(offset.X), float64(offset.Y+textSize/2))
@@ -576,10 +573,7 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 		}
 
 		textSize := (item.FontSize * uiScale) + 2
-		face := &text.GoTextFace{
-			Source: mplusFaceSource,
-			Size:   float64(textSize),
-		}
+		face := textFace(textSize)
 		loo := text.LayoutOptions{
 			LineSpacing:    1.2,
 			PrimaryAlign:   text.AlignStart,
@@ -636,10 +630,7 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 		}
 
 		textSize := (item.FontSize * uiScale) + 2
-		face := &text.GoTextFace{
-			Source: mplusFaceSource,
-			Size:   float64(textSize),
-		}
+		face := textFace(textSize)
 		loo := text.LayoutOptions{
 			LineSpacing:    1.2,
 			PrimaryAlign:   text.AlignStart,
@@ -682,10 +673,7 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 		}
 
 		textSize := (item.FontSize * uiScale) + 2
-		face := &text.GoTextFace{
-			Source: mplusFaceSource,
-			Size:   float64(textSize),
-		}
+		face := textFace(textSize)
 		loo := text.LayoutOptions{
 			LineSpacing:    0,
 			PrimaryAlign:   text.AlignCenter,
@@ -721,10 +709,7 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 		}
 
 		textSize := (item.FontSize * uiScale) + 2
-		face := &text.GoTextFace{
-			Source: mplusFaceSource,
-			Size:   float64(textSize),
-		}
+		face := textFace(textSize)
 		loo := text.LayoutOptions{
 			LineSpacing:    0,
 			PrimaryAlign:   text.AlignStart,
@@ -771,7 +756,7 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 		}
 
 		textSize := (item.FontSize * uiScale) + 2
-		face := &text.GoTextFace{Source: mplusFaceSource, Size: float64(textSize)}
+		face := textFace(textSize)
 		maxW, _ := text.Measure(maxLabel, face, 0)
 
 		gap := currentLayout.SliderValueGap
@@ -847,7 +832,7 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 		}
 
 		textSize := (item.FontSize * uiScale) + 2
-		face := &text.GoTextFace{Source: mplusFaceSource, Size: float64(textSize)}
+		face := textFace(textSize)
 		loo := text.LayoutOptions{PrimaryAlign: text.AlignStart, SecondaryAlign: text.AlignCenter}
 		tdop := ebiten.DrawImageOptions{}
 		tdop.GeoM.Translate(float64(offset.X+item.BorderPad+item.Padding+currentLayout.TextPadding), float64(offset.Y+maxSize.Y/2))
@@ -906,10 +891,7 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 	} else if item.ItemType == ITEM_TEXT {
 
 		textSize := (item.FontSize * uiScale) + 2
-		face := &text.GoTextFace{
-			Source: mplusFaceSource,
-			Size:   float64(textSize),
-		}
+		face := textFace(textSize)
 		loo := text.LayoutOptions{
 			LineSpacing:    float64(textSize) * 1.2,
 			PrimaryAlign:   text.AlignStart,
@@ -958,7 +940,7 @@ func drawDropdownOptions(item *itemData, offset point, clip rect, screen *ebiten
 	first := int(item.Scroll.Y / optionH)
 	offY := startY - (item.Scroll.Y - float32(first)*optionH)
 	textSize := (item.FontSize * uiScale) + 2
-	face := &text.GoTextFace{Source: mplusFaceSource, Size: float64(textSize)}
+	face := textFace(textSize)
 	loo := text.LayoutOptions{PrimaryAlign: text.AlignStart, SecondaryAlign: text.AlignCenter}
 	drawRect := rect{X0: offset.X, Y0: startY, X1: offset.X + maxSize.X, Y1: startY + optionH*float32(visible)}
 

--- a/eui/util.go
+++ b/eui/util.go
@@ -300,10 +300,7 @@ func (win *windowData) titleTextWidth() point {
 		return point{}
 	}
 	textSize := ((win.GetTitleSize()) / 1.5)
-	face := &text.GoTextFace{
-		Source: mplusFaceSource,
-		Size:   float64(textSize),
-	}
+	face := textFace(textSize)
 	textWidth, textHeight := text.Measure(win.Title, face, 0)
 	return point{X: float32(textWidth), Y: float32(textHeight)}
 }

--- a/eui/util_test.go
+++ b/eui/util_test.go
@@ -119,7 +119,7 @@ func TestSetSliderValue(t *testing.T) {
 	item.setSliderValue(point{X: 42})
 	maxLabel := sliderMaxLabel
 	textSize := (item.FontSize * uiScale) + 2
-	face := &text.GoTextFace{Source: mplusFaceSource, Size: float64(textSize)}
+	face := textFace(textSize)
 	maxW, _ := text.Measure(maxLabel, face, 0)
 	knobW := item.AuxSize.X * uiScale
 	width := item.DrawRect.X1 - item.DrawRect.X0 - knobW - currentLayout.SliderValueGap - float32(maxW)
@@ -148,7 +148,7 @@ func sliderTrackWidth(item *itemData) float32 {
 	// different ranges have equal track lengths.
 	maxLabel := sliderMaxLabel
 	textSize := (item.FontSize * uiScale) + 2
-	face := &text.GoTextFace{Source: mplusFaceSource, Size: float64(textSize)}
+	face := textFace(textSize)
 	maxW, _ := text.Measure(maxLabel, face, 0)
 	knobW := item.AuxSize.X * uiScale
 	width := maxSize.X - knobW - currentLayout.SliderValueGap - float32(maxW)


### PR DESCRIPTION
## Summary
- add `fontcache.go` to reuse text faces
- clear cache whenever font source changes
- use cached `textFace` throughout rendering and tests

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687d5bbc1c38832abe8d1098a6148b7c