### PR TITLE
Add window refresh function and disable FPS display

### DIFF
--- a/api.md
+++ b/api.md
@@ -373,4 +373,7 @@ func Windows() []*WindowData
 
 func (win *WindowData) AddItem(child *ItemData)
     AddItem appends a child item to the window.
+
+func (win *WindowData) Refresh()
+    Refresh forces the window to recalculate layout and scrolling after modifying contents.
 ```

--- a/eui/render.go
+++ b/eui/render.go
@@ -48,7 +48,7 @@ func Draw(screen *ebiten.Image) {
 		drawDropdownOptions(dr.item, dr.offset, dr.clip, screen)
 	}
 
-	drawFPS(screen)
+	// drawFPS(screen)
 
 	if DumpMode && !dumpDone {
 		if err := DumpCachedImages(); err != nil {

--- a/eui/window.go
+++ b/eui/window.go
@@ -525,3 +525,9 @@ func (win windowData) itemOverlap(size point) (bool, bool) {
 
 	return xc, yc
 }
+
+// Refresh forces the window to recalculate layout and scrolling after modifying contents.
+func (win *windowData) Refresh() {
+	win.resizeFlows()
+	win.adjustScrollForResize()
+}


### PR DESCRIPTION
## Summary
- hide FPS overlay in the renderer
- add exported `Refresh` method to `WindowData` for manual layout updates
- document new `Refresh` API

## Testing
- `go vet ./...` *(fails: package EUI/eui is not in std)*
- `go build ./...` *(fails: package EUI/eui is not in std)*
- `go vet ./eui`
- `go build ./eui`


------
https://chatgpt.com/codex/tasks/task_e_6891d876f788832ab0da38a19a041c71