### PR TITLE
eui: refresh window layout after flow modifications

### DIFF
--- a/eui/util_test.go
+++ b/eui/util_test.go
@@ -237,6 +237,27 @@ func TestFlowContentBounds(t *testing.T) {
 	}
 }
 
+func TestWindowRefreshRecalculatesFlow(t *testing.T) {
+	uiScale = 1
+
+	win := &windowData{AutoSize: true, TitleHeight: 0}
+	flow := &itemData{ItemType: ITEM_FLOW, FlowType: FLOW_VERTICAL}
+	win.addItemTo(flow)
+	flow.addItemTo(&itemData{ItemType: ITEM_BUTTON, Size: point{X: 10, Y: 20}})
+	flow.addItemTo(&itemData{ItemType: ITEM_BUTTON, Size: point{X: 10, Y: 20}})
+
+	win.Refresh()
+	if got := win.GetSize().Y; got != 40 {
+		t.Fatalf("initial window height got %v want %v", got, 40)
+	}
+
+	flow.Contents = flow.Contents[1:]
+	win.Refresh()
+	if got := win.GetSize().Y; got != 20 {
+		t.Fatalf("refreshed window height got %v want %v", got, 20)
+	}
+}
+
 func TestPixelOffset(t *testing.T) {
 	if off := pixelOffset(1); off != 0.5 {
 		t.Errorf("odd width offset got %v", off)

--- a/eui/window.go
+++ b/eui/window.go
@@ -555,6 +555,7 @@ func (win windowData) itemOverlap(size point) (bool, bool) {
 // Refresh forces the window to recalculate layout, resize to its contents,
 // and adjust scrolling after modifying contents.
 func (win *windowData) Refresh() {
+	win.resizeFlows()
 	win.updateAutoSize()
 	win.adjustScrollForResize()
 	for _, it := range win.Contents {


### PR DESCRIPTION
## Summary
- ensure `WindowData.Refresh` recalculates flow layout before determining window size
- add regression test verifying window height updates after removing flow items

## Testing
- `go vet -v ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68936623d434832a8cc2c5693faa3795