### PR TITLE
Fix color wheel freeze by using non-blocking event sends

### DIFF
--- a/eui/events.go
+++ b/eui/events.go
@@ -35,7 +35,10 @@ func (h *EventHandler) Emit(ev UIEvent) {
 		return
 	}
 	if h.Events != nil {
-		h.Events <- ev
+		select {
+		case h.Events <- ev:
+		default:
+		}
 	}
 	if h.Handle != nil {
 		h.Handle(ev)


### PR DESCRIPTION
## Summary
- avoid blocking when emitting events if nobody is listening

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687dd00476b8832a926db840ea7b4127