### PR TITLE
Fix dropdown scrolling

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -369,6 +369,9 @@ func (item *itemData) clickItem(mpos point, click bool) bool {
 			if visible <= 0 {
 				visible = 5
 			}
+			if visible > len(item.Options) {
+				visible = len(item.Options)
+			}
 			startY := item.DrawRect.Y1
 			openHeight := optionH * float32(visible)
 			r := rect{X0: item.DrawRect.X0, Y0: startY, X1: item.DrawRect.X1, Y1: startY + openHeight}
@@ -426,6 +429,9 @@ func (item *itemData) clickItem(mpos point, click bool) bool {
 				if visible <= 0 {
 					visible = 5
 				}
+				if visible > len(item.Options) {
+					visible = len(item.Options)
+				}
 				startY := item.DrawRect.Y1
 				openHeight := optionH * float32(visible)
 				r := rect{X0: item.DrawRect.X0, Y0: startY, X1: item.DrawRect.X1, Y1: startY + openHeight}
@@ -479,6 +485,9 @@ func (item *itemData) clickItem(mpos point, click bool) bool {
 			visible := item.MaxVisible
 			if visible <= 0 {
 				visible = 5
+			}
+			if visible > len(item.Options) {
+				visible = len(item.Options)
 			}
 			startY := item.DrawRect.Y1
 			openHeight := optionH * float32(visible)
@@ -694,11 +703,17 @@ func scrollDropdown(items []*itemData, mpos point, delta point) bool {
 			if visible <= 0 {
 				visible = 5
 			}
+			if visible > len(it.Options) {
+				visible = len(it.Options)
+			}
 			startY := it.DrawRect.Y1
 			openH := optionH * float32(visible)
 			r := rect{X0: it.DrawRect.X0, Y0: startY, X1: it.DrawRect.X1, Y1: startY + openH}
 			if r.containsPoint(mpos) {
 				maxScroll := optionH*float32(len(it.Options)) - openH
+				if maxScroll < 0 {
+					maxScroll = 0
+				}
 				it.Scroll.Y -= delta.Y * optionH
 				if it.Scroll.Y < 0 {
 					it.Scroll.Y = 0
@@ -821,6 +836,9 @@ func dropdownOpenContains(items []*itemData, mpos point) bool {
 			if visible <= 0 {
 				visible = 5
 			}
+			if visible > len(it.Options) {
+				visible = len(it.Options)
+			}
 			startY := it.DrawRect.Y1
 			openH := optionH * float32(visible)
 			r := rect{X0: it.DrawRect.X0, Y0: startY, X1: it.DrawRect.X1, Y1: startY + openH}
@@ -850,6 +868,9 @@ func clickOpenDropdown(items []*itemData, mpos point, click bool) bool {
 			visible := it.MaxVisible
 			if visible <= 0 {
 				visible = 5
+			}
+			if visible > len(it.Options) {
+				visible = len(it.Options)
 			}
 			startY := it.DrawRect.Y1
 			openH := optionH * float32(visible)

--- a/eui/render.go
+++ b/eui/render.go
@@ -1009,6 +1009,9 @@ func drawDropdownOptions(item *itemData, offset point, clip rect, screen *ebiten
 	if visible <= 0 {
 		visible = 5
 	}
+	if visible > len(item.Options) {
+		visible = len(item.Options)
+	}
 	startY := offset.Y + maxSize.Y
 	first := int(item.Scroll.Y / optionH)
 	offY := startY - (item.Scroll.Y - float32(first)*optionH)
@@ -1053,6 +1056,20 @@ func drawDropdownOptions(item *itemData, offset point, clip rect, screen *ebiten
 		tdo := &text.DrawOptions{DrawImageOptions: td, LayoutOptions: loo}
 		tdo.ColorScale.ScaleWithColor(style.TextColor)
 		text.Draw(subImg, item.Options[i], face, tdo)
+	}
+
+	if len(item.Options) > visible {
+		openH := optionH * float32(visible)
+		totalH := optionH * float32(len(item.Options))
+		barH := openH * openH / totalH
+		maxScroll := totalH - openH
+		pos := float32(0)
+		if maxScroll > 0 {
+			pos = (item.Scroll.Y / maxScroll) * (openH - barH)
+		}
+		col := NewColor(96, 96, 96, 192)
+		sbW := currentStyle.BorderPad.Slider * 2
+		drawFilledRect(subImg, drawRect.X1-sbW, startY+pos, sbW, barH, col.ToRGBA(), false)
 	}
 }
 


### PR DESCRIPTION
## Summary
- prevent dropdown scroll index errors by clamping MaxVisible to the option count
- draw vertical scrollbars for dropdowns when there are more items than visible

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687f3f413b68832aa303055ca2dc8c7a