### PR TITLE
Reduce per-frame allocations

### DIFF
--- a/eui/color_wheel.go
+++ b/eui/color_wheel.go
@@ -7,6 +7,8 @@ import (
 	"github.com/hajimehoshi/ebiten/v2"
 )
 
+var sampleOffsets = []float64{0.125, 0.375, 0.625, 0.875}
+
 // colorWheelImage creates an Ebiten image containing a color wheel of the given size.
 // The wheel ranges 0-359 degrees with black at the center and fully saturated
 // color on the outer edge.
@@ -17,14 +19,13 @@ func colorWheelImage(size int) *ebiten.Image {
 	img := ebiten.NewImage(size, size)
 	r := float64(size) / 2
 	// Use a 4x4 grid of subpixel samples for smoother edges
-	offsets := []float64{0.125, 0.375, 0.625, 0.875}
-	maxSamples := len(offsets) * len(offsets)
+	maxSamples := len(sampleOffsets) * len(sampleOffsets)
 	for y := 0; y < size; y++ {
 		for x := 0; x < size; x++ {
 			var rr, gg, bb, aa float64
 			var coverage int
-			for _, oy := range offsets {
-				for _, ox := range offsets {
+			for _, oy := range sampleOffsets {
+				for _, ox := range sampleOffsets {
 					dx := float64(x) + ox - r
 					dy := float64(y) + oy - r
 					dist := math.Hypot(dx, dy)
@@ -62,4 +63,17 @@ func colorWheelImage(size int) *ebiten.Image {
 		}
 	}
 	return img
+}
+
+// wheelImage returns a cached color wheel image for the item, generating one
+// if necessary. The image is recreated when the requested size differs from the
+// cached version.
+func (it *itemData) wheelImage(size int) *ebiten.Image {
+	if size <= 0 {
+		size = 1
+	}
+	if it.wheelImg == nil || it.wheelImg.Bounds().Dx() != size {
+		it.wheelImg = colorWheelImage(size)
+	}
+	return it.wheelImg
 }

--- a/eui/render.go
+++ b/eui/render.go
@@ -877,12 +877,10 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 			wheelSize = maxSize.X
 		}
 
-		if item.Image == nil || item.Image.Bounds().Dx() != int(wheelSize) {
-			item.Image = colorWheelImage(int(wheelSize))
-		}
+		img := item.wheelImage(int(wheelSize))
 		op := &ebiten.DrawImageOptions{}
 		op.GeoM.Translate(float64(offset.X), float64(offset.Y))
-		subImg.DrawImage(item.Image, op)
+		subImg.DrawImage(img, op)
 
 		h, _, v, _ := rgbaToHSVA(color.RGBA(item.WheelColor))
 		radius := wheelSize / 2

--- a/eui/struct.go
+++ b/eui/struct.go
@@ -99,6 +99,9 @@ type itemData struct {
 
 	ImageName string
 	Image     *ebiten.Image
+	// wheelImg caches the generated color wheel graphic so it doesn't
+	// need to be recreated every frame.
+	wheelImg *ebiten.Image
 
 	//Style
 	Padding, Margin float32


### PR DESCRIPTION
## Summary
- avoid allocations when reading keyboard input
- remove last rune without converting the whole string
- reuse color wheel sampling offsets
- cache color wheel image inside each item

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687d661cb31c832ab4c5847c25bba9f5