### PR TITLE
Add WebAssembly build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ go build -o demo ./cmd/demo
 go run ./cmd/demo -debug
 ```
 
+## Building for WebAssembly
+
+Compile the demo to `wasm` using the provided script:
+
+```sh
+./scripts/build_wasm.sh
+```
+
+Open `web/index.html` in a browser to run it.
+
 ## Customization
 
 The library loads the built in `AccentDark` palette, `RoundHybrid` style and a default font automatically. Additional examples live under [`eui/themes`](eui/themes). Use `eui.ListThemes()` and `eui.ListStyles()` to see the names that are available. To try a different look enable `eui.AutoReload` and load files explicitly:

--- a/scripts/build_wasm.sh
+++ b/scripts/build_wasm.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+OUT_DIR="$(dirname "$0")/../web"
+mkdir -p "$OUT_DIR"
+
+cp "$(go env GOROOT)/misc/wasm/wasm_exec.js" "$OUT_DIR/"
+
+GOOS=js GOARCH=wasm go build -o "$OUT_DIR/demo.wasm" ./cmd/demo
+
+echo "WASM build output in $OUT_DIR. Open index.html in a browser."

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>EUI Demo (WASM)</title>
+</head>
+<body>
+    <script src="wasm_exec.js"></script>
+    <script>
+        const go = new Go();
+        WebAssembly.instantiateStreaming(fetch("demo.wasm"), go.importObject).then((result) => {
+            go.run(result.instance);
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `build_wasm.sh` helper
- include `web/index.html` to load the wasm build
- document how to build for WebAssembly in README

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687e9cd61c20832abb029abeea3b6201