### PR TITLE
Ensure active window resets when windows are removed

### DIFF
--- a/eui/remove_window_test.go
+++ b/eui/remove_window_test.go
@@ -1,0 +1,26 @@
+//go:build test
+
+package eui
+
+import "testing"
+
+func TestRemoveWindowUpdatesActiveWindow(t *testing.T) {
+	win0 := &windowData{Title: "win0", Open: false}
+	win1 := &windowData{Title: "win1", Open: true}
+	win2 := &windowData{Title: "win2", Open: true}
+
+	windows = []*windowData{win0, win1, win2}
+	activeWindow = win2
+
+	win2.RemoveWindow()
+	if activeWindow != win1 {
+		t.Fatalf("expected active window to be win1, got %v", activeWindow)
+	}
+
+	win1.RemoveWindow()
+	if activeWindow != nil {
+		t.Fatalf("expected active window to be nil, got %v", activeWindow)
+	}
+
+	win0.RemoveWindow()
+}

--- a/eui/window.go
+++ b/eui/window.go
@@ -134,6 +134,15 @@ func (target *windowData) RemoveWindow() {
 			win.disposeImages()
 			windows = append(windows[:i], windows[i+1:]...)
 			win.Open = false
+			if activeWindow == target {
+				activeWindow = nil
+				for j := len(windows) - 1; j >= 0; j-- {
+					if windows[j].Open {
+						activeWindow = windows[j]
+						break
+					}
+				}
+			}
 			return
 		}
 	}


### PR DESCRIPTION
## Summary
- Update RemoveWindow to clear or switch active window when target removed
- Add regression test covering active window updates

## Testing
- `go vet ./...`
- `go build ./... && echo build-done`


------
https://chatgpt.com/codex/tasks/task_e_6897a8563b90832a9c8d839e1ab5481a