### PR TITLE
Fix dump mode panic

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ go run ./cmd/demo             # launches the showcase window
 # or
 go build -o demo ./cmd/demo
 ./demo -debug                 # optional debug overlays
-# dump cached images to ./debug (runs once then exits)
+# dump cached images to ./debug after one frame then exit
 ./demo -dump
 # pass -debug with go run to enable overlays
 go run ./cmd/demo -debug

--- a/api.md
+++ b/api.md
@@ -70,7 +70,7 @@ It is currently in a pre‑alpha state and the API may change at any time.
 - `Windows() []*WindowData`
 - `Overlays() []*ItemData`
 - `AddOverlayFlow(flow *ItemData)`
-- `DumpCachedImages() error` – write cached images to `./debug`
+- `DumpCachedImages() error` – write cached images to `./debug`. Requires the game to be running.
 - `SetScreenSize(w, h int)`
 - `ScreenSize() (int, int)`
 - `SetFontSource(src *text.GoTextFaceSource)`

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -75,13 +75,6 @@ func main() {
 	overlay.AddItem(toggleBtn)
 	eui.AddOverlayFlow(overlay)
 
-	if eui.DumpMode {
-		if err := eui.DumpCachedImages(); err != nil {
-			panic(err)
-		}
-		return
-	}
-
 	go startEbiten()
 
 	<-signalHandle

--- a/eui/dump.go
+++ b/eui/dump.go
@@ -8,8 +8,8 @@ import (
 )
 
 // DumpCachedImages writes all cached item images and item source images
-// to the debug directory. It ensures any pending renders are generated
-// before writing the files.
+// to the debug directory. The game must be running so pixels can be read.
+// Any pending renders are generated before writing the files.
 func DumpCachedImages() error {
 	if err := os.MkdirAll("debug", 0755); err != nil {
 		return err


### PR DESCRIPTION
## Summary
- fix panic when running demo with `-dump` by deferring image writes until after Ebiten starts
- clarify dump behaviour in README, api docs and comment for `DumpCachedImages`

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687dbb3590b8832a992153723c023aa7