### PR TITLE
Ensure UI redraws on theme changes

### DIFF
--- a/eui/layout.go
+++ b/eui/layout.go
@@ -136,6 +136,7 @@ func LoadLayout(name string) error {
 	if currentTheme != nil {
 		applyLayoutToTheme(currentTheme)
 		applyThemeToAll()
+		markAllDirty()
 	}
 	refreshLayoutMod()
 	return nil

--- a/eui/theme.go
+++ b/eui/theme.go
@@ -112,6 +112,7 @@ func LoadTheme(name string) error {
 	currentThemeName = name
 	applyLayoutToTheme(currentTheme)
 	applyThemeToAll()
+	markAllDirty()
 	if ac, ok := namedColors["accent"]; ok {
 		accentHue, accentSaturation, accentValue, accentAlpha = rgbaToHSVA(color.RGBA(ac))
 	}
@@ -198,6 +199,7 @@ func applyAccentColor() {
 	namedColors["sliderfilled"] = col
 	applyThemeToAll()
 	updateColorWheels(col)
+	markAllDirty()
 }
 
 // applyThemeToAll updates all existing windows to use the current theme.

--- a/eui/util.go
+++ b/eui/util.go
@@ -344,6 +344,30 @@ func (item *itemData) markDirty() {
 	}
 }
 
+func markItemTreeDirty(it *itemData) {
+	if it == nil {
+		return
+	}
+	it.markDirty()
+	for _, child := range it.Contents {
+		markItemTreeDirty(child)
+	}
+	for _, tab := range it.Tabs {
+		markItemTreeDirty(tab)
+	}
+}
+
+func markAllDirty() {
+	for _, win := range windows {
+		for _, it := range win.Contents {
+			markItemTreeDirty(it)
+		}
+	}
+	for _, ov := range overlays {
+		markItemTreeDirty(ov)
+	}
+}
+
 func (item *itemData) bounds(offset point) rect {
 	r := rect{
 		X0: offset.X,


### PR DESCRIPTION
## Summary
- mark all items dirty recursively
- mark items dirty when applying themes, layouts or accent colors

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687dbd61c320832a96b56fae09843db7