### PR TITLE
Fix inactive showcase window stacking on click

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -162,8 +162,10 @@ func Update() error {
 		// expanded dropdown. Break so windows behind don't receive the
 		// event.
 		if win.getWinRect().containsPoint(mpos) || dropdownOpenContains(win.Contents, mpos) {
-			if click && activeWindow != win {
-				win.BringForward()
+			if click {
+				if activeWindow != win || windows[len(windows)-1] != win {
+					win.BringForward()
+				}
 			}
 			break
 		}


### PR DESCRIPTION
## Summary
- bring clicked window to front even when already active

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687f3b4c643c832ab099a1a2c3dc3d4b