### PR TITLE
Fix window stacking behavior when adding or focusing windows

### DIFF
--- a/eui/util_test.go
+++ b/eui/util_test.go
@@ -196,6 +196,28 @@ func TestMarkOpen(t *testing.T) {
 		t.Errorf("window order incorrect: %v", windows)
 	}
 }
+
+func TestAddWindowReorders(t *testing.T) {
+	win1 := &windowData{Title: "win1", Open: true}
+	win2 := &windowData{Title: "win2", Open: true}
+	windows = nil
+
+	win1.AddWindow(false)
+	win2.AddWindow(false)
+	if len(windows) != 2 || windows[1] != win2 {
+		t.Fatalf("expected win2 at front: %v", windows)
+	}
+
+	win1.AddWindow(false)
+	if windows[1] != win1 {
+		t.Errorf("expected win1 brought forward: %v", windows)
+	}
+
+	win1.AddWindow(true)
+	if windows[0] != win1 {
+		t.Errorf("expected win1 moved to back: %v", windows)
+	}
+}
 func TestSetSizeClampAndScroll(t *testing.T) {
 	win := &windowData{
 		Size:        point{X: 100, Y: 100},

--- a/eui/window.go
+++ b/eui/window.go
@@ -86,7 +86,11 @@ func stripItemColors(it *itemData) {
 func (target *windowData) AddWindow(toBack bool) {
 	for _, win := range windows {
 		if win == target {
-			log.Println("Window already exists")
+			if toBack {
+				target.ToBack()
+			} else {
+				target.BringForward()
+			}
 			return
 		}
 	}
@@ -320,6 +324,7 @@ func (target *windowData) BringForward() {
 			windows = append(windows[:w], windows[w+1:]...)
 			windows = append(windows, target)
 			activeWindow = target
+			return
 		}
 	}
 }
@@ -347,12 +352,13 @@ func (target *windowData) ToBack() {
 		if win == target {
 			windows = append(windows[:w], windows[w+1:]...)
 			windows = append([]*windowData{target}, windows...)
-		}
-	}
-	if activeWindow == target {
-		numWindows := len(windows)
-		if numWindows > 0 {
-			activeWindow = windows[numWindows-1]
+			if activeWindow == target {
+				numWindows := len(windows)
+				if numWindows > 0 {
+					activeWindow = windows[numWindows-1]
+				}
+			}
+			return
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Ensure AddWindow moves existing windows to the requested front/back position
- Make BringForward/ToBack stop iterating after reordering to avoid missed moves
- Add tests verifying AddWindow reorders windows correctly

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./...` *(fails: undefined globals such as DebugMode)*

------
https://chatgpt.com/codex/tasks/task_e_6895448453a0832aa659fd1fd86f226e