### PR TITLE
Reuse vertex and index buffers

### DIFF
--- a/eui/bufferpool.go
+++ b/eui/bufferpool.go
@@ -1,0 +1,52 @@
+package eui
+
+import (
+	"sync"
+
+	"github.com/hajimehoshi/ebiten/v2"
+)
+
+const (
+	defaultVertexCap = 64
+	defaultIndexCap  = 128
+	maxVertexCap     = 1024
+	maxIndexCap      = 2048
+)
+
+var vertexPool = sync.Pool{
+	New: func() any {
+		return make([]ebiten.Vertex, 0, defaultVertexCap)
+	},
+}
+
+var indexPool = sync.Pool{
+	New: func() any {
+		return make([]uint16, 0, defaultIndexCap)
+	},
+}
+
+func getVertices() []ebiten.Vertex {
+	return vertexPool.Get().([]ebiten.Vertex)[:0]
+}
+
+func putVertices(v []ebiten.Vertex) {
+	if cap(v) > maxVertexCap {
+		v = make([]ebiten.Vertex, 0, defaultVertexCap)
+	} else {
+		v = v[:0]
+	}
+	vertexPool.Put(v)
+}
+
+func getIndices() []uint16 {
+	return indexPool.Get().([]uint16)[:0]
+}
+
+func putIndices(i []uint16) {
+	if cap(i) > maxIndexCap {
+		i = make([]uint16, 0, defaultIndexCap)
+	} else {
+		i = i[:0]
+	}
+	indexPool.Put(i)
+}

