### PR TITLE
Add UI scale buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ building a game UI. Highlights include:
 - **Overlay items** – keep controls always on screen.
 - **Palette and style themes** – JSON files define colors and spacing. Switch
   them at runtime or reload automatically while iterating.
-- **UI scaling** – call `eui.SetUIScale()` to adapt to any resolution.
+- **UI scaling** – call `eui.SetUIScale()` to adapt to any resolution or
+  `eui.UIScale()` to read the current value.
 - **Image caching** – widgets cache their drawing for better performance.
   Enable `eui.DumpMode` to write the cached images to disk for inspection.
 - **Event system** – each widget returns an `EventHandler` that uses channels or

--- a/api.md
+++ b/api.md
@@ -259,6 +259,9 @@ func SetScreenSize(w, h int)
     SetScreenSize sets the current screen size used for layout calculations.
 
 func SetUIScale(scale float32)
+
+func UIScale() float32
+    UIScale returns the current UI scale factor.
 func Update() error
     Update processes input and updates window state. Programs embedding the UI
     can call this from their Ebiten Update handler.

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -16,6 +16,7 @@ var (
 	dumpMode     *bool
 	themeSel     *eui.WindowData
 	signalHandle chan os.Signal
+	currentScale float32
 )
 
 func main() {
@@ -42,7 +43,8 @@ func main() {
 	//         log.Fatal(err)
 	// }
 
-	eui.SetUIScale(1.5)
+	currentScale = 1.5
+	eui.SetUIScale(currentScale)
 
 	showcase := makeShowcaseWindow()
 	showcase.AddWindow(false)
@@ -87,6 +89,34 @@ func main() {
 	statusText, _ = eui.NewText(&eui.ItemData{Size: eui.Point{X: 316, Y: 24}, FontSize: 8})
 	statusOverlay.AddItem(statusText)
 	eui.AddOverlayFlow(statusOverlay)
+
+	scaleOverlay := &eui.ItemData{
+		ItemType: eui.ITEM_FLOW,
+		FlowType: eui.FLOW_HORIZONTAL,
+		Size:     eui.Point{X: 56, Y: 24},
+		Position: eui.Point{X: 4, Y: 32},
+		PinTo:    eui.PIN_BOTTOM_LEFT,
+	}
+	minusBtn, minusEvents := eui.NewButton(&eui.ItemData{Text: "-", Size: eui.Point{X: 24, Y: 24}, FontSize: 8})
+	minusEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventClick {
+			currentScale -= 0.2
+			if currentScale < 0.2 {
+				currentScale = 0.2
+			}
+			eui.SetUIScale(currentScale)
+		}
+	}
+	plusBtn, plusEvents := eui.NewButton(&eui.ItemData{Text: "+", Size: eui.Point{X: 24, Y: 24}, FontSize: 8})
+	plusEvents.Handle = func(ev eui.UIEvent) {
+		if ev.Type == eui.EventClick {
+			currentScale += 0.2
+			eui.SetUIScale(currentScale)
+		}
+	}
+	scaleOverlay.AddItem(minusBtn)
+	scaleOverlay.AddItem(plusBtn)
+	eui.AddOverlayFlow(scaleOverlay)
 
 	go startEbiten()
 

--- a/eui/util.go
+++ b/eui/util.go
@@ -319,7 +319,16 @@ func (win *windowData) SetTitleSize(size float32) {
 
 func SetUIScale(scale float32) {
 	uiScale = scale
+	for _, win := range windows {
+		win.resizeFlows()
+	}
+	for _, ov := range overlays {
+		ov.resizeFlow(ov.GetSize())
+	}
+	markAllDirty()
 }
+
+func UIScale() float32 { return uiScale }
 
 func (win *windowData) GetTitleSize() float32 {
 	return win.TitleHeight * uiScale


### PR DESCRIPTION
## Summary
- control UI scale at runtime via `SetUIScale` and new `UIScale()` getter
- expose scale buttons in the demo overlay
- document the new API

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687ed7634ed8832ab6738c63b37c9ae2