### PR TITLE
Add image label support for widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ building a game UI. Highlights include:
 - **Cross platform** – runs anywhere Ebiten does: desktop, web or mobile.
 - **Basic touch support** – with two‑finger scrolling (drag up to scroll up).
   Mouse scrolling is clamped to +/-3 and rate-limited to 4 events per half-second on WebAssembly.
+- **Image labels** – buttons, sliders, checkboxes, radios and dropdowns can use an image instead of text for their labels.
 
 ## Running the Demo
 

--- a/api.md
+++ b/api.md
@@ -275,6 +275,8 @@ type FlowType = flowType
 
 
 type ItemData = itemData
+    ItemData represents a widget. Set LabelImage to supply an image label for
+    buttons, checkboxes, radios, sliders and dropdowns.
 
 func Overlays() []*ItemData
     Overlays returns the list of active overlays.

--- a/eui/dispose.go
+++ b/eui/dispose.go
@@ -18,6 +18,13 @@ func (item *itemData) disposeImages() {
 		item.Image.Dispose()
 		item.Image = nil
 	}
+	if item.LabelImage != nil {
+		if DebugMode {
+			log.Printf("disposing label image for item %p", item)
+		}
+		item.LabelImage.Dispose()
+		item.LabelImage = nil
+	}
 	for _, child := range item.Contents {
 		if child != nil {
 			child.disposeImages()

--- a/eui/dump.go
+++ b/eui/dump.go
@@ -45,6 +45,13 @@ func dumpItemImages(items []*itemData, prefix string) {
 					f.Close()
 				}
 			}
+			if it.LabelImage != nil {
+				fn := filepath.Join("debug", name+"_label.png")
+				if f, err := os.Create(fn); err == nil {
+					png.Encode(f, it.LabelImage)
+					f.Close()
+				}
+			}
 		}
 		if len(it.Contents) > 0 {
 			dumpItemImages(it.Contents, name)

--- a/eui/input.go
+++ b/eui/input.go
@@ -581,7 +581,9 @@ func (item *itemData) setSliderValue(mpos point) {
 func (item *itemData) colorAt(mpos point) (Color, bool) {
 	size := point{X: item.Size.X * uiScale, Y: item.Size.Y * uiScale}
 	offsetY := float32(0)
-	if item.Label != "" {
+	if item.LabelImage != nil {
+		offsetY = float32(item.LabelImage.Bounds().Dy())*uiScale + currentStyle.TextPadding*uiScale
+	} else if item.Label != "" {
 		offsetY = (item.FontSize*uiScale + 2) + currentStyle.TextPadding*uiScale
 	}
 	wheelSize := size.Y

--- a/eui/render.go
+++ b/eui/render.go
@@ -521,7 +521,18 @@ func (item *itemData) drawItemInternal(parent *itemData, offset point, clip rect
 	subImg := screen.SubImage(item.DrawRect.getRectangle()).(*ebiten.Image)
 	style := item.themeStyle()
 
-	if item.Label != "" {
+	if item.LabelImage != nil {
+		sop := &ebiten.DrawImageOptions{}
+		sop.GeoM.Scale(float64(uiScale), float64(uiScale))
+		sop.GeoM.Translate(float64(offset.X), float64(offset.Y))
+		subImg.DrawImage(item.LabelImage, sop)
+		h := float32(item.LabelImage.Bounds().Dy())*uiScale + currentStyle.TextPadding*uiScale
+		offset.Y += h
+		maxSize.Y -= h
+		if maxSize.Y < 0 {
+			maxSize.Y = 0
+		}
+	} else if item.Label != "" {
 		textSize := (item.FontSize * uiScale) + 2
 		face := textFace(textSize)
 		loo := text.LayoutOptions{PrimaryAlign: text.AlignStart, SecondaryAlign: text.AlignCenter}
@@ -988,7 +999,9 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 
 		if item.ItemType == ITEM_DROPDOWN && item.Open {
 			dropOff := offset
-			if item.Label != "" {
+			if item.LabelImage != nil {
+				dropOff.Y += float32(item.LabelImage.Bounds().Dy())*uiScale + currentStyle.TextPadding*uiScale
+			} else if item.Label != "" {
 				textSize := (item.FontSize * uiScale) + 2
 				dropOff.Y += textSize + currentStyle.TextPadding*uiScale
 			}

--- a/eui/struct.go
+++ b/eui/struct.go
@@ -62,16 +62,18 @@ type windowData struct {
 type itemData struct {
 	Parent *itemData
 	// Name is used when the item is part of a tabbed flow
-	Name      string
-	Text      string
-	Label     string
-	Position  point
-	Size      point
-	Alignment alignType
-	PinTo     pinType
-	FontSize  float32
-	LineSpace float32 //Multiplier, 1.0 = no gap between lines
-	ItemType  itemTypeData
+	Name           string
+	Text           string
+	Label          string
+	LabelImageName string
+	LabelImage     *ebiten.Image
+	Position       point
+	Size           point
+	Alignment      alignType
+	PinTo          pinType
+	FontSize       float32
+	LineSpace      float32 //Multiplier, 1.0 = no gap between lines
+	ItemType       itemTypeData
 
 	Value      float32
 	MinValue   float32

--- a/eui/util.go
+++ b/eui/util.go
@@ -467,7 +467,9 @@ func (win *windowData) GetPos() point {
 
 func (item *itemData) GetSize() point {
 	sz := point{X: item.Size.X * uiScale, Y: item.Size.Y * uiScale}
-	if item.Label != "" {
+	if item.LabelImage != nil {
+		sz.Y += float32(item.LabelImage.Bounds().Dy())*uiScale + currentStyle.TextPadding*uiScale
+	} else if item.Label != "" {
 		textSize := (item.FontSize * uiScale) + 2
 		sz.Y += textSize + currentStyle.TextPadding*uiScale
 	}


### PR DESCRIPTION
## Summary
- allow providing `LabelImage`/`LabelImageName` on items to use an image as the widget label
- render image labels and adjust layout/offset calculations accordingly
- document image label option in README and API reference

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68935e1c82b0832aa3d326d7592b50ee