### PR TITLE
Add demo dump mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ go run ./cmd/demo             # launches the showcase window
 # or
 go build -o demo ./cmd/demo
 ./demo -debug                 # optional debug overlays
+# dump cached images to ./debug
+./demo -dump
 # pass -debug with go run to enable overlays
 go run ./cmd/demo -debug
 ```

--- a/api.md
+++ b/api.md
@@ -42,6 +42,8 @@ It is currently in a pre‑alpha state and the API may change at any time.
 ## Variables
 
 - `DebugMode` – when set, additional outlines are rendered for debugging.
+- `DumpMode` – when set, cached images are written to `./debug` and the
+  program exits.
 - `ColorWhite`, `ColorBlack`, `ColorRed`, ... – a large palette of predefined
   colors available as variables of type `Color`.
 
@@ -68,6 +70,7 @@ It is currently in a pre‑alpha state and the API may change at any time.
 - `Windows() []*WindowData`
 - `Overlays() []*ItemData`
 - `AddOverlayFlow(flow *ItemData)`
+- `DumpCachedImages() error` – write cached images to `./debug`
 - `SetScreenSize(w, h int)`
 - `ScreenSize() (int, int)`
 - `SetFontSource(src *text.GoTextFaceSource)`

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -13,6 +13,7 @@ import (
 
 var (
 	debugMode    *bool
+	dumpMode     *bool
 	themeSel     *eui.WindowData
 	signalHandle chan os.Signal
 )
@@ -20,8 +21,10 @@ var (
 func main() {
 
 	debugMode = flag.Bool("debug", false, "enable debug visuals")
+	dumpMode = flag.Bool("dump", false, "dump cached images and exit")
 	flag.Parse()
 	eui.DebugMode = *debugMode
+	eui.DumpMode = *dumpMode
 
 	signalHandle = make(chan os.Signal, 1)
 	signal.Notify(signalHandle, syscall.SIGINT, syscall.SIGTERM, os.Interrupt)
@@ -71,6 +74,13 @@ func main() {
 	}
 	overlay.AddItem(toggleBtn)
 	eui.AddOverlayFlow(overlay)
+
+	if eui.DumpMode {
+		if err := eui.DumpCachedImages(); err != nil {
+			panic(err)
+		}
+		return
+	}
 
 	go startEbiten()
 

--- a/eui/dump.go
+++ b/eui/dump.go
@@ -1,0 +1,56 @@
+package eui
+
+import (
+	"fmt"
+	"image/png"
+	"os"
+	"path/filepath"
+)
+
+// DumpCachedImages writes all cached item images and item source images
+// to the debug directory. It ensures any pending renders are generated
+// before writing the files.
+func DumpCachedImages() error {
+	if err := os.MkdirAll("debug", 0755); err != nil {
+		return err
+	}
+	for i, win := range windows {
+		dumpItemImages(win.Contents, fmt.Sprintf("window_%d", i))
+	}
+	for i, ov := range overlays {
+		dumpItemImages([]*itemData{ov}, fmt.Sprintf("overlay_%d", i))
+	}
+	return nil
+}
+
+func dumpItemImages(items []*itemData, prefix string) {
+	for idx, it := range items {
+		if it == nil {
+			continue
+		}
+		name := fmt.Sprintf("%s_%d", prefix, idx)
+		if it.ItemType != ITEM_FLOW {
+			it.ensureRender()
+			if it.Render != nil {
+				fn := filepath.Join("debug", name+".png")
+				if f, err := os.Create(fn); err == nil {
+					png.Encode(f, it.Render)
+					f.Close()
+				}
+			}
+			if it.Image != nil {
+				fn := filepath.Join("debug", name+"_src.png")
+				if f, err := os.Create(fn); err == nil {
+					png.Encode(f, it.Image)
+					f.Close()
+				}
+			}
+		}
+		if len(it.Contents) > 0 {
+			dumpItemImages(it.Contents, name)
+		}
+		if len(it.Tabs) > 0 {
+			dumpItemImages(it.Tabs, name+"_tab")
+		}
+	}
+}

--- a/eui/glob.go
+++ b/eui/glob.go
@@ -31,6 +31,10 @@ var (
 	// DebugMode enables rendering of debug outlines.
 	DebugMode bool
 
+	// DumpMode causes the library to write cached images to disk
+	// before exiting when enabled.
+	DumpMode bool
+
 	whiteImage    = ebiten.NewImage(3, 3)
 	whiteSubImage = whiteImage.SubImage(image.Rect(1, 1, 2, 2)).(*ebiten.Image)
 )


### PR DESCRIPTION
## Summary
- add new DumpMode variable to the library
- implement `DumpCachedImages` to write cached images to `./debug`
- support `-dump` flag in demo and exit early when dumping
- document dump mode in README and API reference

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687db7ac7ddc832abeb13edccd910d52