### PR TITLE
Ensure window refresh triggers re-render

### DIFF
--- a/eui/window.go
+++ b/eui/window.go
@@ -556,4 +556,7 @@ func (win windowData) itemOverlap(size point) (bool, bool) {
 func (win *windowData) Refresh() {
 	win.resizeFlows()
 	win.adjustScrollForResize()
+	for _, it := range win.Contents {
+		markItemTreeDirty(it)
+	}
 }


### PR DESCRIPTION
## Summary
- Mark all window contents dirty during Refresh so layout changes get rerendered

## Testing
- `go vet ./...` *(fails: package EUI/eui is not in std)*
- `go build ./...` *(fails: package EUI/eui is not in std)*

------
https://chatgpt.com/codex/tasks/task_e_6891dc87be10832aa925315d1b722b47