### PR TITLE
Add debug flag and render count overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,12 @@ gofmt -w <files>
 The demonstration application lives under `cmd/demo`. You can run it directly using `go run` or build a binary:
 
 ```sh
-go run ./cmd/demo            # launches the showcase window
+go run ./cmd/demo             # launches the showcase window
 # or
 go build -o demo ./cmd/demo
-./demo -debug                # optional debug overlays
+./demo -debug                 # optional debug overlays
+# pass -debug with go run to enable overlays
+go run ./cmd/demo -debug
 ```
 
 ## Customization

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -21,6 +21,7 @@ func main() {
 
 	debugMode = flag.Bool("debug", false, "enable debug visuals")
 	flag.Parse()
+	eui.DebugMode = *debugMode
 
 	signalHandle = make(chan os.Signal, 1)
 	signal.Notify(signalHandle, syscall.SIGINT, syscall.SIGTERM, os.Interrupt)

--- a/eui/render.go
+++ b/eui/render.go
@@ -942,6 +942,10 @@ func (item *itemData) ensureRender() {
 	prevHover := item.Hovered
 	item.Render.Clear()
 	item.drawItemInternal(nil, point{}, rect{X0: 0, Y0: 0, X1: size.X, Y1: size.Y}, item.Render)
+	if DebugMode {
+		item.RenderCount++
+		ebitenutil.DebugPrintAt(item.Render, fmt.Sprintf("%d", item.RenderCount), 0, 0)
+	}
 	item.DrawRect = prevRect
 	item.Hovered = prevHover
 	item.Dirty = false

--- a/eui/struct.go
+++ b/eui/struct.go
@@ -131,8 +131,9 @@ type itemData struct {
 
 	// Render caches the pre-rendered image for this item when Dirty is
 	// false. Flows are never cached.
-	Render *ebiten.Image
-	Dirty  bool
+	Render      *ebiten.Image
+	Dirty       bool
+	RenderCount int
 
 	// Drop shadow styling
 	ShadowSize  float32


### PR DESCRIPTION
## Summary
- enable the `-debug` flag in the demo to set `eui.DebugMode`
- track render counts for items when in debug mode
- draw render count in cached images
- document usage of `-debug`

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687db5443f24832a98a535e58dbf886d