### PR TITLE
Fix overlay layering for theme button

### DIFF
--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -84,7 +84,6 @@ func main() {
 		themeSel.MarkOpen()
 	}
 	overlay.AddItem(toggleBtn)
-	eui.AddOverlayFlow(overlay)
 
 	statusOverlay := &eui.ItemData{
 		ItemType: eui.ITEM_FLOW,
@@ -135,6 +134,8 @@ func main() {
 	scaleOverlay.AddItem(textItem)
 
 	eui.AddOverlayFlow(scaleOverlay)
+	// Add the theme toggle overlay last so it stays on top
+	eui.AddOverlayFlow(overlay)
 
 	go startEbiten()
 


### PR DESCRIPTION
## Summary
- keep theme toggle overlay on top of other overlays

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687f55c95628832a855c091aa8bce1cb