### PR TITLE
Fix window clamping on screen resize

### DIFF
--- a/api.md
+++ b/api.md
@@ -264,7 +264,8 @@ func SetFontSource(src *text.GoTextFaceSource)
     SetFontSource sets the text face source used when rendering text.
 
 func SetScreenSize(w, h int)
-    SetScreenSize sets the current screen size used for layout calculations.
+    SetScreenSize sets the current screen size used for layout calculations
+    and clamps existing windows to the new bounds.
 
 func SetUIScale(scale float32)
     SetUIScale updates layout metrics for the given scale and resizes

--- a/eui/glob.go
+++ b/eui/glob.go
@@ -64,6 +64,6 @@ func Layout(outsideWidth, outsideHeight int) (int, int) {
 	}
 	scaledW := int(float64(outsideWidth) * scale)
 	scaledH := int(float64(outsideHeight) * scale)
-	screenWidth, screenHeight = scaledW, scaledH
+	SetScreenSize(scaledW, scaledH)
 	return scaledW, scaledH
 }

--- a/eui/public.go
+++ b/eui/public.go
@@ -16,6 +16,23 @@ func Overlays() []*ItemData { return overlays }
 func SetScreenSize(w, h int) {
 	screenWidth = w
 	screenHeight = h
+	for _, win := range windows {
+		size := win.GetSize()
+		resized := false
+		if size.X > float32(screenWidth) {
+			win.Size.X = float32(screenWidth) / uiScale
+			resized = true
+		}
+		if size.Y > float32(screenHeight) {
+			win.Size.Y = float32(screenHeight) / uiScale
+			resized = true
+		}
+		if resized {
+			win.resizeFlows()
+			win.adjustScrollForResize()
+		}
+		win.clampToScreen()
+	}
 }
 
 // ScreenSize returns the current screen size.

--- a/eui/util_test.go
+++ b/eui/util_test.go
@@ -384,3 +384,18 @@ func TestClampToScreen(t *testing.T) {
 		t.Errorf("window not clamped: %+v", pos)
 	}
 }
+
+func TestSetScreenSizeClamps(t *testing.T) {
+	win := &windowData{Size: point{X: 100, Y: 50}, Position: point{X: 80, Y: 60}}
+	windows = []*windowData{win}
+	oldW, oldH := screenWidth, screenHeight
+	defer func() {
+		screenWidth, screenHeight = oldW, oldH
+		windows = nil
+	}()
+	SetScreenSize(90, 70)
+	pos := win.getPosition()
+	if pos.X+win.GetSize().X > float32(screenWidth) || pos.Y+win.GetSize().Y > float32(screenHeight) {
+		t.Errorf("window not clamped after SetScreenSize: %+v", pos)
+	}
+}


### PR DESCRIPTION
## Summary
- clamp existing windows in `SetScreenSize`
- call `SetScreenSize` from `Layout`
- document new behaviour in `api.md`
- test window clamping during screen resize

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687f3246b8f8832ab4195df3a16f5aa9