### PR TITLE
Fix autosize padding at small scales

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -723,7 +723,7 @@ func scrollWindow(win *windowData, delta point) bool {
 	if win.NoScroll {
 		return false
 	}
-	pad := win.Padding + win.BorderPad
+	pad := (win.Padding + win.BorderPad) * uiScale
 	req := win.contentBounds()
 	avail := point{
 		X: win.GetSize().X - 2*pad,
@@ -763,7 +763,7 @@ func dragWindowScroll(win *windowData, mpos point, vert bool) {
 	if win.NoScroll {
 		return
 	}
-	pad := win.Padding + win.BorderPad
+	pad := (win.Padding + win.BorderPad) * uiScale
 	req := win.contentBounds()
 	avail := point{
 		X: win.GetSize().X - 2*pad,

--- a/eui/render.go
+++ b/eui/render.go
@@ -227,7 +227,7 @@ func (win *windowData) drawScrollbars(screen *ebiten.Image) {
 	if win.NoScroll {
 		return
 	}
-	pad := win.Padding + win.BorderPad
+	pad := (win.Padding + win.BorderPad) * uiScale
 	req := win.contentBounds()
 	avail := point{
 		X: win.GetSize().X - 2*pad,
@@ -268,7 +268,7 @@ func (win *windowData) drawScrollbars(screen *ebiten.Image) {
 }
 
 func (win *windowData) drawItems(screen *ebiten.Image) {
-	pad := win.Padding + win.BorderPad
+	pad := (win.Padding + win.BorderPad) * uiScale
 	winPos := pointAdd(win.getPosition(), point{X: pad, Y: win.GetTitleSize() + pad})
 	winPos = pointSub(winPos, win.Scroll)
 	clip := win.getMainRect()
@@ -409,7 +409,7 @@ func (item *itemData) drawFlows(win *windowData, parent *itemData, offset point,
 			flowOff := pointAdd(drawOffset, flowOffset)
 
 			if subItem.PinTo != PIN_TOP_LEFT {
-				pad := win.Padding + win.BorderPad
+				pad := (win.Padding + win.BorderPad) * uiScale
 				objOff := pointAdd(win.getPosition(), point{X: pad, Y: win.GetTitleSize() + pad})
 				objOff = pointSub(objOff, win.Scroll)
 				objOff = pointAdd(objOff, subItem.getPosition(win))

--- a/eui/util.go
+++ b/eui/util.go
@@ -169,7 +169,7 @@ func (win *windowData) adjustScrollForResize() {
 		return
 	}
 
-	pad := win.Padding + win.BorderPad
+	pad := (win.Padding + win.BorderPad) * uiScale
 	req := win.contentBounds()
 	avail := point{
 		X: win.GetSize().X - 2*pad,
@@ -258,7 +258,7 @@ func (win *windowData) getScrollbarPart(mpos point) dragType {
 		return PART_NONE
 	}
 
-	pad := win.Padding + win.BorderPad
+	pad := (win.Padding + win.BorderPad) * uiScale
 	req := win.contentBounds()
 	avail := point{
 		X: win.GetSize().X - 2*pad,
@@ -471,7 +471,7 @@ func (win *windowData) contentBounds() point {
 
 func (win *windowData) updateAutoSize() {
 	req := win.contentBounds()
-	pad := win.Padding + win.BorderPad
+	pad := (win.Padding + win.BorderPad) * uiScale
 
 	size := win.GetSize()
 	needX := req.X + 2*pad


### PR DESCRIPTION
## Summary
- scale window padding computations using `UIScale`
- adjust rendering and input handling accordingly

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687ef11b0ca0832a9e258a33e13b4eb2