### PR TITLE
Log dropped events when event channel is full

### DIFF
--- a/eui/events.go
+++ b/eui/events.go
@@ -1,5 +1,7 @@
 package eui
 
+import "log"
+
 // UIEventType defines the kind of event emitted by widgets.
 type UIEventType int
 
@@ -41,6 +43,7 @@ func (h *EventHandler) Emit(ev UIEvent) {
 		select {
 		case h.Events <- ev:
 		default:
+			log.Printf("Event channel full, dropping event: %+v", ev)
 		}
 	}
 	if h.Handle != nil {

--- a/eui/events_test.go
+++ b/eui/events_test.go
@@ -1,0 +1,25 @@
+//go:build test
+
+package eui
+
+import (
+	"bytes"
+	"log"
+	"testing"
+)
+
+func TestEmitLogsWhenChannelFull(t *testing.T) {
+	var buf bytes.Buffer
+	orig := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(orig)
+
+	h := &EventHandler{Events: make(chan UIEvent, 1)}
+	h.Events <- UIEvent{Type: EventClick}
+
+	h.Emit(UIEvent{Type: EventSliderChanged})
+
+	if buf.Len() == 0 {
+		t.Fatal("expected log output when event dropped, got none")
+	}
+}


### PR DESCRIPTION
## Summary
- log and drop events when handler channel is full
- add tests ensuring a log entry is emitted when dropping

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6897a8818758832a8a12d05d3ab57d6d