### PR TITLE
Fix overlay dirty state

### DIFF
--- a/eui/render.go
+++ b/eui/render.go
@@ -107,6 +107,7 @@ func drawOverlay(item *itemData, screen *ebiten.Image) {
 	} else {
 		item.drawItem(nil, offset, clip, screen)
 	}
+	clearDirty(item)
 }
 
 func (win *windowData) Draw(screen *ebiten.Image) {


### PR DESCRIPTION
## Summary
- clear overlay dirty flag after drawing

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687d926ff428832ab05881a52b8cba7a