### PR TITLE
Add drop shadow toggle and render metrics

### DIFF
--- a/api.md
+++ b/api.md
@@ -41,7 +41,8 @@ It is currently in a pre‑alpha state and the API may change at any time.
 
 ## Variables
 
-- `DebugMode` – when set, additional outlines are rendered for debugging.
+ - `DebugMode` – when set, additional outlines are rendered for debugging.
+ - `DropShadows` – toggle drop shadow rendering for windows and widgets.
 - `ColorWhite`, `ColorBlack`, `ColorRed`, ... – a large palette of predefined
   colors available as variables of type `Color`.
 

--- a/cmd/demo/theme_selector.go
+++ b/cmd/demo/theme_selector.go
@@ -86,6 +86,13 @@ func makeThemeSelector() *eui.WindowData {
 	cw := eui.NewColorWheel(&eui.ItemData{Size: eui.Point{X: 160, Y: 128}})
 	mainFlow.AddItem(cw)
 
+	shadowChk := eui.NewCheckbox(&eui.ItemData{Text: "Drop Shadows", Size: eui.Point{X: 150, Y: 24}, FontSize: 8})
+	shadowChk.Checked = eui.DropShadows
+	shadowChk.Action = func() {
+		eui.DropShadows = shadowChk.Checked
+	}
+	mainFlow.AddItem(shadowChk)
+
 	satSlider = eui.NewSlider(&eui.ItemData{Label: "Color Intensity", Size: eui.Point{X: 128, Y: 24}, MinValue: 0, MaxValue: 1, FontSize: 8})
 	satSlider.Value = float32(eui.AccentSaturation())
 	satSlider.Action = func() {

--- a/eui/glob.go
+++ b/eui/glob.go
@@ -30,6 +30,9 @@ var (
 	// DebugMode enables rendering of debug outlines.
 	DebugMode bool
 
+	// DropShadows controls rendering of drop shadows on windows and widgets.
+	DropShadows bool = true
+
 	whiteImage    = ebiten.NewImage(3, 3)
 	whiteSubImage = whiteImage.SubImage(image.Rect(1, 1, 2, 2)).(*ebiten.Image)
 )

--- a/eui/render.go
+++ b/eui/render.go
@@ -21,9 +21,13 @@ type dropdownRender struct {
 	clip   rect
 }
 
-var pendingDropdowns []dropdownRender
+var (
+	pendingDropdowns []dropdownRender
+	renderMS         float64
+)
 
 func (g *Game) Draw(screen *ebiten.Image) {
+	start := time.Now()
 
 	pendingDropdowns = pendingDropdowns[:0]
 
@@ -43,6 +47,7 @@ func (g *Game) Draw(screen *ebiten.Image) {
 		drawDropdownOptions(dr.item, dr.offset, dr.clip, screen)
 	}
 
+	renderMS = float64(time.Since(start).Microseconds()) / 1000.0
 	drawFPS(screen)
 }
 
@@ -71,7 +76,7 @@ func (win *windowData) Draw(screen *ebiten.Image) {
 }
 
 func (win *windowData) drawBG(screen *ebiten.Image) {
-	if win.ShadowSize > 0 && win.ShadowColor.A > 0 {
+	if DropShadows && win.ShadowSize > 0 && win.ShadowColor.A > 0 {
 		rr := roundRect{
 			Size:     win.GetSize(),
 			Position: win.getPosition(),
@@ -944,7 +949,7 @@ func drawDropdownOptions(item *itemData, offset point, clip rect, screen *ebiten
 	loo := text.LayoutOptions{PrimaryAlign: text.AlignStart, SecondaryAlign: text.AlignCenter}
 	drawRect := rect{X0: offset.X, Y0: startY, X1: offset.X + maxSize.X, Y1: startY + optionH*float32(visible)}
 
-	if item.ShadowSize > 0 && item.ShadowColor.A > 0 {
+	if DropShadows && item.ShadowSize > 0 && item.ShadowColor.A > 0 {
 		rr := roundRect{
 			Size:     point{X: drawRect.X1 - drawRect.X0, Y: drawRect.Y1 - drawRect.Y0},
 			Position: point{X: drawRect.X0, Y: drawRect.Y0},
@@ -1320,7 +1325,7 @@ func drawArrow(screen *ebiten.Image, x0, y0, x1, y1, width float32, col Color) {
 }
 
 func drawFPS(screen *ebiten.Image) {
-	drawFilledRect(screen, 0, 0, 58, 16, color.RGBA{R: 0, G: 0, B: 0, A: 192}, false)
-	buf := fmt.Sprintf("%4v FPS", int(math.Round(ebiten.ActualFPS())))
+	drawFilledRect(screen, 0, 0, 90, 16, color.RGBA{R: 0, G: 0, B: 0, A: 192}, false)
+	buf := fmt.Sprintf("%4v FPS %5.2fms", int(math.Round(ebiten.ActualFPS())), renderMS)
 	ebitenutil.DebugPrintAt(screen, buf, 0, 0)
 }


### PR DESCRIPTION
## Summary
- allow drop shadows to be toggled via new `DropShadows` variable
- record CPU draw time per frame and display it in `drawFPS`
- add drop shadow checkbox to the demo theme window
- document `DropShadows` variable

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687d5ed85e04832a8f0341ababd1e05d