### PR TITLE
Use os.Getwd for theme paths with cached base dir

### DIFF
--- a/eui/basedir.go
+++ b/eui/basedir.go
@@ -1,0 +1,19 @@
+package eui
+
+import (
+	"os"
+	"sync"
+)
+
+var (
+	baseDir     string
+	baseDirErr  error
+	baseDirOnce sync.Once
+)
+
+func getBaseDir() (string, error) {
+	baseDirOnce.Do(func() {
+		baseDir, baseDirErr = os.Getwd()
+	})
+	return baseDir, baseDirErr
+}

--- a/eui/style.go
+++ b/eui/style.go
@@ -121,10 +121,14 @@ var (
 )
 
 func LoadStyle(name string) error {
-	file := filepath.Join(os.Getenv("PWD")+"/themes/styles", name+".json")
+	dir, err := getBaseDir()
+	if err != nil {
+		return err
+	}
+	file := filepath.Join(dir, "themes", "styles", name+".json")
 	data, err := os.ReadFile(file)
 	if err != nil {
-		data, err = embeddedStyles.ReadFile(filepath.Join("themes/styles", name+".json"))
+		data, err = embeddedStyles.ReadFile(filepath.Join("themes", "styles", name+".json"))
 		if err != nil {
 			return err
 		}

--- a/eui/theme.go
+++ b/eui/theme.go
@@ -66,7 +66,11 @@ func resolveColor(s string, colors map[string]string, seen map[string]bool) (Col
 // LoadTheme reads a theme JSON file from the themes directory and
 // sets it as the current theme without modifying existing windows.
 func LoadTheme(name string) error {
-	file := filepath.Join(os.Getenv("PWD")+"/themes", "palettes", name+".json")
+	dir, err := getBaseDir()
+	if err != nil {
+		return err
+	}
+	file := filepath.Join(dir, "themes", "palettes", name+".json")
 	data, err := os.ReadFile(file)
 	if err != nil {
 		data, err = embeddedThemes.ReadFile(filepath.Join("themes", "palettes", name+".json"))

--- a/eui/watchers.go
+++ b/eui/watchers.go
@@ -23,7 +23,12 @@ func init() {
 }
 
 func refreshThemeMod() {
-	path := filepath.Join(os.Getenv("PWD"), "themes", "palettes", currentThemeName+".json")
+	dir, err := getBaseDir()
+	if err != nil {
+		themeModTime = time.Time{}
+		return
+	}
+	path := filepath.Join(dir, "themes", "palettes", currentThemeName+".json")
 	if info, err := os.Stat(path); err == nil {
 		themeModTime = info.ModTime()
 	} else {
@@ -32,7 +37,12 @@ func refreshThemeMod() {
 }
 
 func refreshStyleMod() {
-	path := filepath.Join(os.Getenv("PWD"), "themes", "styles", currentStyleName+".json")
+	dir, err := getBaseDir()
+	if err != nil {
+		styleModTime = time.Time{}
+		return
+	}
+	path := filepath.Join(dir, "themes", "styles", currentStyleName+".json")
 	if info, err := os.Stat(path); err == nil {
 		styleModTime = info.ModTime()
 	} else {
@@ -48,7 +58,12 @@ func checkThemeStyleMods() {
 		return
 	}
 	modCheckTime = time.Now()
-	path := filepath.Join(os.Getenv("PWD"), "themes", "palettes", currentThemeName+".json")
+	dir, err := getBaseDir()
+	if err != nil {
+		log.Printf("Unable to get working directory: %v", err)
+		return
+	}
+	path := filepath.Join(dir, "themes", "palettes", currentThemeName+".json")
 	if info, err := os.Stat(path); err == nil {
 		if info.ModTime().After(themeModTime) {
 			log.Println("Palette reload")
@@ -61,7 +76,7 @@ func checkThemeStyleMods() {
 		log.Println("Unable to stat " + currentThemeName + ": " + err.Error())
 	}
 
-	path = filepath.Join(os.Getenv("PWD"), "themes", "styles", currentStyleName+".json")
+	path = filepath.Join(dir, "themes", "styles", currentStyleName+".json")
 	if info, err := os.Stat(path); err == nil {
 		if info.ModTime().After(styleModTime) {
 			log.Println("Style theme reload")


### PR DESCRIPTION
## Summary
- cache working directory for theme/style lookups
- replace PWD env usage with `os.Getwd` and `filepath.Join`

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6897a85e10e8832a9c4c4a4d00c3dcc6