### PR TITLE
Protect font face cache with mutex

### DIFF
--- a/eui/fontcache.go
+++ b/eui/fontcache.go
@@ -1,14 +1,23 @@
 package eui
 
-import "github.com/hajimehoshi/ebiten/v2/text/v2"
+import (
+	"sync"
 
-var faceCache = map[float64]*text.GoTextFace{}
+	"github.com/hajimehoshi/ebiten/v2/text/v2"
+)
+
+var (
+	faceCache   = map[float64]*text.GoTextFace{}
+	faceCacheMu sync.Mutex
+)
 
 func textFace(size float32) *text.GoTextFace {
 	if mplusFaceSource == nil {
 		return &text.GoTextFace{Size: float64(size)}
 	}
 	s := float64(size)
+	faceCacheMu.Lock()
+	defer faceCacheMu.Unlock()
 	if f, ok := faceCache[s]; ok {
 		return f
 	}


### PR DESCRIPTION
## Summary
- add mutex to guard global font face cache
- lock/unlock in textFace when accessing cache

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6897ab4f6ee4832a89a2251b6acf29bf