### PR TITLE
Average performance metrics

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -230,7 +230,7 @@ func (g *Game) Update() error {
 		ov.resizeFlow(ov.GetSize())
 	}
 
-	updateMS = float64(time.Since(start).Microseconds()) / 1000.0
+	updateMSFrame = float64(time.Since(start).Microseconds()) / 1000.0
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- keep last-second averages for update/render/cpu metrics
- display averaged metrics in the FPS overlay

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687d6ccdadc8832abc4e48c5b1b0a3be