### PR TITLE
Dispose cached window images

### DIFF
--- a/eui/dispose.go
+++ b/eui/dispose.go
@@ -1,0 +1,32 @@
+package eui
+
+// disposeImages releases any cached images for the item and its children.
+func (item *itemData) disposeImages() {
+	if item.Render != nil {
+		item.Render.Dispose()
+		item.Render = nil
+	}
+	if item.Image != nil {
+		item.Image.Dispose()
+		item.Image = nil
+	}
+	for _, child := range item.Contents {
+		if child != nil {
+			child.disposeImages()
+		}
+	}
+	for _, tab := range item.Tabs {
+		if tab != nil {
+			tab.disposeImages()
+		}
+	}
+}
+
+// disposeImages releases cached images for all items in the window.
+func (win *windowData) disposeImages() {
+	for _, it := range win.Contents {
+		if it != nil {
+			it.disposeImages()
+		}
+	}
+}

--- a/eui/window.go
+++ b/eui/window.go
@@ -117,11 +117,14 @@ func (target *windowData) AddWindow(toBack bool) {
 	}
 }
 
-// Remove window from window list, if found.
+// RemoveWindow removes a window from the active list. Any cached images
+// belonging to the window are disposed and pointers cleared.
 func (target *windowData) RemoveWindow() {
 	for i, win := range windows {
 		if win == target { // Compare pointers
+			win.disposeImages()
 			windows = append(windows[:i], windows[i+1:]...)
+			win.Open = false
 			return
 		}
 	}


### PR DESCRIPTION
## Summary
- dispose cached images for items recursively
- free cached images when removing windows

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687dc1c88488832a9d298b15e49e781a