### PR TITLE
Fix DumpMode to dump after first frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ go run ./cmd/demo             # launches the showcase window
 # or
 go build -o demo ./cmd/demo
 ./demo -debug                 # optional debug overlays
-# dump cached images to ./debug
+# dump cached images to ./debug (runs once then exits)
 ./demo -dump
 # pass -debug with go run to enable overlays
 go run ./cmd/demo -debug

--- a/api.md
+++ b/api.md
@@ -42,8 +42,8 @@ It is currently in a pre‑alpha state and the API may change at any time.
 ## Variables
 
 - `DebugMode` – when set, additional outlines are rendered for debugging.
-- `DumpMode` – when set, cached images are written to `./debug` and the
-  program exits.
+- `DumpMode` – when set, cached images are written to `./debug` after the first
+  frame is rendered and the program exits.
 - `ColorWhite`, `ColorBlack`, `ColorRed`, ... – a large palette of predefined
   colors available as variables of type `Color`.
 

--- a/eui/render.go
+++ b/eui/render.go
@@ -5,6 +5,7 @@ import (
 	"image"
 	"image/color"
 	"math"
+	"os"
 	"strings"
 	"time"
 
@@ -23,6 +24,7 @@ type dropdownRender struct {
 }
 
 var pendingDropdowns []dropdownRender
+var dumpDone bool
 
 func (g *Game) Draw(screen *ebiten.Image) {
 
@@ -45,6 +47,14 @@ func (g *Game) Draw(screen *ebiten.Image) {
 	}
 
 	drawFPS(screen)
+
+	if DumpMode && !dumpDone {
+		if err := DumpCachedImages(); err != nil {
+			panic(err)
+		}
+		dumpDone = true
+		os.Exit(0)
+	}
 }
 
 func drawOverlay(item *itemData, screen *ebiten.Image) {


### PR DESCRIPTION
## Summary
- handle DumpMode inside `Game.Draw` so images are written after the first frame
- document DumpMode behavior in README and API docs

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687db92969ec832aa1ecb5ef0f08f964