### PR TITLE
Handle text input events in demo

### DIFF
--- a/cmd/demo/showcase.go
+++ b/cmd/demo/showcase.go
@@ -87,8 +87,13 @@ func makeShowcaseWindow() *eui.WindowData {
 	}
 	mainFlow.AddItem(intSlider)
 
-	input, _ := eui.NewInput(&eui.ItemData{Label: "Text Field", Text: "", Size: eui.Point{X: 180, Y: 24}, FontSize: 8})
+	input, inputEvents := eui.NewInput(&eui.ItemData{Label: "Text Field", Text: "", Size: eui.Point{X: 180, Y: 24}, FontSize: 8})
 	input.Action = func() { setStatus("Text Field focused") }
+	inputEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventInputChanged {
+			setStatus("Input: " + ev.Text)
+		}
+	}
 	mainFlow.AddItem(input)
 
 	dropdown, dropdownEvents := eui.NewDropdown(&eui.ItemData{Label: "Select Option", Size: eui.Point{X: 180, Y: 24}, FontSize: 8})


### PR DESCRIPTION
## Summary
- wire up EventInputChanged handling in the demo showcase

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687ddd99249c832aafe5c308faefb1f9