### PR TITLE
Cache tab label metrics and images for flow tabs

### DIFF
--- a/eui/dispose.go
+++ b/eui/dispose.go
@@ -25,6 +25,13 @@ func (item *itemData) deallocImages() {
 		item.LabelImage.Deallocate()
 		item.LabelImage = nil
 	}
+	if item.nameImage != nil {
+		if DebugMode {
+			log.Printf("disposing name image for item %p", item)
+		}
+		item.nameImage.Deallocate()
+		item.nameImage = nil
+	}
 	for _, child := range item.Contents {
 		if child != nil {
 			child.deallocImages()

--- a/eui/struct.go
+++ b/eui/struct.go
@@ -98,6 +98,12 @@ type itemData struct {
 	prevReveal bool
 	prevText   string
 
+	// Cached metrics and image for tab labels (Name)
+	nameWidth, nameHeight float32
+	nameImage             *ebiten.Image
+	nameFontSize          float32
+	prevName              string
+
 	Hovered, Checked, Focused,
 	Disabled, Invisible bool
 	Clicked  time.Time


### PR DESCRIPTION
## Summary
- cache tab name width/height and pre-rendered image in itemData
- reuse cached tab label image during drawFlows instead of Measure/Draw each frame
- dispose cached tab label images when items are deallocated

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6897face8de0832a93edac7e34a533f6