### PR TITLE
fix: respect autosize flag on refresh

### DIFF
--- a/eui/util_test.go
+++ b/eui/util_test.go
@@ -297,6 +297,26 @@ func TestWindowRefreshRecalculatesFlow(t *testing.T) {
 	}
 }
 
+func TestWindowRefreshKeepsFixedSize(t *testing.T) {
+	uiScale = 1
+
+	win := &windowData{Size: point{X: 100, Y: 50}, TitleHeight: 0}
+	flow := &itemData{ItemType: ITEM_FLOW, FlowType: FLOW_VERTICAL}
+	win.addItemTo(flow)
+	flow.addItemTo(&itemData{ItemType: ITEM_BUTTON, Size: point{X: 10, Y: 20}})
+
+	win.Refresh()
+	if got := win.GetSize().Y; got != 50 {
+		t.Fatalf("initial window height got %v want %v", got, 50)
+	}
+
+	flow.addItemTo(&itemData{ItemType: ITEM_BUTTON, Size: point{X: 10, Y: 40}})
+	win.Refresh()
+	if got := win.GetSize().Y; got != 50 {
+		t.Fatalf("refreshed window height got %v want %v", got, 50)
+	}
+}
+
 func TestPixelOffset(t *testing.T) {
 	if off := pixelOffset(1); off != 0.5 {
 		t.Errorf("odd width offset got %v", off)

--- a/eui/window.go
+++ b/eui/window.go
@@ -562,7 +562,11 @@ func (win windowData) itemOverlap(size point) (bool, bool) {
 // and adjust scrolling after modifying contents.
 func (win *windowData) Refresh() {
 	win.resizeFlows()
-	win.updateAutoSize()
+	if win.AutoSize {
+		win.updateAutoSize()
+	} else {
+		win.clampToScreen()
+	}
 	win.adjustScrollForResize()
 	for _, it := range win.Contents {
 		markItemTreeDirty(it)


### PR DESCRIPTION
## Summary
- avoid resizing windows on Refresh when AutoSize is false
- add regression test ensuring Refresh keeps fixed window size

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./eui` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6896dbb46d34832a8a002a362e3373a0