### PR TITLE
Fix bottom-right theme button hitbox

### DIFF
--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -60,7 +60,7 @@ func main() {
 	overlay := &eui.ItemData{
 		ItemType: eui.ITEM_FLOW,
 		FlowType: eui.FLOW_HORIZONTAL,
-		Size:     eui.Point{X: 84, Y: 32},
+		Size:     eui.Point{X: 80, Y: 24},
 		Position: eui.Point{X: 4, Y: 4},
 		PinTo:    eui.PIN_BOTTOM_RIGHT,
 	}


### PR DESCRIPTION
## Summary
- resize the theme selector overlay to match the toggle button

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687f51617e08832a87483b6d53144b27