### PR TITLE
Simplify close button rendering

### DIFF
--- a/eui/render.go
+++ b/eui/render.go
@@ -285,8 +285,15 @@ func (win *windowData) drawWinTitle(screen *ebiten.Image) {
 			// fill background for close area if configured
 			if win.Theme.Window.CloseBGColor.A > 0 {
 				r := win.xRect()
-				closeArea := screen.SubImage(r.getRectangle()).(*ebiten.Image)
-				closeArea.Fill(win.Theme.Window.CloseBGColor)
+				drawFilledRect(
+					screen,
+					r.X0,
+					r.Y0,
+					r.X1-r.X0,
+					r.Y1-r.Y0,
+					win.Theme.Window.CloseBGColor,
+					false,
+				)
 			}
 			xThick := 1 * uiScale
 			if win.HoverClose {


### PR DESCRIPTION
## Summary
- draw window close button background directly with `drawFilledRect`

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6897e57c38b4832a92c858fb269e25eb