### PR TITLE
Fix window cache invalidation

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -26,8 +26,9 @@ func (g *Game) Update() error {
 
 	checkThemeLayoutMods()
 
-	// Reset hover states and update click-based dirty flags each frame.
-	refreshDirtyStates()
+	// Record previous input state then reset hover flags for this frame.
+	storePrevStates()
+	clearAllHover()
 
 	mx, my := ebiten.CursorPosition()
 	mpos := point{X: float32(mx), Y: float32(my)}
@@ -235,6 +236,10 @@ func (g *Game) Update() error {
 	for _, ov := range overlays {
 		ov.resizeFlow(ov.GetSize())
 	}
+
+	// Compare current state with the previous frame and mark dirty when
+	// changes are detected.
+	applyStateChanges()
 
 	updateMSFrame = float64(time.Since(start).Microseconds()) / 1000.0
 	return nil

--- a/eui/render.go
+++ b/eui/render.go
@@ -258,7 +258,6 @@ func (win *windowData) drawBorder(screen *ebiten.Image) {
 			FrameColor = win.Theme.Window.ActiveColor
 		} else if win.Hovered {
 			FrameColor = win.Theme.Window.HoverColor
-			win.Hovered = false
 		}
 		drawRoundRect(screen, &roundRect{
 			Size:     win.GetSize(),
@@ -380,7 +379,6 @@ func (item *itemData) drawFlows(win *windowData, parent *itemData, offset point,
 			} else if tab.Hovered {
 				col = style.HoverColor
 			}
-			tab.Hovered = false
 			if item.Filled {
 				drawTabShape(subImg,
 					point{X: x, Y: offset.Y},
@@ -593,7 +591,6 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 			itemColor = style.ClickColor
 			bColor = style.Color
 		} else if item.Hovered {
-			item.Hovered = false
 			itemColor = style.HoverColor
 		}
 		auxSize := pointScaleMul(item.AuxSize)
@@ -658,7 +655,6 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 			itemColor = style.ClickColor
 			bColor = style.OutlineColor
 		} else if item.Hovered {
-			item.Hovered = false
 			itemColor = style.HoverColor
 		}
 		auxSize := pointScaleMul(item.AuxSize)
@@ -719,7 +715,6 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 			if time.Since(item.Clicked) < clickFlash {
 				itemColor = style.ClickColor
 			} else if item.Hovered {
-				item.Hovered = false
 				itemColor = style.HoverColor
 			}
 			if item.Filled {
@@ -755,7 +750,6 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 		if item.Focused {
 			itemColor = style.ClickColor
 		} else if item.Hovered {
-			item.Hovered = false
 			itemColor = style.HoverColor
 		}
 
@@ -798,7 +792,6 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 
 		itemColor := style.Color
 		if item.Hovered {
-			item.Hovered = false
 			itemColor = style.HoverColor
 		}
 
@@ -878,7 +871,6 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 		if item.Open {
 			itemColor = style.SelectedColor
 		} else if item.Hovered {
-			item.Hovered = false
 			itemColor = style.HoverColor
 		}
 

--- a/eui/struct.go
+++ b/eui/struct.go
@@ -60,6 +60,9 @@ type windowData struct {
 
 	// cache stores the pre-rendered window image when all items are clean.
 	cache *ebiten.Image
+	// PrevHovered stores the window hover state from the previous frame so
+	// we can detect changes and invalidate the cache only when necessary.
+	PrevHovered bool
 }
 
 type itemData struct {
@@ -141,6 +144,11 @@ type itemData struct {
 
 	// Dirty indicates the item needs to be re-rendered.
 	Dirty bool
+	// PrevHovered tracks the previous frame hover state so changes can mark
+	// the item dirty. PrevClick records if the item was showing its click
+	// highlight last frame.
+	PrevHovered bool
+	PrevClick   bool
 }
 
 type roundRect struct {


### PR DESCRIPTION
## Summary
- store previous hover and click state for windows and items
- reset hover flags each frame but detect state changes
- stop mutating hover flags during rendering

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687d7e349000832abcb4cabdd6ea52fb