### PR TITLE
Refactor window rendering to avoid sub-images

### DIFF
--- a/eui/render.go
+++ b/eui/render.go
@@ -176,10 +176,8 @@ func (win *windowData) Draw(screen *ebiten.Image) {
 	}
 	win.drawItems(screen)
 	win.drawScrollbars(screen)
-	titleArea := screen.SubImage(win.getTitleRect().getRectangle()).(*ebiten.Image)
-	win.drawWinTitle(titleArea)
-	windowArea := screen.SubImage(win.getWinRect().getRectangle()).(*ebiten.Image)
-	win.drawBorder(windowArea)
+	win.drawWinTitle(screen, win.getTitleRect())
+	win.drawBorder(screen, win.getWinRect())
 	win.drawDebug(screen)
 }
 
@@ -241,10 +239,10 @@ func (win *windowData) drawBG(screen *ebiten.Image) {
 	})
 }
 
-func (win *windowData) drawWinTitle(screen *ebiten.Image) {
+func (win *windowData) drawWinTitle(screen *ebiten.Image, r rect) {
 	// Window Title
 	if win.TitleHeight > 0 {
-		screen.Fill(win.Theme.Window.TitleBGColor)
+		drawFilledRect(screen, r.X0, r.Y0, r.X1-r.X0, r.Y1-r.Y0, win.Theme.Window.TitleBGColor, false)
 
 		textSize := ((win.GetTitleSize()) / 2)
 		face := textFace(textSize)
@@ -264,8 +262,8 @@ func (win *windowData) drawWinTitle(screen *ebiten.Image) {
 				SecondaryAlign: text.AlignCenter,
 			}
 			tdop := ebiten.DrawImageOptions{}
-			tdop.GeoM.Translate(float64(win.getPosition().X+((win.GetTitleSize())/4)),
-				float64(win.getPosition().Y+((win.GetTitleSize())/2)))
+			tdop.GeoM.Translate(float64(r.X0+((win.GetTitleSize())/4)),
+				float64(r.Y0+((win.GetTitleSize())/2)))
 
 			top := &text.DrawOptions{DrawImageOptions: tdop, LayoutOptions: loo}
 
@@ -284,9 +282,8 @@ func (win *windowData) drawWinTitle(screen *ebiten.Image) {
 			color := win.Theme.Window.TitleColor
 			// fill background for close area if configured
 			if win.Theme.Window.CloseBGColor.A > 0 {
-				r := win.xRect()
-				closeArea := screen.SubImage(r.getRectangle()).(*ebiten.Image)
-				closeArea.Fill(win.Theme.Window.CloseBGColor)
+				xr := win.xRect()
+				drawFilledRect(screen, xr.X0, xr.Y0, xr.X1-xr.X0, xr.Y1-xr.Y0, win.Theme.Window.CloseBGColor, false)
 			}
 			xThick := 1 * uiScale
 			if win.HoverClose {
@@ -294,18 +291,18 @@ func (win *windowData) drawWinTitle(screen *ebiten.Image) {
 				win.HoverClose = false
 			}
 			strokeLine(screen,
-				win.getPosition().X+win.GetSize().X-(win.GetTitleSize())+xpad,
-				win.getPosition().Y+xpad,
+				r.X1-(win.GetTitleSize())+xpad,
+				r.Y0+xpad,
 
-				win.getPosition().X+win.GetSize().X-xpad,
-				win.getPosition().Y+(win.GetTitleSize())-xpad,
+				r.X1-xpad,
+				r.Y0+(win.GetTitleSize())-xpad,
 				xThick, color, true)
 			strokeLine(screen,
-				win.getPosition().X+win.GetSize().X-xpad,
-				win.getPosition().Y+xpad,
+				r.X1-xpad,
+				r.Y0+xpad,
 
-				win.getPosition().X+win.GetSize().X-(win.GetTitleSize())+xpad,
-				win.getPosition().Y+(win.GetTitleSize())-xpad,
+				r.X1-(win.GetTitleSize())+xpad,
+				r.Y0+(win.GetTitleSize())-xpad,
 				xThick, color, true)
 
 			buttonsWidth += (win.GetTitleSize())
@@ -326,15 +323,15 @@ func (win *windowData) drawWinTitle(screen *ebiten.Image) {
 			}
 			for x := textWidth + float64((win.GetTitleSize())/1.5); x < float64(win.GetSize().X-buttonsWidth); x = x + float64(uiScale*spacing) {
 				strokeLine(screen,
-					win.getPosition().X+float32(x), win.getPosition().Y+dpad,
-					win.getPosition().X+float32(x), win.getPosition().Y+(win.GetTitleSize())-dpad,
+					r.X0+float32(x), r.Y0+dpad,
+					r.X0+float32(x), r.Y0+(win.GetTitleSize())-dpad,
 					xThick, xColor, false)
 			}
 		}
 	}
 }
 
-func (win *windowData) drawBorder(screen *ebiten.Image) {
+func (win *windowData) drawBorder(screen *ebiten.Image, r rect) {
 	//Draw borders
 	if win.Outlined && win.Border > 0 {
 		FrameColor := win.Theme.Window.BorderColor
@@ -345,8 +342,8 @@ func (win *windowData) drawBorder(screen *ebiten.Image) {
 			win.Hovered = false
 		}
 		drawRoundRect(screen, &roundRect{
-			Size:     win.GetSize(),
-			Position: win.getPosition(),
+			Size:     point{X: r.X1 - r.X0, Y: r.Y1 - r.Y0},
+			Position: point{X: r.X0, Y: r.Y0},
 			Fillet:   win.Fillet,
 			Filled:   false,
 			Border:   win.Border,


### PR DESCRIPTION
## Summary
- draw window titles and borders directly on the screen without creating sub-images
- have drawWinTitle and drawBorder accept destination rectangles and use drawFilledRect/coordinates

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6897e56d1bb4832a842b7ed83d505d61