### PR TITLE
Fix demo color wheel handler

### DIFF
--- a/cmd/demo/theme_selector.go
+++ b/cmd/demo/theme_selector.go
@@ -81,6 +81,12 @@ func makeThemeSelector() *eui.WindowData {
 	}
 
 	cw, _ := eui.NewColorWheel(&eui.ItemData{Size: eui.Point{X: 160, Y: 128}})
+	cw.OnColorChange = func(col eui.Color) {
+		eui.SetAccentColor(col)
+		if satSlider != nil {
+			satSlider.Value = float32(eui.AccentSaturation())
+		}
+	}
 	mainFlow.AddItem(cw)
 
 	satSlider, satEvents := eui.NewSlider(&eui.ItemData{Label: "Color Intensity", Size: eui.Point{X: 128, Y: 24}, MinValue: 0, MaxValue: 1, FontSize: 8})


### PR DESCRIPTION
## Summary
- update theme selector demo to use `OnColorChange` callback for the color wheel

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687dd3879460832aa0eaaf42f41d2dec