### PR TITLE
Switch border width calculations to rounding

### DIFF
--- a/eui/render.go
+++ b/eui/render.go
@@ -1109,7 +1109,7 @@ func drawRoundRect(screen *ebiten.Image, rrect *roundRect) {
 		indices  []uint16
 	)
 
-	width := float32(math.Floor(float64(rrect.Border)))
+	width := float32(math.Round(float64(rrect.Border)))
 	off := float32(0)
 	if !rrect.Filled {
 		off = pixelOffset(width)
@@ -1258,7 +1258,7 @@ func strokeTabShape(screen *ebiten.Image, pos point, size point, col Color, fill
 	)
 
 	// Align to pixel boundaries
-	border = float32(math.Floor(float64(border)))
+	border = float32(math.Round(float64(border)))
 	off := pixelOffset(border)
 	pos.X = float32(math.Round(float64(pos.X))) + off
 	pos.Y = float32(math.Round(float64(pos.Y))) + off
@@ -1306,7 +1306,7 @@ func strokeTabTop(screen *ebiten.Image, pos point, size point, col Color, fillet
 		indices  []uint16
 	)
 
-	border = float32(math.Floor(float64(border)))
+	border = float32(math.Round(float64(border)))
 	off := pixelOffset(border)
 	pos.X = float32(math.Round(float64(pos.X))) + off
 	pos.Y = float32(math.Round(float64(pos.Y))) + off

--- a/eui/util.go
+++ b/eui/util.go
@@ -679,14 +679,14 @@ func (win *windowData) resizeFlows() {
 }
 
 func pixelOffset(width float32) float32 {
-	if int(math.Floor(float64(width)))%2 == 0 {
+	if int(math.Round(float64(width)))%2 == 0 {
 		return 0
 	}
 	return 0.5
 }
 
 func strokeLine(dst *ebiten.Image, x0, y0, x1, y1, width float32, col color.Color, aa bool) {
-	width = float32(math.Floor(float64(width)))
+	width = float32(math.Round(float64(width)))
 	off := pixelOffset(width)
 	x0 = float32(math.Round(float64(x0))) + off
 	y0 = float32(math.Round(float64(y0))) + off
@@ -696,7 +696,7 @@ func strokeLine(dst *ebiten.Image, x0, y0, x1, y1, width float32, col color.Colo
 }
 
 func strokeRect(dst *ebiten.Image, x, y, w, h, width float32, col color.Color, aa bool) {
-	width = float32(math.Floor(float64(width)))
+	width = float32(math.Round(float64(width)))
 	off := pixelOffset(width)
 	x = float32(math.Round(float64(x))) + off
 	y = float32(math.Round(float64(y))) + off

--- a/eui/util_test.go
+++ b/eui/util_test.go
@@ -250,7 +250,7 @@ func TestPixelOffset(t *testing.T) {
 }
 
 func roundRectKeyPoints(rrect *roundRect) []point {
-	width := float32(math.Floor(float64(rrect.Border)))
+	width := float32(math.Round(float64(rrect.Border)))
 	off := float32(0)
 	if !rrect.Filled {
 		off = pixelOffset(width)


### PR DESCRIPTION
## Summary
- round border widths instead of flooring
- update unit tests accordingly

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687f3e484b94832aa8d8af50435cc9b6