### PR TITLE
Sync demo scale label with clamped UIScale

### DIFF
--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -84,10 +84,8 @@ func main() {
 		if ev.Type == eui.EventClick {
 			currentScale = eui.UIScale()
 			currentScale -= 0.25
-			if currentScale < 0.25 {
-				currentScale = 0.25
-			}
 			eui.SetUIScale(currentScale)
+			currentScale = eui.UIScale()
 			textItem.Text = fmt.Sprintf("Scale: %2.2f", currentScale)
 		}
 	}
@@ -96,10 +94,8 @@ func main() {
 		if ev.Type == eui.EventClick {
 			currentScale = eui.UIScale()
 			currentScale += 0.25
-			if currentScale > 4.0 {
-				currentScale = 4
-			}
 			eui.SetUIScale(currentScale)
+			currentScale = eui.UIScale()
 			textItem.Text = fmt.Sprintf("Scale: %2.2f", currentScale)
 		}
 	}


### PR DESCRIPTION
## Summary
- refresh the demo's scale buttons to read back the clamped value from `eui.UIScale`
## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6897b1c114bc832ab9180b8afcb72f3b