### PR TITLE
Implement per-item caching

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -255,7 +255,6 @@ func (win *windowData) clickWindowItems(mpos point, click bool) {
 	}
 	if !win.Hovered {
 		win.Hovered = true
-		win.cache = nil
 	}
 
 	for _, item := range win.Contents {

--- a/eui/struct.go
+++ b/eui/struct.go
@@ -58,10 +58,8 @@ type windowData struct {
 	ShadowSize  float32
 	ShadowColor Color
 
-	// cache stores the pre-rendered window image when all items are clean.
-	cache *ebiten.Image
 	// PrevHovered stores the window hover state from the previous frame so
-	// we can detect changes and invalidate the cache only when necessary.
+	// changes can be detected between frames.
 	PrevHovered bool
 }
 
@@ -108,6 +106,8 @@ type itemData struct {
 	// wheelImg caches the generated color wheel graphic so it doesn't
 	// need to be recreated every frame.
 	wheelImg *ebiten.Image
+	// cache stores the pre-rendered item image.
+	cache *ebiten.Image
 
 	//Style
 	Padding, Margin float32

--- a/eui/util.go
+++ b/eui/util.go
@@ -194,7 +194,10 @@ func (win *windowData) setSize(size point) bool {
 	}
 
 	if win.Size != prev {
-		win.cache = nil
+		// size changed, mark contents dirty so caches refresh
+		for _, it := range win.Contents {
+			markDirty(it)
+		}
 	}
 
 	return tooSmall
@@ -705,13 +708,10 @@ func markItemStateChanges(it *itemData) {
 	}
 }
 
-// applyStateChanges checks for changed hover states and invalidates window
-// caches when needed.
+// applyStateChanges checks for changed hover states and marks items dirty when
+// their visual state changes.
 func applyStateChanges() {
 	for _, win := range windows {
-		if win.PrevHovered != win.Hovered {
-			win.cache = nil
-		}
 		win.PrevHovered = win.Hovered
 		for _, it := range win.Contents {
 			markItemStateChanges(it)


### PR DESCRIPTION
## Summary
- cache each item individually instead of the entire window
- drop window cache field
- update window drawing to render directly
- mark window contents dirty when resized
- adjust hover state handling

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687d80522ab8832ab8486b0a7e91433f