--- a/eui/render.go
+++ b/eui/render.go
@@ -1294,11 +1294,13 @@ func drawDropShadow(screen *ebiten.Image, rrect *roundRect, size float32, col Co
 }
 
 func drawRoundRect(screen *ebiten.Image, rrect *roundRect) {
-	var (
-		path     vector.Path
-		vertices []ebiten.Vertex
-		indices  []uint16
-	)
+	var path vector.Path
+	vertices := getVertices()
+	indices := getIndices()
+	defer func() {
+		putVertices(vertices)
+		putIndices(indices)
+	}()
 
 	width := float32(math.Round(float64(rrect.Border)))
 	off := float32(0)
@@ -1371,10 +1373,10 @@ func drawRoundRect(screen *ebiten.Image, rrect *roundRect) {
 	path.Close()
 
 	if rrect.Filled {
-		vertices, indices = path.AppendVerticesAndIndicesForFilling(vertices[:0], indices[:0])
+		vertices, indices = path.AppendVerticesAndIndicesForFilling(vertices, indices)
 	} else {
 		opv := &vector.StrokeOptions{Width: width}
-		vertices, indices = path.AppendVerticesAndIndicesForStroke(vertices[:0], indices[:0], opv)
+		vertices, indices = path.AppendVerticesAndIndicesForStroke(vertices, indices, opv)
 	}
 
 	col := rrect.Color
@@ -1392,11 +1394,13 @@ func drawRoundRect(screen *ebiten.Image, rrect *roundRect) {
 }
 
 func drawTabShape(screen *ebiten.Image, pos point, size point, col Color, fillet float32, slope float32) {
-	var (
-		path     vector.Path
-		vertices []ebiten.Vertex
-		indices  []uint16
-	)
+	var path vector.Path
+	vertices := getVertices()
+	indices := getIndices()
+	defer func() {
+		putVertices(vertices)
+		putIndices(indices)
+	}()
 
 	// Align to pixel boundaries to avoid artifacts
 	pos.X = float32(math.Round(float64(pos.X)))
@@ -1424,7 +1428,7 @@ func drawTabShape(screen *ebiten.Image, pos point, size point, col Color, fillet
 	path.LineTo(pos.X, pos.Y+size.Y)
 	path.Close()
 
-	vertices, indices = path.AppendVerticesAndIndicesForFilling(vertices[:0], indices[:0])
+	vertices, indices = path.AppendVerticesAndIndicesForFilling(vertices, indices)
 	c := col
 	for i := range vertices {
 		vertices[i].SrcX = 1
@@ -1442,11 +1446,13 @@ func drawTabShape(screen *ebiten.Image, pos point, size point, col Color, fillet
 }
 
 func strokeTabShape(screen *ebiten.Image, pos point, size point, col Color, fillet float32, slope float32, border float32) {
-	var (
-		path     vector.Path
-		vertices []ebiten.Vertex
-		indices  []uint16
-	)
+	var path vector.Path
+	vertices := getVertices()
+	indices := getIndices()
+	defer func() {
+		putVertices(vertices)
+		putIndices(indices)
+	}()
 
 	// Align to pixel boundaries
 	border = float32(math.Round(float64(border)))
@@ -1475,7 +1481,7 @@ func strokeTabShape(screen *ebiten.Image, pos point, size point, col Color, fill
 	path.Close()
 
 	opv := &vector.StrokeOptions{Width: border}
-	vertices, indices = path.AppendVerticesAndIndicesForStroke(vertices[:0], indices[:0], opv)
+	vertices, indices = path.AppendVerticesAndIndicesForStroke(vertices, indices, opv)
 	c := col
 	for i := range vertices {
 		vertices[i].SrcX = 1
@@ -1491,11 +1497,13 @@ func strokeTabShape(screen *ebiten.Image, pos point, size point, col Color, fill
 }
 
 func strokeTabTop(screen *ebiten.Image, pos point, size point, col Color, fillet float32, slope float32, border float32) {
-	var (
-		path     vector.Path
-		vertices []ebiten.Vertex
-		indices  []uint16
-	)
+	var path vector.Path
+	vertices := getVertices()
+	indices := getIndices()
+	defer func() {
+		putVertices(vertices)
+		putIndices(indices)
+	}()
 
 	border = float32(math.Round(float64(border)))
 	off := pixelOffset(border)
@@ -1521,7 +1529,7 @@ func strokeTabTop(screen *ebiten.Image, pos point, size point, col Color, fillet
 	}
 
 	opv := &vector.StrokeOptions{Width: border}
-	vertices, indices = path.AppendVerticesAndIndicesForStroke(vertices[:0], indices[:0], opv)
+	vertices, indices = path.AppendVerticesAndIndicesForStroke(vertices, indices, opv)
 	c := col
 	for i := range vertices {
 		vertices[i].SrcX = 1
@@ -1537,11 +1545,13 @@ func strokeTabTop(screen *ebiten.Image, pos point, size point, col Color, fillet
 }
 
 func drawTriangle(screen *ebiten.Image, pos point, size float32, col Color) {
-	var (
-		path     vector.Path
-		vertices []ebiten.Vertex
-		indices  []uint16
-	)
+	var path vector.Path
+	vertices := getVertices()
+	indices := getIndices()
+	defer func() {
+		putVertices(vertices)
+		putIndices(indices)
+	}()
 
 	// Quantize to pixel boundaries
 	pos.X = float32(math.Round(float64(pos.X)))
@@ -1553,7 +1563,7 @@ func drawTriangle(screen *ebiten.Image, pos point, size float32, col Color) {
 	path.LineTo(pos.X+size/2, pos.Y+size)
 	path.Close()
 
-	vertices, indices = path.AppendVerticesAndIndicesForFilling(vertices[:0], indices[:0])
+	vertices, indices = path.AppendVerticesAndIndicesForFilling(vertices, indices)
 	c := col
 	for i := range vertices {
 		vertices[i].SrcX = 1
@@ -1590,11 +1600,13 @@ func drawEye(screen *ebiten.Image, r rect, col Color) {
 }
 
 func drawCheckmark(screen *ebiten.Image, start, mid, end point, width float32, col Color) {
-	var (
-		path     vector.Path
-		vertices []ebiten.Vertex
-		indices  []uint16
-	)
+	var path vector.Path
+	vertices := getVertices()
+	indices := getIndices()
+	defer func() {
+		putVertices(vertices)
+		putIndices(indices)
+	}()
 
 	width = float32(math.Round(float64(width)))
 	off := pixelOffset(width)
@@ -1604,7 +1616,7 @@ func drawCheckmark(screen *ebiten.Image, start, mid, end point, width float32, c
 	path.LineTo(float32(math.Round(float64(end.X)))+off, float32(math.Round(float64(end.Y)))+off)
 
 	opv := &vector.StrokeOptions{Width: width, LineJoin: vector.LineJoinRound, LineCap: vector.LineCapRound}
-	vertices, indices = path.AppendVerticesAndIndicesForStroke(vertices[:0], indices[:0], opv)
+	vertices, indices = path.AppendVerticesAndIndicesForStroke(vertices, indices, opv)
 	c := col
 	for i := range vertices {
 		vertices[i].SrcX = 1


### PR DESCRIPTION
## Summary
- add package-level pools for reusable `[]ebiten.Vertex` and `[]uint16`
- use pooled buffers in drawRoundRect, drawTabShape, strokeTabShape, strokeTabTop, drawTriangle and drawCheckmark

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6897e58acb00832abd23e15fc8d33264