### PR TITLE
Clamp UI scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ building a game UI. Highlights include:
 - **Palette and style themes** – JSON files define colors and spacing. Switch
   them at runtime or reload automatically while iterating.
 - **UI scaling** – call `eui.SetUIScale()` to adapt to any resolution or
-  `eui.UIScale()` to read the current value. Windows using `AutoSize` adjust
-  their dimensions automatically when the scale changes. When HiDPI scaling is
-  enabled the effective scale may change on the first layout pass. Call
-  `eui.UIScale()` after `eui.Layout` to obtain the final value.
+  `eui.UIScale()` to read the current value. The scale is clamped between 0.5
+  and 2.5. Windows using `AutoSize` adjust their dimensions automatically when
+  the scale changes. When HiDPI scaling is enabled the effective scale may
+  change on the first layout pass. Call `eui.UIScale()` after `eui.Layout` to
+  obtain the final value.
 - **HiDPI support** – automatically adjusts the UI scale and screen resolution
   to match the device scale factor. Disable by setting `eui.AutoHiDPI = false`.
 - **Image caching** – widgets cache their drawing for better performance.

--- a/api.md
+++ b/api.md
@@ -269,7 +269,8 @@ func SetScreenSize(w, h int)
 
 func SetUIScale(scale float32)
     SetUIScale updates layout metrics for the given scale and resizes
-    windows created with AutoSize.
+    windows created with AutoSize. The value is clamped to the range
+    0.5–2.5.
 func UIScale() float32
     UIScale returns the current UI scale factor. When `AutoHiDPI` is enabled
     the value may change after `Layout` applies the device scale factor.

--- a/eui/util.go
+++ b/eui/util.go
@@ -413,6 +413,12 @@ func (win *windowData) SetTitleSize(size float32) {
 }
 
 func SetUIScale(scale float32) {
+	if scale < 0.5 {
+		scale = 0.5
+	}
+	if scale > 2.5 {
+		scale = 2.5
+	}
 	uiScale = scale
 	for _, win := range windows {
 		if win.AutoSize {


### PR DESCRIPTION
## Summary
- clamp `SetUIScale` to 0.5–2.5
- document UI scale clamping in README and `api.md`

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687f5540e70c832aa7f3de4d7258a52d