### PR TITLE
Enable debug flag

### DIFF
--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -22,6 +22,8 @@ func main() {
 	debugMode = flag.Bool("debug", false, "enable debug visuals")
 	flag.Parse()
 
+	eui.DebugMode = *debugMode
+
 	signalHandle = make(chan os.Signal, 1)
 	signal.Notify(signalHandle, syscall.SIGINT, syscall.SIGTERM, os.Interrupt)
 


### PR DESCRIPTION
## Summary
- wire the `-debug` flag to `eui.DebugMode` so cached render counts show up

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687d8cabd160832a91678b39b11656db