### PR TITLE
Handle struct mismatches in mergeData

### DIFF
--- a/eui/util_test.go
+++ b/eui/util_test.go
@@ -71,6 +71,27 @@ func TestMergeData(t *testing.T) {
 	}
 }
 
+func TestMergeDataMismatchedStructs(t *testing.T) {
+	type origStruct struct {
+		A int
+		B int
+	}
+	type updStruct struct {
+		B int
+		C int
+	}
+
+	orig := &origStruct{A: 1, B: 2}
+	upd := &updStruct{B: 3, C: 4}
+	res := mergeData(orig, upd).(*origStruct)
+	if res.A != 1 {
+		t.Errorf("A=%v", res.A)
+	}
+	if res.B != 3 {
+		t.Errorf("B=%v", res.B)
+	}
+}
+
 func TestPinPositions(t *testing.T) {
 	screenWidth = 800
 	screenHeight = 600


### PR DESCRIPTION
## Summary
- merge struct data by field name instead of index
- skip missing fields in mergeData instead of panicking
- add regression test for merging mismatched structs

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./eui` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6897ab4dc17c832aa22e9a5bc044cc89