### PR TITLE
Use Value.IsZero for zero-check

### DIFF
--- a/eui/window.go
+++ b/eui/window.go
@@ -72,7 +72,7 @@ func mergeData(original interface{}, updates interface{}) interface{} {
 }
 
 func isZeroValue(value reflect.Value) bool {
-	return reflect.DeepEqual(value.Interface(), reflect.Zero(value.Type()).Interface())
+	return value.IsZero()
 }
 
 func stripWindowColors(w *windowData) {


### PR DESCRIPTION
## Summary
- optimize zero value detection by replacing reflect.DeepEqual with Value.IsZero

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6897f69826ec832a9a94412245b2621c