### PR TITLE
Implement item render caching

### DIFF
--- a/eui/struct.go
+++ b/eui/struct.go
@@ -129,6 +129,11 @@ type itemData struct {
 	// rendered.
 	DrawRect rect
 
+	// Render caches the pre-rendered image for this item when Dirty is
+	// false. Flows are never cached.
+	Render *ebiten.Image
+	Dirty  bool
+
 	// Drop shadow styling
 	ShadowSize  float32
 	ShadowColor Color


### PR DESCRIPTION
## Summary
- add render cache fields to items
- generate item cache images when marked dirty
- reuse cached render during drawing

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687da966ed38832ab5b2164bdfbad251