### PR TITLE
Increase corner resize zone

### DIFF
--- a/eui/const.go
+++ b/eui/const.go
@@ -9,7 +9,12 @@ const (
 	defaultTabWidth  = 128
 	defaultTabHeight = 24
 
+	// scrollTolerance defines the padding around window edges used to detect
+	// resize drags along the sides.
 	scrollTolerance = 2
+	// cornerTolerance defines the larger area around window corners used to
+	// detect diagonal resizing.
+	cornerTolerance = 16
 
 	// sliderMaxLabel defines the formatted text used to measure the value
 	// field of sliders. Using a constant ensures int and float sliders have

--- a/eui/util.go
+++ b/eui/util.go
@@ -250,7 +250,21 @@ func (win *windowData) getResizePart(mpos point) dragType {
 	}
 
 	t := scrollTolerance * uiScale
+	ct := cornerTolerance * uiScale
 	winRect := win.getWinRect()
+	// Check enlarged corner areas first
+	if mpos.X >= winRect.X0-ct && mpos.X <= winRect.X0+ct && mpos.Y >= winRect.Y0-ct && mpos.Y <= winRect.Y0+ct {
+		return PART_TOP_LEFT
+	}
+	if mpos.X >= winRect.X1-ct && mpos.X <= winRect.X1+ct && mpos.Y >= winRect.Y0-ct && mpos.Y <= winRect.Y0+ct {
+		return PART_TOP_RIGHT
+	}
+	if mpos.X >= winRect.X0-ct && mpos.X <= winRect.X0+ct && mpos.Y >= winRect.Y1-ct && mpos.Y <= winRect.Y1+ct {
+		return PART_BOTTOM_LEFT
+	}
+	if mpos.X >= winRect.X1-ct && mpos.X <= winRect.X1+ct && mpos.Y >= winRect.Y1-ct && mpos.Y <= winRect.Y1+ct {
+		return PART_BOTTOM_RIGHT
+	}
 	outRect := winRect
 	outRect.X0 -= t
 	outRect.X1 += t


### PR DESCRIPTION
## Summary
- widen window corner resize area to 16 pixels for easier dragging

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687f3bbc3a60832a90f5733fc7a8cecf