### PR TITLE
Enable HiDPI scaling by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ building a game UI. Highlights include:
 - **UI scaling** – call `eui.SetUIScale()` to adapt to any resolution or
   `eui.UIScale()` to read the current value. Windows using `AutoSize` adjust
   their dimensions automatically when the scale changes.
-- **HiDPI support** – enable `eui.AutoHiDPI` or call `eui.SyncHiDPIScale()`
-  to match the device scale factor when moving between monitors.
+- **HiDPI support** – automatically adjusts the UI scale and screen resolution
+  to match the device scale factor. Disable by setting `eui.AutoHiDPI = false`.
 - **Image caching** – widgets cache their drawing for better performance.
   Enable `eui.DumpMode` to write the cached images to disk for inspection.
 - **Event system** – each widget returns an `EventHandler` that uses channels or
@@ -70,7 +70,7 @@ The library loads the built in `AccentDark` palette, `RoundHybrid` style and a d
 // _ = eui.LoadTheme("MyTheme")
 // _ = eui.LoadStyle("MyStyle")
 ```
-Set `eui.AutoHiDPI = true` to keep the UI size consistent when switching between standard and high‑DPI displays.
+HiDPI scaling is enabled by default so the UI keeps the same size on screen when switching between standard and high‑DPI displays. `eui.Layout` automatically scales the game screen to the device resolution. Set `eui.AutoHiDPI = false` to disable this behavior.
 
 See [themes/README.md](eui/themes/README.md) for a list of the bundled schemes and details on creating your own.
 

--- a/api.md
+++ b/api.md
@@ -167,6 +167,7 @@ var (
 
        // AutoHiDPI enables automatic scaling when the device scale factor changes.
        // The active UI scale is adjusted so the interface keeps the same size on screen.
+       // This defaults to true and can be disabled if necessary.
        AutoHiDPI bool
 )
 
@@ -198,8 +199,9 @@ func FontSource() *text.GoTextFaceSource
     FontSource returns the current text face source.
 
 func Layout(outsideWidth, outsideHeight int) (int, int)
-    Layout reports the dimensions for the game's screen. Pass Ebiten's outside
-    size values to this from your Layout function.
+    Layout reports the screen dimensions and scales the resolution using the
+    device scale factor. Pass Ebiten's outside size values to this from your
+    Layout function. Disable this behavior by setting `AutoHiDPI` to false.
 
 func ListStyles() ([]string, error)
     ListStyles returns the available style theme names.

--- a/eui/glob.go
+++ b/eui/glob.go
@@ -39,8 +39,9 @@ var (
 	whiteSubImage = whiteImage.SubImage(image.Rect(1, 1, 2, 2)).(*ebiten.Image)
 
 	// AutoHiDPI enables automatic scaling when the device scale factor
-	// changes, keeping the UI size consistent on HiDPI displays.
-	AutoHiDPI       bool
+	// changes, keeping the UI size consistent on HiDPI displays. It is
+	// enabled by default and can be disabled if needed.
+	AutoHiDPI       bool    = true
 	lastDeviceScale float64 = 1.0
 )
 
@@ -53,9 +54,16 @@ func init() {
 // Layout reports the dimensions for the game's screen.
 // Pass Ebiten's outside size values to this from your Layout function.
 func Layout(outsideWidth, outsideHeight int) (int, int) {
-	screenWidth, screenHeight = outsideWidth, outsideHeight
+	scale := 1.0
 	if AutoHiDPI {
+		scale = ebiten.Monitor().DeviceScaleFactor()
+		if scale <= 0 {
+			scale = 1
+		}
 		SyncHiDPIScale()
 	}
-	return outsideWidth, outsideHeight
+	scaledW := int(float64(outsideWidth) * scale)
+	scaledH := int(float64(outsideHeight) * scale)
+	screenWidth, screenHeight = scaledW, scaledH
+	return scaledW, scaledH
 }


### PR DESCRIPTION
## Summary
- default `AutoHiDPI` to `true`
- update `Layout` and `AutoHiDPI` documentation
- document automatic HiDPI scaling in README

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687f09cb9c10832aaa3a23974f6da86f