### PR TITLE
Limit wasm scroll with x/time rate limiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ building a game UI. Highlights include:
 - **Debug overlays** – toggle with the `-debug` flag when running the demo.
 - **Cross platform** – runs anywhere Ebiten does: desktop, web or mobile.
 - **Basic touch support** – with two‑finger scrolling (drag up to scroll up).
-  Mouse scrolling is clamped to +/-1 and rate-limited to 10 events per second on WebAssembly.
+  Mouse scrolling is clamped to +/-3 and rate-limited to 4 events per half-second on WebAssembly.
 
 ## Running the Demo
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module EUI
 
 go 1.23.2
 
-require github.com/hajimehoshi/ebiten/v2 v2.8.5
+require (
+	github.com/hajimehoshi/ebiten/v2 v2.8.5
+	golang.org/x/time v0.12.0
+)
 
 require (
 	github.com/ebitengine/gomobile v0.0.0-20240911145611-4856209ac325 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,3 +24,5 @@ golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
 golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.18.0 h1:XvMDiNzPAl0jr17s6W9lcaIhGUfUORdGCNsuLmPG224=
 golang.org/x/text v0.18.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=
+golang.org/x/time v0.12.0 h1:ScB/8o8olJvc+CQPWrK3fPZNfh7qgwCrY0zJmoEQLSE=
+golang.org/x/time v0.12.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=


### PR DESCRIPTION
## Summary
- control scroll rate in `pointer.go` using a limiter
- add `golang.org/x/time` dependency
- document the new rate limit in README

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687f40e969f0832aa26149596d5b022a