### PR TITLE
Add image label size parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ building a game UI. Highlights include:
 - **Cross platform** – runs anywhere Ebiten does: desktop, web or mobile.
 - **Basic touch support** – with two‑finger scrolling (drag up to scroll up).
   Mouse scrolling is clamped to +/-3 and rate-limited to 4 events per half-second on WebAssembly.
-- **Image labels** – buttons, sliders, checkboxes, radios and dropdowns can use an image instead of text for their labels.
+- **Image labels** – buttons, sliders, checkboxes, radios and dropdowns can use an image instead of text for their labels, with optional custom sizing.
 
 ## Running the Demo
 

--- a/api.md
+++ b/api.md
@@ -276,7 +276,8 @@ type FlowType = flowType
 
 type ItemData = itemData
     ItemData represents a widget. Set LabelImage to supply an image label for
-    buttons, checkboxes, radios, sliders and dropdowns.
+    buttons, checkboxes, radios, sliders and dropdowns. Use LabelImageSize to
+    control the display size of the image label.
 
 func Overlays() []*ItemData
     Overlays returns the list of active overlays.

--- a/eui/input.go
+++ b/eui/input.go
@@ -582,7 +582,11 @@ func (item *itemData) colorAt(mpos point) (Color, bool) {
 	size := point{X: item.Size.X * uiScale, Y: item.Size.Y * uiScale}
 	offsetY := float32(0)
 	if item.LabelImage != nil {
-		offsetY = float32(item.LabelImage.Bounds().Dy())*uiScale + currentStyle.TextPadding*uiScale
+		h := float32(item.LabelImage.Bounds().Dy())
+		if item.LabelImageSize.Y > 0 {
+			h = item.LabelImageSize.Y
+		}
+		offsetY = h*uiScale + currentStyle.TextPadding*uiScale
 	} else if item.Label != "" {
 		offsetY = (item.FontSize*uiScale + 2) + currentStyle.TextPadding*uiScale
 	}

--- a/eui/render.go
+++ b/eui/render.go
@@ -522,11 +522,21 @@ func (item *itemData) drawItemInternal(parent *itemData, offset point, clip rect
 	style := item.themeStyle()
 
 	if item.LabelImage != nil {
+		bw := float32(item.LabelImage.Bounds().Dx())
+		bh := float32(item.LabelImage.Bounds().Dy())
+		dw := bw
+		dh := bh
+		if item.LabelImageSize.X > 0 {
+			dw = item.LabelImageSize.X
+		}
+		if item.LabelImageSize.Y > 0 {
+			dh = item.LabelImageSize.Y
+		}
 		sop := &ebiten.DrawImageOptions{}
-		sop.GeoM.Scale(float64(uiScale), float64(uiScale))
+		sop.GeoM.Scale(float64(dw/bw*uiScale), float64(dh/bh*uiScale))
 		sop.GeoM.Translate(float64(offset.X), float64(offset.Y))
 		subImg.DrawImage(item.LabelImage, sop)
-		h := float32(item.LabelImage.Bounds().Dy())*uiScale + currentStyle.TextPadding*uiScale
+		h := dh*uiScale + currentStyle.TextPadding*uiScale
 		offset.Y += h
 		maxSize.Y -= h
 		if maxSize.Y < 0 {
@@ -1000,7 +1010,11 @@ func (item *itemData) drawItem(parent *itemData, offset point, clip rect, screen
 		if item.ItemType == ITEM_DROPDOWN && item.Open {
 			dropOff := offset
 			if item.LabelImage != nil {
-				dropOff.Y += float32(item.LabelImage.Bounds().Dy())*uiScale + currentStyle.TextPadding*uiScale
+				h := float32(item.LabelImage.Bounds().Dy())
+				if item.LabelImageSize.Y > 0 {
+					h = item.LabelImageSize.Y
+				}
+				dropOff.Y += h*uiScale + currentStyle.TextPadding*uiScale
 			} else if item.Label != "" {
 				textSize := (item.FontSize * uiScale) + 2
 				dropOff.Y += textSize + currentStyle.TextPadding*uiScale

--- a/eui/struct.go
+++ b/eui/struct.go
@@ -67,6 +67,7 @@ type itemData struct {
 	Label          string
 	LabelImageName string
 	LabelImage     *ebiten.Image
+	LabelImageSize point
 	Position       point
 	Size           point
 	Alignment      alignType

--- a/eui/util.go
+++ b/eui/util.go
@@ -468,7 +468,11 @@ func (win *windowData) GetPos() point {
 func (item *itemData) GetSize() point {
 	sz := point{X: item.Size.X * uiScale, Y: item.Size.Y * uiScale}
 	if item.LabelImage != nil {
-		sz.Y += float32(item.LabelImage.Bounds().Dy())*uiScale + currentStyle.TextPadding*uiScale
+		h := float32(item.LabelImage.Bounds().Dy())
+		if item.LabelImageSize.Y > 0 {
+			h = item.LabelImageSize.Y
+		}
+		sz.Y += h*uiScale + currentStyle.TextPadding*uiScale
 	} else if item.Label != "" {
 		textSize := (item.FontSize * uiScale) + 2
 		sz.Y += textSize + currentStyle.TextPadding*uiScale


### PR DESCRIPTION
## Summary
- allow widgets to specify a custom size for label images
- scale label images to requested dimensions and adjust layout math
- document optional image label sizing

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68936478605c832aa434603a57c262a4