### PR TITLE
Fix dropdown scroll speed

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -714,7 +714,9 @@ func scrollDropdown(items []*itemData, mpos point, delta point) bool {
 				if maxScroll < 0 {
 					maxScroll = 0
 				}
-				it.Scroll.Y -= delta.Y * optionH
+				// Use the same scaling as window scrolling for a
+				// consistent feel across widgets.
+				it.Scroll.Y -= delta.Y * 16
 				if it.Scroll.Y < 0 {
 					it.Scroll.Y = 0
 				}


### PR DESCRIPTION
## Summary
- drop-down scrolling should match window scroll speed

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687f450ecd1c832abf6b06fed82925d6