### PR TITLE
Fix UI scale update when AutoHiDPI is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ building a game UI. Highlights include:
   them at runtime or reload automatically while iterating.
 - **UI scaling** – call `eui.SetUIScale()` to adapt to any resolution or
   `eui.UIScale()` to read the current value. Windows using `AutoSize` adjust
-  their dimensions automatically when the scale changes.
+  their dimensions automatically when the scale changes. When HiDPI scaling is
+  enabled the effective scale may change on the first layout pass. Call
+  `eui.UIScale()` after `eui.Layout` to obtain the final value.
 - **HiDPI support** – automatically adjusts the UI scale and screen resolution
   to match the device scale factor. Disable by setting `eui.AutoHiDPI = false`.
 - **Image caching** – widgets cache their drawing for better performance.

--- a/api.md
+++ b/api.md
@@ -167,7 +167,9 @@ var (
 
        // AutoHiDPI enables automatic scaling when the device scale factor changes.
        // The active UI scale is adjusted so the interface keeps the same size on screen.
-       // This defaults to true and can be disabled if necessary.
+       // This defaults to true and can be disabled if necessary. Applications
+       // that track their own scaling variables should call `UIScale()` after
+       // `Layout` to read the updated value.
        AutoHiDPI bool
 )
 
@@ -268,7 +270,8 @@ func SetUIScale(scale float32)
     SetUIScale updates layout metrics for the given scale and resizes
     windows created with AutoSize.
 func UIScale() float32
-    UIScale returns the current UI scale factor.
+    UIScale returns the current UI scale factor. When `AutoHiDPI` is enabled
+    the value may change after `Layout` applies the device scale factor.
 func SyncHiDPIScale()
     SyncHiDPIScale adjusts the UI scale automatically when the device scale
     factor changes.

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -103,6 +103,7 @@ func main() {
 	minusBtn, minusEvents := eui.NewButton(&eui.ItemData{Text: "-", Size: eui.Point{X: 24, Y: 24}, FontSize: 8})
 	minusEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventClick {
+			currentScale = eui.UIScale()
 			currentScale -= 0.25
 			if currentScale < 0.25 {
 				currentScale = 0.25
@@ -114,6 +115,7 @@ func main() {
 	plusBtn, plusEvents := eui.NewButton(&eui.ItemData{Text: "+", Size: eui.Point{X: 24, Y: 24}, FontSize: 8})
 	plusEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventClick {
+			currentScale = eui.UIScale()
 			currentScale += 0.25
 			if currentScale > 4.0 {
 				currentScale = 4


### PR DESCRIPTION
## Summary
- ensure the demo reads the actual scale before adjusting with +/- buttons
- document how AutoHiDPI affects `UIScale`
- update API notes for tracking device scale

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687f23d1fc00832a9439c16c6da40ab4