### PR TITLE
Fix input hide toggle

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -464,6 +464,7 @@ func (item *itemData) clickItem(mpos point, click bool) bool {
 					Y1: item.DrawRect.Y0 + lh + (contentH-eyeSize)/2 + eyeSize,
 				}
 				if eyeRect.containsPoint(mpos) {
+					item.Reveal = !item.Reveal
 					item.markDirty()
 					return true
 				}

--- a/eui/render.go
+++ b/eui/render.go
@@ -842,30 +842,24 @@ func (item *itemData) drawItemInternal(parent *itemData, offset point, clip rect
 			})
 		}
 
-		eyeSize := maxSize.Y - (item.BorderPad+item.Padding)*2
-		if eyeSize < 0 {
-			eyeSize = 0
-		}
-		eyeRect := rect{
-			X0: offset.X + maxSize.X - eyeSize - item.BorderPad - item.Padding,
-			Y0: offset.Y + (maxSize.Y-eyeSize)/2,
-			X1: offset.X + maxSize.X - item.BorderPad - item.Padding,
-			Y1: offset.Y + (maxSize.Y-eyeSize)/2 + eyeSize,
-		}
-
-		show := !item.Hide
+		var eyeRect rect
 		if item.Hide {
-			mx, my := pointerPosition()
-			mpos := point{X: float32(mx), Y: float32(my)}
-			if pointerPressed() && eyeRect.containsPoint(mpos) {
-				show = true
+			eyeSize := maxSize.Y - (item.BorderPad+item.Padding)*2
+			if eyeSize < 0 {
+				eyeSize = 0
+			}
+			eyeRect = rect{
+				X0: offset.X + maxSize.X - eyeSize - item.BorderPad - item.Padding,
+				Y0: offset.Y + (maxSize.Y-eyeSize)/2,
+				X1: offset.X + maxSize.X - item.BorderPad - item.Padding,
+				Y1: offset.Y + (maxSize.Y-eyeSize)/2 + eyeSize,
 			}
 		}
 
 		disp := item.Text
-		if item.Hide && !show {
+		if item.Hide && !item.Reveal {
 			n := utf8.RuneCountInString(item.Text)
-			disp = strings.Repeat("•", n)
+			disp = strings.Repeat("*", n)
 		}
 
 		textSize := (item.FontSize * uiScale) + 2
@@ -884,7 +878,9 @@ func (item *itemData) drawItemInternal(parent *itemData, offset point, clip rect
 		top.ColorScale.ScaleWithColor(style.TextColor)
 		text.Draw(subImg, disp, face, top)
 
-		drawEye(subImg, eyeRect, style.TextColor)
+		if item.Hide {
+			drawEye(subImg, eyeRect, style.TextColor)
+		}
 
 		if item.Focused {
 			width, _ := text.Measure(disp, face, 0)

--- a/eui/struct.go
+++ b/eui/struct.go
@@ -93,6 +93,7 @@ type itemData struct {
 	IntOnly    bool
 	RadioGroup string
 	Hide       bool
+	Reveal     bool
 
 	Hovered, Checked, Focused,
 	Disabled, Invisible bool


### PR DESCRIPTION
## Summary
- show hide toggle only on inputs configured to hide text
- display hidden input characters as asterisks
- allow eye icon to toggle text visibility

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6896cfef9c18832a955992c5ce5147fa