### PR TITLE
Add window tree JSON dump

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ building a game UI. Highlights include:
   to match the device scale factor. Disable by setting `eui.AutoHiDPI = false`.
 - **Image caching** – widgets cache their drawing for better performance.
   Enable `eui.DumpMode` to write the cached images to disk for inspection.
+- **Tree dump** – press <kbd>Shift</kbd>+<kbd>`</kbd> or run the demo with
+  `-tree` to save the window hierarchy as JSON.
 - **Event system** – each widget returns an `EventHandler` that uses channels or
   callbacks so your code can react to clicks, slider movements and text input.
 - **Debug overlays** – toggle with the `-debug` flag when running the demo.
@@ -48,6 +50,8 @@ go build -o demo ./cmd/demo
 ./demo -debug                 # optional debug overlays and disposal logs
 # dump cached images to ./debug after one frame then exit
 ./demo -dump
+# dump the window tree to ./debug/tree.json then exit
+./demo -tree
 # pass -debug with go run to enable overlays
 go run ./cmd/demo -debug
 ```

--- a/api.md
+++ b/api.md
@@ -94,9 +94,13 @@ var (
 	// DebugMode enables rendering of debug outlines.
 	DebugMode bool
 
-	// DumpMode causes the library to write cached images to disk
-	// before exiting when enabled.
-	DumpMode bool
+        // DumpMode causes the library to write cached images to disk
+        // before exiting when enabled.
+        DumpMode bool
+
+        // TreeMode dumps the window hierarchy to debug/tree.json
+        // before exiting when enabled.
+        TreeMode bool
 )
 var (
 
@@ -132,6 +136,9 @@ func DumpCachedImages() error
     DumpCachedImages writes all cached item images and item source images to the
     debug directory. The game must be running so pixels can be read. Any pending
     renders are generated before writing the files.
+
+func DumpTree() error
+    DumpTree writes the window and overlay hierarchy to debug/tree.json.
 
 func EnsureFontSource(ttf []byte) error
     EnsureFontSource initializes the font source from ttf data if needed.

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -16,6 +16,7 @@ import (
 var (
 	debugMode    *bool
 	dumpMode     *bool
+	treeMode     *bool
 	themeSel     *eui.WindowData
 	signalHandle chan os.Signal
 	currentScale float32
@@ -25,9 +26,11 @@ func main() {
 
 	debugMode = flag.Bool("debug", false, "enable debug visuals")
 	dumpMode = flag.Bool("dump", false, "dump cached images and exit")
+	treeMode = flag.Bool("tree", false, "dump window tree and exit")
 	flag.Parse()
 	eui.DebugMode = *debugMode
 	eui.DumpMode = *dumpMode
+	eui.TreeMode = *treeMode
 
 	signalHandle = make(chan os.Signal, 1)
 	signal.Notify(signalHandle, syscall.SIGINT, syscall.SIGTERM, os.Interrupt)

--- a/cmd/settings/main.go
+++ b/cmd/settings/main.go
@@ -16,6 +16,7 @@ import (
 var (
 	debugMode    *bool
 	dumpMode     *bool
+	treeMode     *bool
 	signalHandle chan os.Signal
 	currentScale float32
 )
@@ -24,9 +25,11 @@ func main() {
 
 	debugMode = flag.Bool("debug", false, "enable debug visuals")
 	dumpMode = flag.Bool("dump", false, "dump cached images and exit")
+	treeMode = flag.Bool("tree", false, "dump window tree and exit")
 	flag.Parse()
 	eui.DebugMode = *debugMode
 	eui.DumpMode = *dumpMode
+	eui.TreeMode = *treeMode
 
 	signalHandle = make(chan os.Signal, 1)
 	signal.Notify(signalHandle, syscall.SIGINT, syscall.SIGTERM, os.Interrupt)

--- a/eui/glob.go
+++ b/eui/glob.go
@@ -35,6 +35,10 @@ var (
 	// before exiting when enabled.
 	DumpMode bool
 
+	// TreeMode dumps the window hierarchy to debug/tree.json
+	// before exiting when enabled.
+	TreeMode bool
+
 	whiteImage    = ebiten.NewImage(3, 3)
 	whiteSubImage = whiteImage.SubImage(image.Rect(1, 1, 2, 2)).(*ebiten.Image)
 

--- a/eui/input.go
+++ b/eui/input.go
@@ -24,6 +24,11 @@ func Update() error {
 
 	checkThemeStyleMods()
 
+	if inpututil.IsKeyJustPressed(ebiten.KeyGraveAccent) &&
+		(ebiten.IsKeyPressed(ebiten.KeyShift) || ebiten.IsKeyPressed(ebiten.KeyShiftLeft) || ebiten.IsKeyPressed(ebiten.KeyShiftRight)) {
+		_ = DumpTree()
+	}
+
 	prevHovered := hoveredItem
 	hoveredItem = nil
 

--- a/eui/render.go
+++ b/eui/render.go
@@ -57,6 +57,13 @@ func Draw(screen *ebiten.Image) {
 		dumpDone = true
 		os.Exit(0)
 	}
+	if TreeMode && !dumpDone {
+		if err := DumpTree(); err != nil {
+			panic(err)
+		}
+		dumpDone = true
+		os.Exit(0)
+	}
 }
 
 func drawOverlay(item *itemData, screen *ebiten.Image) {

--- a/eui/tree.go
+++ b/eui/tree.go
@@ -1,0 +1,98 @@
+package eui
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// DumpTree writes the window and overlay hierarchy to debug/tree.json.
+func DumpTree() error {
+	if err := os.MkdirAll("debug", 0755); err != nil {
+		return err
+	}
+	tree := struct {
+		Windows  []treeWindow `json:"windows"`
+		Overlays []treeItem   `json:"overlays"`
+	}{}
+	for _, w := range windows {
+		tw := treeWindow{
+			Title:    w.Title,
+			Position: w.Position,
+			Size:     w.Size,
+			PinTo:    w.PinTo,
+		}
+		for _, it := range w.Contents {
+			tw.Items = append(tw.Items, makeTreeItem(it))
+		}
+		tree.Windows = append(tree.Windows, tw)
+	}
+	for _, ov := range overlays {
+		tree.Overlays = append(tree.Overlays, makeTreeItem(ov))
+	}
+	data, err := json.MarshalIndent(tree, "", "  ")
+	if err != nil {
+		return err
+	}
+	fn := filepath.Join("debug", "tree.json")
+	return os.WriteFile(fn, data, 0644)
+}
+
+type treeWindow struct {
+	Title    string     `json:"title"`
+	Position point      `json:"position"`
+	Size     point      `json:"size"`
+	PinTo    pinType    `json:"pin_to"`
+	Items    []treeItem `json:"items"`
+}
+
+type treeItem struct {
+	Name     string     `json:"name,omitempty"`
+	Text     string     `json:"text,omitempty"`
+	Type     string     `json:"type"`
+	Position point      `json:"position"`
+	Size     point      `json:"size"`
+	Items    []treeItem `json:"items,omitempty"`
+}
+
+func makeTreeItem(it *itemData) treeItem {
+	ti := treeItem{
+		Name:     it.Name,
+		Text:     it.Text,
+		Type:     itemTypeName(it.ItemType),
+		Position: it.Position,
+		Size:     it.Size,
+	}
+	for _, c := range it.Contents {
+		ti.Items = append(ti.Items, makeTreeItem(c))
+	}
+	for _, t := range it.Tabs {
+		ti.Items = append(ti.Items, makeTreeItem(t))
+	}
+	return ti
+}
+
+func itemTypeName(t itemTypeData) string {
+	switch t {
+	case ITEM_FLOW:
+		return "flow"
+	case ITEM_TEXT:
+		return "text"
+	case ITEM_BUTTON:
+		return "button"
+	case ITEM_CHECKBOX:
+		return "checkbox"
+	case ITEM_RADIO:
+		return "radio"
+	case ITEM_INPUT:
+		return "input"
+	case ITEM_SLIDER:
+		return "slider"
+	case ITEM_DROPDOWN:
+		return "dropdown"
+	case ITEM_COLORWHEEL:
+		return "colorwheel"
+	default:
+		return "unknown"
+	}
+}


### PR DESCRIPTION
## Summary
- dump window hierarchy to debug/tree.json with `DumpTree`
- press <kbd>Shift</kbd>+<kbd>`</kbd> to dump at runtime
- add `-tree` CLI option for automated dump
- document new feature and API

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_688113c7ce38832a9a541e9280e40416