### PR TITLE
Add disposal logs in debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The demonstration application lives under `cmd/demo`. You can run it directly us
 go run ./cmd/demo             # launches the showcase window
 # or
 go build -o demo ./cmd/demo
-./demo -debug                 # optional debug overlays
+./demo -debug                 # optional debug overlays and disposal logs
 # dump cached images to ./debug after one frame then exit
 ./demo -dump
 # pass -debug with go run to enable overlays

--- a/eui/dispose.go
+++ b/eui/dispose.go
@@ -1,12 +1,20 @@
 package eui
 
+import "log"
+
 // disposeImages releases any cached images for the item and its children.
 func (item *itemData) disposeImages() {
 	if item.Render != nil {
+		if DebugMode {
+			log.Printf("disposing render for item %p", item)
+		}
 		item.Render.Dispose()
 		item.Render = nil
 	}
 	if item.Image != nil {
+		if DebugMode {
+			log.Printf("disposing source image for item %p", item)
+		}
 		item.Image.Dispose()
 		item.Image = nil
 	}
@@ -24,6 +32,9 @@ func (item *itemData) disposeImages() {
 
 // disposeImages releases cached images for all items in the window.
 func (win *windowData) disposeImages() {
+	if DebugMode {
+		log.Printf("disposing images for window %p (%s)", win, win.Title)
+	}
 	for _, it := range win.Contents {
 		if it != nil {
 			it.disposeImages()


### PR DESCRIPTION
## Summary
- log cached image disposal when `DebugMode` is set
- mention disposal logging in debug mode in README

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687dc44e6578832a86085493d75565ad