### PR TITLE
Fix flow label rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ EUI aims to stay small and easy to use while still providing the essentials for
 building a game UI. Highlights include:
 
 - **Window management** – draggable, resizable windows with optional pinning.
-- **Flow layouts** – vertical or horizontal flows for composing widgets.
+ - **Flow layouts** – vertical or horizontal flows for composing widgets. Flows
+   can optionally draw labels and borders to visually group content.
 - **Overlay items** – keep controls always on screen.
 - **Palette and style themes** – JSON files define colors and spacing. Switch
   them at runtime or reload automatically while iterating.

--- a/eui/render.go
+++ b/eui/render.go
@@ -299,6 +299,9 @@ func (item *itemData) drawFlows(win *windowData, parent *itemData, offset point,
 	}
 	subImg := screen.SubImage(item.DrawRect.getRectangle()).(*ebiten.Image)
 	style := item.themeStyle()
+	if style == nil {
+		style = &itemData{}
+	}
 
 	labelPad := float32(0)
 	if item.Label != "" {
@@ -322,7 +325,8 @@ func (item *itemData) drawFlows(win *windowData, parent *itemData, offset point,
 	if maxSize.Y < 0 {
 		maxSize.Y = 0
 	}
-	if item.Filled {
+	drawContainer := len(item.Tabs) == 0 || item.Label != "" || item.Border > 0 || item.Outlined
+	if drawContainer && item.Filled {
 		drawRoundRect(subImg, &roundRect{
 			Size:     maxSize,
 			Position: contentOff,
@@ -331,7 +335,7 @@ func (item *itemData) drawFlows(win *windowData, parent *itemData, offset point,
 			Color:    style.Color,
 		})
 	}
-	if item.Outlined || item.Border > 0 {
+	if drawContainer && (item.Outlined || item.Border > 0) {
 		border := item.Border * uiScale
 		if border <= 0 {
 			border = 1 * uiScale

--- a/eui/util.go
+++ b/eui/util.go
@@ -570,8 +570,12 @@ func (item *itemData) contentBounds() point {
 		}
 		list = item.Tabs[item.ActiveTab].Contents
 	}
+	labelPad := float32(0)
+	if item.ItemType == ITEM_FLOW && item.Label != "" {
+		labelPad = (item.FontSize*uiScale + 2) + currentStyle.TextPadding*uiScale
+	}
 	if len(list) == 0 {
-		return point{}
+		return point{Y: labelPad}
 	}
 
 	base := point{}
@@ -609,9 +613,13 @@ func (item *itemData) contentBounds() point {
 	}
 
 	if first {
-		return point{}
+		return point{Y: labelPad}
 	}
-	return point{X: b.X1 - base.X, Y: b.Y1 - base.Y}
+	size := point{X: b.X1 - base.X, Y: b.Y1 - base.Y}
+	if item.ItemType == ITEM_FLOW {
+		size.Y += labelPad
+	}
+	return size
 }
 
 func (item *itemData) resizeFlow(parentSize point) {

--- a/eui/util.go
+++ b/eui/util.go
@@ -414,7 +414,7 @@ func (win *windowData) GetPos() point {
 
 func (item *itemData) GetSize() point {
 	sz := point{X: item.Size.X * uiScale, Y: item.Size.Y * uiScale}
-	if item.Label != "" {
+	if item.ItemType != ITEM_FLOW && item.Label != "" {
 		textSize := (item.FontSize * uiScale) + 2
 		sz.Y += textSize + currentStyle.TextPadding*uiScale
 	}


### PR DESCRIPTION
## Summary
- enable labels and borders for flows so they can act as groups
- include flow labels in size calculations
- update README to mention optional flow labels and borders

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687f479654e8832abf1ebbd06db50690