### PR TITLE
Add touch-aware pointer helpers

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -27,10 +27,10 @@ func Update() error {
 	prevHovered := hoveredItem
 	hoveredItem = nil
 
-	mx, my := ebiten.CursorPosition()
+	mx, my := pointerPosition()
 	mpos := point{X: float32(mx), Y: float32(my)}
 
-	click := inpututil.IsMouseButtonJustPressed(ebiten.MouseButton0)
+	click := pointerJustPressed()
 	if click {
 		if !dropdownOpenContainsAnywhere(mpos) {
 			closeAllDropdowns()
@@ -40,16 +40,16 @@ func Update() error {
 		}
 		focusedItem = nil
 	}
-	clickTime := inpututil.MouseButtonPressDuration(ebiten.MouseButton0)
+	clickTime := pointerPressDuration()
 	clickDrag := clickTime > 1
 
-	if !ebiten.IsMouseButtonPressed(ebiten.MouseButton0) {
+	if !pointerPressed() {
 		dragPart = PART_NONE
 		dragWin = nil
 		activeItem = nil
 	}
 
-	wx, wy := ebiten.Wheel()
+	wx, wy := pointerWheel()
 	wheelDelta := point{X: float32(wx), Y: float32(wy)}
 
 	posCh := pointScaleDiv(pointSub(mpos, mposOld))
@@ -353,7 +353,7 @@ func (item *itemData) clickFlows(mpos point, click bool) bool {
 }
 
 func (item *itemData) clickItem(mpos point, click bool) bool {
-	if ebiten.IsMouseButtonPressed(ebiten.MouseButton0) && activeItem != nil && activeItem != item {
+	if pointerPressed() && activeItem != nil && activeItem != item {
 		return false
 	}
 	// For dropdowns check the expanded option area as well
@@ -456,7 +456,7 @@ func (item *itemData) clickItem(mpos point, click bool) bool {
 			item.markDirty()
 		}
 		hoveredItem = item
-		if item.ItemType == ITEM_COLORWHEEL && ebiten.IsMouseButtonPressed(ebiten.MouseButton0) {
+		if item.ItemType == ITEM_COLORWHEEL && pointerPressed() {
 			if col, ok := item.colorAt(mpos); ok {
 				item.WheelColor = col
 				item.markDirty()
@@ -499,7 +499,7 @@ func (item *itemData) clickItem(mpos point, click bool) bool {
 				}
 			}
 		}
-		if item.ItemType == ITEM_SLIDER && ebiten.IsMouseButtonPressed(ebiten.MouseButton0) {
+		if item.ItemType == ITEM_SLIDER && pointerPressed() {
 			item.setSliderValue(mpos)
 			item.markDirty()
 			if item.Action != nil {

--- a/eui/pointer.go
+++ b/eui/pointer.go
@@ -1,0 +1,50 @@
+package eui
+
+import (
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/inpututil"
+)
+
+// pointerPosition returns the current pointer position.
+// If a touch is active, the first touch is used. Otherwise the mouse cursor position is returned.
+func pointerPosition() (int, int) {
+	ids := ebiten.AppendTouchIDs(nil)
+	if len(ids) > 0 {
+		return ebiten.TouchPosition(ids[0])
+	}
+	return ebiten.CursorPosition()
+}
+
+// pointerWheel returns the wheel delta when using a mouse.
+// For touch input this always returns zero.
+func pointerWheel() (float64, float64) {
+	if len(ebiten.AppendTouchIDs(nil)) > 0 {
+		return 0, 0
+	}
+	return ebiten.Wheel()
+}
+
+// pointerJustPressed reports whether the primary pointer was just pressed.
+func pointerJustPressed() bool {
+	if len(inpututil.AppendJustPressedTouchIDs(nil)) > 0 {
+		return true
+	}
+	return inpututil.IsMouseButtonJustPressed(ebiten.MouseButton0)
+}
+
+// pointerPressed reports whether the primary pointer is currently pressed.
+func pointerPressed() bool {
+	if len(ebiten.AppendTouchIDs(nil)) > 0 {
+		return true
+	}
+	return ebiten.IsMouseButtonPressed(ebiten.MouseButton0)
+}
+
+// pointerPressDuration returns how long the primary pointer has been pressed.
+func pointerPressDuration() int {
+	ids := ebiten.AppendTouchIDs(nil)
+	if len(ids) > 0 {
+		return inpututil.TouchPressDuration(ids[0])
+	}
+	return inpututil.MouseButtonPressDuration(ebiten.MouseButton0)
+}


### PR DESCRIPTION
## Summary
- add a pointer helper package so touch inputs emulate mouse
- use pointer helpers in input handling

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687f16dd61d4832a95fd25c3e8d15d73