### PR TITLE
Include title bar in window aspect ratio calculations

### DIFF
--- a/api.md
+++ b/api.md
@@ -376,7 +376,7 @@ Setting MainPortal to true renders the window before others, clears the
 screen outside it and omits the window background so underlying content shows
 through. MainPortal windows are processed after other windows so they don't
 steal clicks when overlapped. Setting FixedRatio enforces an AspectA:AspectB
-window size during resizing.
+content area during resizing and accounts for the title bar height.
 
 func Windows() []*WindowData
     Windows returns the list of active windows.

--- a/eui/util.go
+++ b/eui/util.go
@@ -178,16 +178,24 @@ func (win *windowData) applyAspect(size point, useDelta bool) point {
 		return size
 	}
 	aspect := win.AspectA / win.AspectB
+	title := win.TitleHeight
 	if useDelta {
 		dx := math.Abs(float64(size.X - win.Size.X))
 		dy := math.Abs(float64(size.Y - win.Size.Y))
 		if dx >= dy {
-			size.Y = size.X / aspect
+			contentH := size.X / aspect
+			size.Y = contentH + title
 		} else {
-			size.X = size.Y * aspect
+			contentH := size.Y - title
+			if contentH < 0 {
+				contentH = 0
+			}
+			size.X = contentH * aspect
+			size.Y = contentH + title
 		}
 	} else {
-		size.Y = size.X / aspect
+		contentH := size.X / aspect
+		size.Y = contentH + title
 	}
 	return size
 }

--- a/eui/util_test.go
+++ b/eui/util_test.go
@@ -240,17 +240,17 @@ func TestSetSizeClampAndScroll(t *testing.T) {
 }
 
 func TestFixedAspectRatio(t *testing.T) {
-	win := &windowData{Size: point{X: 100, Y: 50}, AspectA: 16, AspectB: 9, FixedRatio: true}
+	win := &windowData{Size: point{X: 100, Y: 50}, TitleHeight: 10, AspectA: 16, AspectB: 9, FixedRatio: true}
 
 	win.setSize(point{X: 160, Y: 100})
-	want := point{X: 160, Y: 90}
+	want := point{X: 160, Y: 100}
 	if win.Size != want {
 		t.Errorf("resize by width got %+v want %+v", win.Size, want)
 	}
 
 	win.Size = point{X: 100, Y: 50}
 	win.setSize(point{X: 120, Y: 120})
-	want = point{X: 213.33333, Y: 120}
+	want = point{X: 195.55556, Y: 120}
 	if math.Abs(float64(win.Size.X-want.X)) > 0.01 || math.Abs(float64(win.Size.Y-want.Y)) > 0.01 {
 		t.Errorf("resize by height got %+v want %+v", win.Size, want)
 	}


### PR DESCRIPTION
## Summary
- include window title height when enforcing fixed aspect ratios
- cover title-aware aspect ratios with tests
- note in API docs that FixedRatio accounts for title bar height

## Testing
- `go vet ./...`
- `go build ./... && echo build-ok`
- `go test -tags test ./...` *(fails: undefined: DebugMode, windows, mplusFaceSource, uiScale)*

------
https://chatgpt.com/codex/tasks/task_e_6896e77a2700832aa02d53fe8f0377a6