### PR TITLE
Add window dirty flag and refresh test

### DIFF
--- a/eui/glob_test.go
+++ b/eui/glob_test.go
@@ -3,9 +3,12 @@
 package eui
 
 import (
+	"image"
+	"image/color"
 	"os"
 	"time"
 
+	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/text/v2"
 )
 
@@ -19,14 +22,30 @@ var (
 	overlays        []*itemData
 	activeWindow    *windowData
 	focusedItem     *itemData
+	hoveredItem     *itemData
 	uiScale         float32 = 1.0
 	clickFlash              = time.Millisecond * 100
 
-	whiteImage    interface{}
-	whiteSubImage interface{}
+	// Debug and dump flags used by rendering logic
+	DebugMode bool
+	DumpMode  bool
+	TreeMode  bool
+
+	whiteImage    = ebiten.NewImage(3, 3)
+	whiteSubImage = whiteImage.SubImage(image.Rect(1, 1, 2, 2)).(*ebiten.Image)
 
 	currentTheme     *Theme
 	currentThemeName string
+
+	lastDeviceScale float64 = 1.0
+	notoTTF                 = defaultTTF
+
+	MinWinSizeX float32 = minWinSizeX
+	MinWinSizeY float32 = minWinSizeY
 )
+
+func init() {
+	whiteImage.Fill(color.White)
+}
 
 type Game struct{}

--- a/eui/render.go
+++ b/eui/render.go
@@ -36,7 +36,12 @@ func Draw(screen *ebiten.Image) {
 		if !win.Open {
 			continue
 		}
-
+		if win.Dirty {
+			for _, it := range win.Contents {
+				markItemTreeDirty(it)
+			}
+			win.Dirty = false
+		}
 		win.Draw(screen)
 	}
 

--- a/eui/struct.go
+++ b/eui/struct.go
@@ -57,6 +57,9 @@ type windowData struct {
 	// Drop shadow styling
 	ShadowSize  float32
 	ShadowColor Color
+
+	// Dirty marks the window for re-rendering when its contents change.
+	Dirty bool
 }
 
 type itemData struct {

--- a/eui/window.go
+++ b/eui/window.go
@@ -561,4 +561,5 @@ func (win *windowData) Refresh() {
 	for _, it := range win.Contents {
 		markItemTreeDirty(it)
 	}
+	win.Dirty = true
 }

--- a/eui/window_refresh_test.go
+++ b/eui/window_refresh_test.go
@@ -1,0 +1,38 @@
+//go:build test
+
+package eui
+
+import (
+	"testing"
+
+	"github.com/hajimehoshi/ebiten/v2"
+)
+
+func TestWindowRefreshRerenders(t *testing.T) {
+	DebugMode = true
+	defer func() { DebugMode = false }()
+
+	textItem := *defaultText
+	textItem.Text = "before"
+	textItem.Theme = baseTheme
+
+	win := *defaultTheme
+	win.Theme = baseTheme
+	win.Contents = []*itemData{&textItem}
+	win.Open = true
+
+	windows = []*windowData{&win}
+	screen := ebiten.NewImage(200, 200)
+
+	win.Dirty = true
+	Draw(screen)
+	rc0 := textItem.RenderCount
+
+	textItem.Text = "after"
+	win.Refresh()
+	Draw(screen)
+
+	if textItem.RenderCount <= rc0 {
+		t.Fatalf("expected render count to increase after Refresh")
+	}
+}


### PR DESCRIPTION
## Summary
- allow windows to be marked dirty for re-rendering
- trigger re-render on Refresh and clear dirty flag after drawing
- add test confirming Refresh updates rendered content

## Testing
- `go vet ./...`
- `go build ./...`
- `xvfb-run -a go test -tags test ./eui`


------
https://chatgpt.com/codex/tasks/task_e_6893f4edc2f8832aa067c68f0da9ded0