### PR TITLE
Fix flow sizing on item addition

### DIFF
--- a/eui/util.go
+++ b/eui/util.go
@@ -66,6 +66,9 @@ func (parent *itemData) addItemTo(item *itemData) {
 		applyThemeToItem(item)
 	}
 	parent.Contents = append(parent.Contents, item)
+	if parent.ItemType == ITEM_FLOW {
+		parent.resizeFlow(parent.GetSize())
+	}
 }
 
 func (parent *windowData) addItemTo(item *itemData) {


### PR DESCRIPTION
## Summary
- recalc parent flow size when new items are appended

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68810de9d6cc832aa943a6fb50a68536