### PR TITLE
Isolate default style on load

### DIFF
--- a/eui/style.go
+++ b/eui/style.go
@@ -133,6 +133,9 @@ func LoadStyle(name string) error {
 			return err
 		}
 	}
+
+	style := *defaultStyle
+	currentStyle = &style
 	if err := json.Unmarshal(data, currentStyle); err != nil {
 		return err
 	}

--- a/eui/style_test.go
+++ b/eui/style_test.go
@@ -1,0 +1,30 @@
+package eui
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestLoadStyleDoesNotModifyDefaultStyle(t *testing.T) {
+	orig := *defaultStyle
+	origCurrentStyle := currentStyle
+	origCurrentStyleName := currentStyleName
+	defer func() {
+		currentStyle = origCurrentStyle
+		currentStyleName = origCurrentStyleName
+	}()
+
+	if err := LoadStyle("CleanLines"); err != nil {
+		t.Fatalf("LoadStyle CleanLines: %v", err)
+	}
+	if !reflect.DeepEqual(*defaultStyle, orig) {
+		t.Errorf("defaultStyle changed after first LoadStyle")
+	}
+
+	if err := LoadStyle("MinimalPro"); err != nil {
+		t.Fatalf("LoadStyle MinimalPro: %v", err)
+	}
+	if !reflect.DeepEqual(*defaultStyle, orig) {
+		t.Errorf("defaultStyle changed after second LoadStyle")
+	}
+}


### PR DESCRIPTION
## Summary
- Prevent LoadStyle from mutating the global defaultStyle by copying it before applying style data
- Add regression test ensuring defaultStyle remains unchanged after loading styles

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6897ab49afd4832aa3063462e1173a71