### PR TITLE
Add touch scrolling and WASM scroll throttle

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ building a game UI. Highlights include:
   callbacks so your code can react to clicks, slider movements and text input.
 - **Debug overlays** – toggle with the `-debug` flag when running the demo.
 - **Cross platform** – runs anywhere Ebiten does: desktop, web or mobile.
-- Touch controls are not yet implemented.
+- Basic touch support with two‑finger scrolling.
+  Mouse scrolling is rate‑limited to 6 events per second on WebAssembly.
 
 ## Running the Demo
 

--- a/eui/pointer.go
+++ b/eui/pointer.go
@@ -1,9 +1,21 @@
 package eui
 
 import (
+	"runtime"
+	"time"
+
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/inpututil"
 )
+
+var (
+	lastWheelTime  time.Time
+	isWasm         = runtime.GOOS == "js" && runtime.GOARCH == "wasm"
+	touchScrolling bool
+	prevTouchAvg   = point{}
+)
+
+const touchScrollScale = 0.05
 
 // pointerPosition returns the current pointer position.
 // If a touch is active, the first touch is used. Otherwise the mouse cursor position is returned.
@@ -15,13 +27,39 @@ func pointerPosition() (int, int) {
 	return ebiten.CursorPosition()
 }
 
-// pointerWheel returns the wheel delta when using a mouse.
-// For touch input this always returns zero.
+// pointerWheel returns the wheel delta for mouse or two-finger touch scrolling.
 func pointerWheel() (float64, float64) {
-	if len(ebiten.AppendTouchIDs(nil)) > 0 {
-		return 0, 0
+	ids := ebiten.AppendTouchIDs(nil)
+	if len(ids) >= 2 {
+		// Average the first two touches to emulate wheel scrolling.
+		x0, y0 := ebiten.TouchPosition(ids[0])
+		x1, y1 := ebiten.TouchPosition(ids[1])
+		avgX := float64(x0+x1) / 2
+		avgY := float64(y0+y1) / 2
+
+		if !touchScrolling {
+			touchScrolling = true
+			prevTouchAvg = point{X: float32(avgX), Y: float32(avgY)}
+			return 0, 0
+		}
+
+		dx := (avgX - float64(prevTouchAvg.X)) * -touchScrollScale
+		dy := (avgY - float64(prevTouchAvg.Y)) * -touchScrollScale
+		prevTouchAvg = point{X: float32(avgX), Y: float32(avgY)}
+		return dx, dy
 	}
-	return ebiten.Wheel()
+
+	touchScrolling = false
+
+	wx, wy := ebiten.Wheel()
+	if isWasm {
+		now := time.Now()
+		if now.Sub(lastWheelTime) < time.Second/6 {
+			return 0, 0
+		}
+		lastWheelTime = now
+	}
+	return wx, wy
 }
 
 // pointerJustPressed reports whether the primary pointer was just pressed.


### PR DESCRIPTION
## Summary
- support two-finger touch scrolling
- detect wasm and throttle scroll events
- document the new touch controls and WASM scroll throttle

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687f215cd948832aa84068548359700f