### PR TITLE
Fix unfixed flow bounds

### DIFF
--- a/eui/util.go
+++ b/eui/util.go
@@ -509,11 +509,17 @@ func markAllDirty() {
 }
 
 func (item *itemData) bounds(offset point) rect {
-	r := rect{
-		X0: offset.X,
-		Y0: offset.Y,
-		X1: offset.X + item.GetSize().X,
-		Y1: offset.Y + item.GetSize().Y,
+	var r rect
+	if item.ItemType == ITEM_FLOW && !item.Fixed {
+		// Unfixed flows should report bounds based solely on their content
+		r = rect{X0: offset.X, Y0: offset.Y, X1: offset.X, Y1: offset.Y}
+	} else {
+		r = rect{
+			X0: offset.X,
+			Y0: offset.Y,
+			X1: offset.X + item.GetSize().X,
+			Y1: offset.Y + item.GetSize().Y,
+		}
 	}
 	if item.ItemType == ITEM_FLOW {
 		var flowOffset point


### PR DESCRIPTION
## Summary
- compute bounds for non-fixed flows from their contents so they do not expand indefinitely

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68810577065c832a8cc8c57bfc9e684e