### PR TITLE
Handle Ebiten errors and unblock exit signals

### DIFF
--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"os/signal"
 	"syscall"
@@ -131,11 +132,13 @@ func startEbiten() {
 
 	ebiten.SetWindowTitle("EUI Prototype")
 
-	if err := ebiten.RunGameWithOptions(newGame(), &ebiten.RunGameOptions{}); err != nil {
-		return
-	}
+	defer func() {
+		signalHandle <- syscall.SIGINT
+	}()
 
-	signalHandle <- syscall.SIGINT
+	if err := ebiten.RunGameWithOptions(newGame(), &ebiten.RunGameOptions{}); err != nil {
+		log.Printf("ebiten.RunGameWithOptions error: %v", err)
+	}
 }
 
 type demoGame struct {

--- a/cmd/settings/main.go
+++ b/cmd/settings/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"os/signal"
 	"syscall"
@@ -122,11 +123,13 @@ func startEbiten() {
 
 	ebiten.SetWindowTitle("EUI Prototype")
 
-	if err := ebiten.RunGameWithOptions(newGame(), &ebiten.RunGameOptions{}); err != nil {
-		return
-	}
+	defer func() {
+		signalHandle <- syscall.SIGINT
+	}()
 
-	signalHandle <- syscall.SIGINT
+	if err := ebiten.RunGameWithOptions(newGame(), &ebiten.RunGameOptions{}); err != nil {
+		log.Printf("ebiten.RunGameWithOptions error: %v", err)
+	}
 }
 
 type demoGame struct {


### PR DESCRIPTION
## Summary
- Log failures from `ebiten.RunGameWithOptions` in demo and settings commands
- Always send a termination signal so the main goroutine exits even when `RunGameWithOptions` fails

## Testing
- `./scripts/setup.sh`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6897b176ef18832ab80540cb6f998a2d