### PR TITLE
Add tab navigation and enter submit for input fields

### DIFF
--- a/api.md
+++ b/api.md
@@ -277,7 +277,8 @@ type FlowType = flowType
 type ItemData = itemData
     ItemData represents a widget. Set Tooltip to display a floating hint when
     hovering over the item (empty string disables it). Set LabelImage to supply
-    an image label for buttons, checkboxes, radios, sliders and dropdowns.
+    an image label for buttons, checkboxes, radios, sliders and dropdowns. For
+    text inputs, assign OnEnter to run a function when the user presses Enter.
 
 func Overlays() []*ItemData
     Overlays returns the list of active overlays.
@@ -361,13 +362,14 @@ type UIEventType int
     UIEventType defines the kind of event emitted by widgets.
 
 const (
-	EventClick UIEventType = iota
-	EventSliderChanged
-	EventDropdownSelected
-	EventCheckboxChanged
-	EventRadioSelected
-	EventColorChanged
-	EventInputChanged
+        EventClick UIEventType = iota
+        EventSliderChanged
+        EventDropdownSelected
+        EventCheckboxChanged
+        EventRadioSelected
+        EventColorChanged
+        EventInputChanged
+        EventInputSubmit
 )
 type WindowData = windowData
 

--- a/eui/events.go
+++ b/eui/events.go
@@ -11,6 +11,7 @@ const (
 	EventRadioSelected
 	EventColorChanged
 	EventInputChanged
+	EventInputSubmit
 )
 
 // UIEvent describes a user interaction with a widget.

--- a/eui/struct.go
+++ b/eui/struct.go
@@ -101,6 +101,7 @@ type itemData struct {
 
 	OnSelect func(int)
 	OnHover  func(int)
+	OnEnter  func(string)
 
 	Fixed, Scrollable bool
 


### PR DESCRIPTION
## Summary
- allow Tab key to advance focus through input widgets
- add OnEnter callback and EventInputSubmit for input submission
- document new input behaviors

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68940ecbdacc832a846943622f44876a