### PR TITLE
Fix hover redraw toggling

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -295,7 +295,6 @@ func (item *itemData) clickFlows(mpos point, click bool) bool {
 			if tab.DrawRect.containsPoint(mpos) {
 				if !tab.Hovered {
 					tab.Hovered = true
-					tab.Dirty = true
 				}
 				if click {
 					activeItem = tab
@@ -419,7 +418,6 @@ func (item *itemData) clickItem(mpos point, click bool) bool {
 	} else {
 		if !item.Hovered {
 			item.Hovered = true
-			item.Dirty = true
 		}
 		if item.ItemType == ITEM_COLORWHEEL && ebiten.IsMouseButtonPressed(ebiten.MouseButton0) {
 			if col, ok := item.colorAt(mpos); ok {


### PR DESCRIPTION
## Summary
- stop marking tab and item caches dirty just for hover

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687d8a39bfbc832aafefbd7888d7a92e