### PR TITLE
Fix flow sizing when added to windows

### DIFF
--- a/eui/util.go
+++ b/eui/util.go
@@ -73,6 +73,7 @@ func (parent *windowData) addItemTo(item *itemData) {
 		applyThemeToItem(item)
 	}
 	parent.Contents = append(parent.Contents, item)
+	item.resizeFlow(parent.GetSize())
 }
 
 func (win *windowData) getMainRect() rect {


### PR DESCRIPTION
## Summary
- resize flows immediately when added to a window so new items update size

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_688109c07128832a969fe24cac5632a4