### PR TITLE
Fix corner window resizing

### DIFF
--- a/eui/util.go
+++ b/eui/util.go
@@ -264,13 +264,27 @@ func (win *windowData) getResizePart(mpos point) dragType {
 	inRect.Y1 -= t
 
 	if outRect.containsPoint(mpos) && !inRect.containsPoint(mpos) {
-		if mpos.Y < inRect.Y0 {
+		top := mpos.Y < inRect.Y0
+		bottom := mpos.Y > inRect.Y1
+		left := mpos.X < inRect.X0
+		right := mpos.X > inRect.X1
+
+		switch {
+		case top && left:
+			return PART_TOP_LEFT
+		case top && right:
+			return PART_TOP_RIGHT
+		case bottom && left:
+			return PART_BOTTOM_LEFT
+		case bottom && right:
+			return PART_BOTTOM_RIGHT
+		case top:
 			return PART_TOP
-		} else if mpos.Y > inRect.Y1 {
+		case bottom:
 			return PART_BOTTOM
-		} else if mpos.X < inRect.X0 {
+		case left:
 			return PART_LEFT
-		} else if mpos.X > inRect.X1 {
+		case right:
 			return PART_RIGHT
 		}
 	}


### PR DESCRIPTION
## Summary
- detect corners in `getResizePart` so diagonal resizing works

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687f347f9cec832a8f48b0f3f05af693