### PR TITLE
Clear MainPortal region instead of black masking

### DIFF
--- a/api.md
+++ b/api.md
@@ -372,7 +372,7 @@ const (
         EventInputSubmit
 )
 type WindowData = windowData
-Setting MainPortal to true renders the window before others, blacks out the
+Setting MainPortal to true renders the window before others, clears the
 screen outside it and omits the window background so underlying content shows
 through. MainPortal windows are processed after other windows so they don't
 steal clicks when overlapped. Setting FixedRatio enforces an AspectA:AspectB

--- a/eui/render.go
+++ b/eui/render.go
@@ -181,16 +181,16 @@ func (win *windowData) drawPortalMask(screen *ebiten.Image) {
 	h := float32(screenHeight)
 
 	if r.Y0 > 0 {
-		screen.SubImage((rect{X0: 0, Y0: 0, X1: w, Y1: r.Y0}).getRectangle()).(*ebiten.Image).Fill(color.Black)
+		screen.SubImage((rect{X0: 0, Y0: 0, X1: w, Y1: r.Y0}).getRectangle()).(*ebiten.Image).Clear()
 	}
 	if r.Y1 < h {
-		screen.SubImage((rect{X0: 0, Y0: r.Y1, X1: w, Y1: h}).getRectangle()).(*ebiten.Image).Fill(color.Black)
+		screen.SubImage((rect{X0: 0, Y0: r.Y1, X1: w, Y1: h}).getRectangle()).(*ebiten.Image).Clear()
 	}
 	if r.X0 > 0 {
-		screen.SubImage((rect{X0: 0, Y0: r.Y0, X1: r.X0, Y1: r.Y1}).getRectangle()).(*ebiten.Image).Fill(color.Black)
+		screen.SubImage((rect{X0: 0, Y0: r.Y0, X1: r.X0, Y1: r.Y1}).getRectangle()).(*ebiten.Image).Clear()
 	}
 	if r.X1 < w {
-		screen.SubImage((rect{X0: r.X1, Y0: r.Y0, X1: w, Y1: r.Y1}).getRectangle()).(*ebiten.Image).Fill(color.Black)
+		screen.SubImage((rect{X0: r.X1, Y0: r.Y0, X1: w, Y1: r.Y1}).getRectangle()).(*ebiten.Image).Clear()
 	}
 }
 

--- a/eui/struct.go
+++ b/eui/struct.go
@@ -36,7 +36,7 @@ type windowData struct {
 	HoverClose, HoverDragbar,
 	AutoSize, FixedRatio bool
 
-	// MainPortal renders the window before others, blacks out the area
+	// MainPortal renders the window before others, clears the area
 	// outside it and skips drawing the background so underlying content can
 	// show through.
 	MainPortal bool


### PR DESCRIPTION
## Summary
- Clear surrounding area for MainPortal windows to let underlying content show
- Document MainPortal now clearing rather than blacking the screen

## Testing
- `go vet ./...`
- `go build ./... && echo done`


------
https://chatgpt.com/codex/tasks/task_e_6896c9b01e10832aa7dbdf27adfe7e7c