### PR TITLE
Fix click detection with multi-touch

### DIFF
--- a/eui/pointer.go
+++ b/eui/pointer.go
@@ -79,6 +79,10 @@ func pointerWheel() (float64, float64) {
 
 // pointerJustPressed reports whether the primary pointer was just pressed.
 func pointerJustPressed() bool {
+	ids := ebiten.AppendTouchIDs(nil)
+	if len(ids) > 1 {
+		return false
+	}
 	if len(inpututil.AppendJustPressedTouchIDs(nil)) > 0 {
 		return true
 	}


### PR DESCRIPTION
## Summary
- avoid passing click events if multiple touch points are active

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687f2e64f720832ab3194b71dd22df10