### PR TITLE
Add auto-size behavior to window Refresh

### DIFF
--- a/api.md
+++ b/api.md
@@ -375,5 +375,6 @@ func (win *WindowData) AddItem(child *ItemData)
     AddItem appends a child item to the window.
 
 func (win *WindowData) Refresh()
-    Refresh forces the window to recalculate layout and scrolling after modifying contents.
+    Refresh forces the window to recalculate layout, resize to its contents and
+    adjust scrolling after modifying contents.
 ```

--- a/eui/window.go
+++ b/eui/window.go
@@ -552,9 +552,10 @@ func (win windowData) itemOverlap(size point) (bool, bool) {
 	return xc, yc
 }
 
-// Refresh forces the window to recalculate layout and scrolling after modifying contents.
+// Refresh forces the window to recalculate layout, resize to its contents,
+// and adjust scrolling after modifying contents.
 func (win *windowData) Refresh() {
-	win.resizeFlows()
+	win.updateAutoSize()
 	win.adjustScrollForResize()
 	for _, it := range win.Contents {
 		markItemTreeDirty(it)


### PR DESCRIPTION
## Summary
- ensure `Refresh` resizes windows to fit their content and updates scrolling
- document that Refresh now adjusts window size in addition to layout

## Testing
- `go vet ./...` *(fails: package EUI/eui is not in std)*
- `go build ./...` *(fails: package EUI/eui is not in std)*
- `go vet ./eui`
- `go build ./eui`


------
https://chatgpt.com/codex/tasks/task_e_6891e0469bdc832a8f9018cb13d50ba2