### PR TITLE
Fix window autosize with UI scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ building a game UI. Highlights include:
 - **Palette and style themes** – JSON files define colors and spacing. Switch
   them at runtime or reload automatically while iterating.
 - **UI scaling** – call `eui.SetUIScale()` to adapt to any resolution or
-  `eui.UIScale()` to read the current value.
+  `eui.UIScale()` to read the current value. Windows using `AutoSize` adjust
+  their dimensions automatically when the scale changes.
 - **Image caching** – widgets cache their drawing for better performance.
   Enable `eui.DumpMode` to write the cached images to disk for inspection.
 - **Event system** – each widget returns an `EventHandler` that uses channels or

--- a/api.md
+++ b/api.md
@@ -259,7 +259,8 @@ func SetScreenSize(w, h int)
     SetScreenSize sets the current screen size used for layout calculations.
 
 func SetUIScale(scale float32)
-
+    SetUIScale updates layout metrics for the given scale and resizes
+    windows created with AutoSize.
 func UIScale() float32
     UIScale returns the current UI scale factor.
 func Update() error

--- a/eui/util.go
+++ b/eui/util.go
@@ -320,7 +320,7 @@ func (win *windowData) SetTitleSize(size float32) {
 func SetUIScale(scale float32) {
 	uiScale = scale
 	for _, win := range windows {
-		win.resizeFlows()
+		win.updateAutoSize()
 	}
 	for _, ov := range overlays {
 		ov.resizeFlow(ov.GetSize())


### PR DESCRIPTION
## Summary
- recalc autosize when calling `SetUIScale`
- explain autosizing behaviour in README and api docs

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687ef560d150832aad40ed77f2d1c8fe