### PR TITLE
Clamp windows to screen bounds

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -150,6 +150,7 @@ func Update() error {
 				case PART_SCROLL_H:
 					dragWindowScroll(win, mpos, false)
 				}
+				win.clampToScreen()
 				break
 			}
 		}

--- a/eui/util_test.go
+++ b/eui/util_test.go
@@ -373,3 +373,14 @@ func TestStrokeRectParams(t *testing.T) {
 		t.Errorf("rect even width params %v %v %v", x, y, bw)
 	}
 }
+
+func TestClampToScreen(t *testing.T) {
+	screenWidth = 200
+	screenHeight = 150
+	win := &windowData{Size: point{X: 100, Y: 50}, Position: point{X: 120, Y: 110}}
+	win.clampToScreen()
+	pos := win.getPosition()
+	if pos.X+win.GetSize().X > float32(screenWidth) || pos.Y+win.GetSize().Y > float32(screenHeight) {
+		t.Errorf("window not clamped: %+v", pos)
+	}
+}

--- a/eui/window.go
+++ b/eui/window.go
@@ -97,6 +97,8 @@ func (target *windowData) AddWindow(toBack bool) {
 		target.AutoSize = false
 	}
 
+	target.clampToScreen()
+
 	if currentTheme != nil {
 		applyThemeToWindow(target)
 	}


### PR DESCRIPTION
## Summary
- add clampToScreen for windows to keep them within the screen
- only autosize windows on scale change if AutoSize is set
- clamp new windows and resized windows
- test clamping behavior

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687f2f057c64832a9887a6721c95e990