### PR TITLE
Add HiDPI auto scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ building a game UI. Highlights include:
 - **UI scaling** – call `eui.SetUIScale()` to adapt to any resolution or
   `eui.UIScale()` to read the current value. Windows using `AutoSize` adjust
   their dimensions automatically when the scale changes.
+- **HiDPI support** – enable `eui.AutoHiDPI` or call `eui.SyncHiDPIScale()`
+  to match the device scale factor when moving between monitors.
 - **Image caching** – widgets cache their drawing for better performance.
   Enable `eui.DumpMode` to write the cached images to disk for inspection.
 - **Event system** – each widget returns an `EventHandler` that uses channels or
@@ -68,6 +70,7 @@ The library loads the built in `AccentDark` palette, `RoundHybrid` style and a d
 // _ = eui.LoadTheme("MyTheme")
 // _ = eui.LoadStyle("MyStyle")
 ```
+Set `eui.AutoHiDPI = true` to keep the UI size consistent when switching between standard and high‑DPI displays.
 
 See [themes/README.md](eui/themes/README.md) for a list of the bundled schemes and details on creating your own.
 

--- a/api.md
+++ b/api.md
@@ -161,9 +161,13 @@ var (
 )
 var (
 
-	// AutoReload enables automatic reloading of theme and layout files
-	// when they are modified on disk, only use this for quickly iterating when designing your own themes.
-	AutoReload bool
+        // AutoReload enables automatic reloading of theme and layout files
+        // when they are modified on disk, only use this for quickly iterating when designing your own themes.
+        AutoReload bool
+
+       // AutoHiDPI enables automatic scaling when the device scale factor changes.
+       // The active UI scale is adjusted so the interface keeps the same size on screen.
+       AutoHiDPI bool
 )
 
 FUNCTIONS
@@ -263,6 +267,9 @@ func SetUIScale(scale float32)
     windows created with AutoSize.
 func UIScale() float32
     UIScale returns the current UI scale factor.
+func SyncHiDPIScale()
+    SyncHiDPIScale adjusts the UI scale automatically when the device scale
+    factor changes.
 func Update() error
     Update processes input and updates window state. Programs embedding the UI
     can call this from their Ebiten Update handler.

--- a/eui/glob.go
+++ b/eui/glob.go
@@ -37,6 +37,11 @@ var (
 
 	whiteImage    = ebiten.NewImage(3, 3)
 	whiteSubImage = whiteImage.SubImage(image.Rect(1, 1, 2, 2)).(*ebiten.Image)
+
+	// AutoHiDPI enables automatic scaling when the device scale factor
+	// changes, keeping the UI size consistent on HiDPI displays.
+	AutoHiDPI       bool
+	lastDeviceScale float64 = 1.0
 )
 
 func init() {
@@ -49,5 +54,8 @@ func init() {
 // Pass Ebiten's outside size values to this from your Layout function.
 func Layout(outsideWidth, outsideHeight int) (int, int) {
 	screenWidth, screenHeight = outsideWidth, outsideHeight
+	if AutoHiDPI {
+		SyncHiDPIScale()
+	}
 	return outsideWidth, outsideHeight
 }

--- a/eui/util.go
+++ b/eui/util.go
@@ -328,6 +328,20 @@ func SetUIScale(scale float32) {
 	markAllDirty()
 }
 
+// SyncHiDPIScale adjusts the UI scale when the device scale factor changes.
+// It preserves the current UI scale relative to the previous factor so the
+// interface keeps the same on-screen size.
+func SyncHiDPIScale() {
+	ds := ebiten.Monitor().DeviceScaleFactor()
+	if ds <= 0 {
+		ds = 1
+	}
+	if ds != lastDeviceScale {
+		SetUIScale(uiScale * float32(ds/lastDeviceScale))
+		lastDeviceScale = ds
+	}
+}
+
 func UIScale() float32 { return uiScale }
 
 func (win *windowData) GetTitleSize() float32 {


### PR DESCRIPTION
## Summary
- add `AutoHiDPI` option and track `lastDeviceScale`
- adjust UI scale in `Layout` when HiDPI is enabled
- expose `SyncHiDPIScale` helper
- document HiDPI support in README and API

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687f04886954832a97be7b416c8ed6db