### PR TITLE
Cache hidden inputs when static

### DIFF
--- a/eui/hidden_input_test.go
+++ b/eui/hidden_input_test.go
@@ -1,0 +1,36 @@
+//go:build test
+
+package eui
+
+import (
+	"testing"
+
+	"github.com/hajimehoshi/ebiten/v2"
+)
+
+func TestHiddenInputCached(t *testing.T) {
+	DebugMode = true
+	defer func() { DebugMode = false }()
+
+	input := *defaultInput
+	input.Hide = true
+	input.Text = "secret"
+	input.Theme = baseTheme
+
+	win := *defaultTheme
+	win.Theme = baseTheme
+	win.Contents = []*itemData{&input}
+	win.Open = true
+
+	windows = []*windowData{&win}
+	screen := ebiten.NewImage(200, 200)
+
+	win.Dirty = true
+	Draw(screen)
+	rc := input.RenderCount
+
+	Draw(screen)
+	if input.RenderCount != rc {
+		t.Fatalf("expected hidden input to remain cached")
+	}
+}

--- a/eui/input.go
+++ b/eui/input.go
@@ -464,8 +464,7 @@ func (item *itemData) clickItem(mpos point, click bool) bool {
 					Y1: item.DrawRect.Y0 + lh + (contentH-eyeSize)/2 + eyeSize,
 				}
 				if eyeRect.containsPoint(mpos) {
-					item.Reveal = !item.Reveal
-					item.markDirty()
+					item.toggleReveal()
 					return true
 				}
 			}
@@ -634,6 +633,16 @@ func (item *itemData) setSliderValue(mpos point) {
 	if item.Handler != nil {
 		item.Handler.Emit(UIEvent{Item: item, Type: EventSliderChanged, Value: item.Value})
 	}
+}
+
+func (item *itemData) toggleHide() {
+	item.Hide = !item.Hide
+	item.markDirty()
+}
+
+func (item *itemData) toggleReveal() {
+	item.Reveal = !item.Reveal
+	item.markDirty()
 }
 
 func (item *itemData) colorAt(mpos point) (Color, bool) {

--- a/eui/render.go
+++ b/eui/render.go
@@ -1092,8 +1092,13 @@ func (item *itemData) ensureRender() {
 		item.Render = ebiten.NewImage(w, h)
 		item.Dirty = true
 	}
-	if item.ItemType == ITEM_INPUT && item.Hide {
-		item.Dirty = true
+	if item.ItemType == ITEM_INPUT {
+		if item.Hide != item.prevHide || item.Reveal != item.prevReveal || item.Text != item.prevText {
+			item.Dirty = true
+		}
+		item.prevHide = item.Hide
+		item.prevReveal = item.Reveal
+		item.prevText = item.Text
 	}
 	if !item.Dirty {
 		return

--- a/eui/struct.go
+++ b/eui/struct.go
@@ -94,6 +94,9 @@ type itemData struct {
 	RadioGroup string
 	Hide       bool
 	Reveal     bool
+	prevHide   bool
+	prevReveal bool
+	prevText   string
 
 	Hovered, Checked, Focused,
 	Disabled, Invisible bool


### PR DESCRIPTION
## Summary
- track previous Hide/Reveal/text values and avoid unnecessary re-renders
- expose toggle helpers that mark inputs dirty on visibility changes
- add regression test ensuring hidden inputs remain cached

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags=test ./eui` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689799d04528832a866007807e12b927