### PR TITLE
Improve defaults for element constructors

### DIFF
--- a/api.md
+++ b/api.md
@@ -156,28 +156,36 @@ func LoadTheme(name string) error
     the current theme without modifying existing windows.
 
 func NewButton(item *itemData) (*itemData, *EventHandler)
-    Create a new button from the default theme
+    Create a new button from the default theme. Unspecified fields
+    inherit their values from the theme.
 
 func NewCheckbox(item *itemData) (*itemData, *EventHandler)
-    Create a new button from the default theme
+    Create a new button from the default theme. Unspecified fields
+    inherit their values from the theme.
 
 func NewColorWheel(item *itemData) (*itemData, *EventHandler)
-    Create a new color wheel from the default theme
+    Create a new color wheel from the default theme. Unspecified fields
+    inherit their values from the theme.
 
 func NewDropdown(item *itemData) (*itemData, *EventHandler)
-    Create a new dropdown from the default theme
+    Create a new dropdown from the default theme. Unspecified fields
+    inherit their values from the theme.
 
 func NewInput(item *itemData) (*itemData, *EventHandler)
-    Create a new input box from the default theme
+    Create a new input box from the default theme. Unspecified fields
+    inherit their values from the theme.
 
 func NewRadio(item *itemData) (*itemData, *EventHandler)
-    Create a new radio button from the default theme
+    Create a new radio button from the default theme. Unspecified fields
+    inherit their values from the theme.
 
 func NewSlider(item *itemData) (*itemData, *EventHandler)
-    Create a new slider from the default theme
+    Create a new slider from the default theme. Unspecified fields
+    inherit their values from the theme.
 
 func NewText(item *itemData) (*itemData, *EventHandler)
-    Create a new textbox from the default theme
+    Create a new textbox from the default theme. Unspecified fields
+    inherit their values from the theme.
 
 func SaveTheme(name string) error
     SaveTheme writes the current theme to a JSON file with the given name.
@@ -221,7 +229,8 @@ func Update() error
     can call this from their Ebiten Update handler.
 
 func NewWindow(win *windowData) *windowData
-    Create a new window from the default theme
+    Create a new window from the default theme. Unspecified fields
+    inherit their values from the theme.
 
 TYPES
 

--- a/eui/window.go
+++ b/eui/window.go
@@ -34,10 +34,13 @@ func mergeData(original interface{}, updates interface{}) interface{} {
 			continue
 		}
 
-		// Booleans need to be copied even when false so themes can
-		// explicitly disable features like outlines or drag bars.
+		// Booleans default to the theme value when false so callers
+		// can omit them without overwriting defaults. Explicit true
+		// values are still applied.
 		if updField.Kind() == reflect.Bool {
-			origField.Set(updField)
+			if updField.Bool() {
+				origField.Set(updField)
+			}
 			continue
 		}
 


### PR DESCRIPTION
## Summary
- keep theme values when bool fields aren't specified
- document that constructors inherit theme defaults

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6880715106e8832a937ea3823440285b