### PR TITLE
Add callback-based event handling

### DIFF
--- a/api.md
+++ b/api.md
@@ -127,16 +127,14 @@ The snippet below creates a simple window containing a button:
 
 ```go
 win := eui.NewWindow(&eui.WindowData{Title: "Example", Size: eui.Point{X: 200, Y: 120}})
-btn, btnEvents := eui.NewButton(&eui.ItemData{Text: "Click Me"})
+btn, handler := eui.NewButton(&eui.ItemData{Text: "Click Me"})
 win.AddItem(btn)
 win.AddWindow(false)
-go func() {
-    for ev := range btnEvents.Events {
-        if ev.Type == eui.EventClick {
-            // handle click
-        }
+handler.Handle = func(ev eui.UIEvent) {
+    if ev.Type == eui.EventClick {
+        // handle click
     }
-}()
+}
 ```
 
 To regenerate this file run:

--- a/eui/events.go
+++ b/eui/events.go
@@ -23,8 +23,23 @@ type UIEvent struct {
 }
 
 // EventHandler holds a channel widgets use to emit events.
+// EventHandler provides both channel and callback based event delivery.
 type EventHandler struct {
 	Events chan UIEvent
+	Handle func(UIEvent)
+}
+
+// Emit delivers the event through the channel and callback if present.
+func (h *EventHandler) Emit(ev UIEvent) {
+	if h == nil {
+		return
+	}
+	if h.Events != nil {
+		h.Events <- ev
+	}
+	if h.Handle != nil {
+		h.Handle(ev)
+	}
 }
 
 func newHandler() *EventHandler {

--- a/eui/input.go
+++ b/eui/input.go
@@ -362,7 +362,7 @@ func (item *itemData) clickItem(mpos point, click bool) bool {
 		activeItem = item
 		item.Clicked = time.Now()
 		if item.ItemType == ITEM_BUTTON && item.Handler != nil {
-			item.Handler.Events <- UIEvent{Item: item, Type: EventClick}
+			item.Handler.Emit(UIEvent{Item: item, Type: EventClick})
 		}
 		item.markDirty()
 		if item.ItemType == ITEM_COLORWHEEL {
@@ -370,7 +370,7 @@ func (item *itemData) clickItem(mpos point, click bool) bool {
 				item.WheelColor = col
 				item.markDirty()
 				if item.Handler != nil {
-					item.Handler.Events <- UIEvent{Item: item, Type: EventColorChanged, Color: col}
+					item.Handler.Emit(UIEvent{Item: item, Type: EventColorChanged, Color: col})
 				}
 				if item.OnColorChange != nil {
 					item.OnColorChange(col)
@@ -383,7 +383,7 @@ func (item *itemData) clickItem(mpos point, click bool) bool {
 			item.Checked = !item.Checked
 			item.markDirty()
 			if item.Handler != nil {
-				item.Handler.Events <- UIEvent{Item: item, Type: EventCheckboxChanged, Checked: item.Checked}
+				item.Handler.Emit(UIEvent{Item: item, Type: EventCheckboxChanged, Checked: item.Checked})
 			}
 		} else if item.ItemType == ITEM_RADIO {
 			item.Checked = true
@@ -393,7 +393,7 @@ func (item *itemData) clickItem(mpos point, click bool) bool {
 			}
 			item.markDirty()
 			if item.Handler != nil {
-				item.Handler.Events <- UIEvent{Item: item, Type: EventRadioSelected, Checked: true}
+				item.Handler.Emit(UIEvent{Item: item, Type: EventRadioSelected, Checked: true})
 			}
 		} else if item.ItemType == ITEM_INPUT {
 			focusedItem = item
@@ -416,7 +416,7 @@ func (item *itemData) clickItem(mpos point, click bool) bool {
 						item.Open = false
 						item.markDirty()
 						if item.Handler != nil {
-							item.Handler.Events <- UIEvent{Item: item, Type: EventDropdownSelected, Index: idx}
+							item.Handler.Emit(UIEvent{Item: item, Type: EventDropdownSelected, Index: idx})
 						}
 						if item.OnSelect != nil {
 							item.OnSelect(idx)
@@ -446,7 +446,7 @@ func (item *itemData) clickItem(mpos point, click bool) bool {
 				item.WheelColor = col
 				item.markDirty()
 				if item.Handler != nil {
-					item.Handler.Events <- UIEvent{Item: item, Type: EventColorChanged, Color: col}
+					item.Handler.Emit(UIEvent{Item: item, Type: EventColorChanged, Color: col})
 				}
 				if item.OnColorChange != nil {
 					item.OnColorChange(col)
@@ -569,7 +569,7 @@ func (item *itemData) setSliderValue(mpos point) {
 	}
 	item.markDirty()
 	if item.Handler != nil {
-		item.Handler.Events <- UIEvent{Item: item, Type: EventSliderChanged, Value: item.Value}
+		item.Handler.Emit(UIEvent{Item: item, Type: EventSliderChanged, Value: item.Value})
 	}
 }
 


### PR DESCRIPTION
## Summary
- extend `EventHandler` to support callbacks via `Handle func(UIEvent)`
- provide `Emit` method to send events to the channel and callback
- update widget code to use `Emit`
- document callback style in `api.md`

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687dcbb4bc10832aa448b716543d09ff