### PR TITLE
Fix dropdown layering and hover rerenders

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -409,8 +409,10 @@ func (item *itemData) clickItem(mpos point, click bool) bool {
 			return true
 		}
 	} else {
-		item.Hovered = true
-		item.markDirty()
+		if !item.Hovered {
+			item.Hovered = true
+			item.markDirty()
+		}
 		hoveredItem = item
 		if item.ItemType == ITEM_COLORWHEEL && ebiten.IsMouseButtonPressed(ebiten.MouseButton0) {
 			if col, ok := item.colorAt(mpos); ok {

--- a/eui/render.go
+++ b/eui/render.go
@@ -979,9 +979,6 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 		op.GeoM.Translate(float64(item.DrawRect.X0), float64(item.DrawRect.Y0))
 		screen.DrawImage(sub, op)
 
-		if item.ItemType == ITEM_DROPDOWN && item.Open {
-			drawDropdownOptions(item, offset, clip, screen)
-		}
 		if DebugMode {
 			strokeRect(screen, item.DrawRect.X0, item.DrawRect.Y0, item.DrawRect.X1-item.DrawRect.X0, item.DrawRect.Y1-item.DrawRect.Y0, 1, color.RGBA{R: 128}, false)
 		}


### PR DESCRIPTION
## Summary
- avoid drawing dropdown options twice so they're not duplicated on screen
- only mark items dirty when hover state changes

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687db030f464832a931475b993fff45a