### PR TITLE
Fix center pin positioning and add regression test

### DIFF
--- a/eui/util_test.go
+++ b/eui/util_test.go
@@ -140,6 +140,25 @@ func TestPinPositions(t *testing.T) {
 	}
 }
 
+func TestCenterPinOddScreenDimensions(t *testing.T) {
+	oldW, oldH := screenWidth, screenHeight
+	defer func() {
+		screenWidth = oldW
+		screenHeight = oldH
+	}()
+
+	screenWidth = 801
+	screenHeight = 601
+	win := &windowData{Position: point{X: 0, Y: 0}, Size: point{X: 100, Y: 80}}
+	var pin pinType = PIN_MID_CENTER
+	pos := pin.getWinPosition(win)
+	exp := point{X: float32(screenWidth)/2 - win.GetSize().X/2 + win.GetPos().X,
+		Y: float32(screenHeight)/2 - win.GetSize().Y/2 + win.GetPos().Y}
+	if pos != exp {
+		t.Errorf("mid center got %+v want %+v", pos, exp)
+	}
+}
+
 func TestItemOverlap(t *testing.T) {
 	win := &windowData{Size: point{X: 100, Y: 100}, Position: point{X: 0, Y: 0}}
 	a := &itemData{Position: point{X: 0, Y: 0}, Size: point{X: 60, Y: 60}}

--- a/eui/window.go
+++ b/eui/window.go
@@ -397,17 +397,17 @@ func (pin pinType) getWinPosition(win *windowData) point {
 	case PIN_TOP_RIGHT:
 		return point{X: float32(screenWidth) - win.GetSize().X - win.GetPos().X, Y: win.GetPos().Y}
 	case PIN_TOP_CENTER:
-		return point{X: float32(screenWidth/2) - win.GetSize().X/2 + win.GetPos().X, Y: win.GetPos().Y}
+		return point{X: float32(screenWidth)/2 - win.GetSize().X/2 + win.GetPos().X, Y: win.GetPos().Y}
 	case PIN_MID_LEFT:
-		return point{X: win.GetPos().X, Y: float32(screenHeight/2) - win.GetSize().Y/2 + win.GetPos().Y}
+		return point{X: win.GetPos().X, Y: float32(screenHeight)/2 - win.GetSize().Y/2 + win.GetPos().Y}
 	case PIN_MID_CENTER:
-		return point{X: float32(screenWidth/2) - win.GetSize().X/2 + win.GetPos().X, Y: float32(screenHeight/2) - win.GetSize().Y/2 + win.GetPos().Y}
+		return point{X: float32(screenWidth)/2 - win.GetSize().X/2 + win.GetPos().X, Y: float32(screenHeight)/2 - win.GetSize().Y/2 + win.GetPos().Y}
 	case PIN_MID_RIGHT:
-		return point{X: float32(screenWidth) - win.GetSize().X - win.GetPos().X, Y: float32(screenHeight/2) - win.GetSize().Y/2 + win.GetPos().Y}
+		return point{X: float32(screenWidth) - win.GetSize().X - win.GetPos().X, Y: float32(screenHeight)/2 - win.GetSize().Y/2 + win.GetPos().Y}
 	case PIN_BOTTOM_LEFT:
 		return point{X: win.GetPos().X, Y: float32(screenHeight) - win.GetSize().Y - win.GetPos().Y}
 	case PIN_BOTTOM_CENTER:
-		return point{X: float32(screenWidth/2) - (win.GetSize().X / 2) + win.GetPos().X, Y: float32(screenHeight) - win.GetSize().Y - win.GetPos().Y}
+		return point{X: float32(screenWidth)/2 - (win.GetSize().X / 2) + win.GetPos().X, Y: float32(screenHeight) - win.GetSize().Y - win.GetPos().Y}
 	case PIN_BOTTOM_RIGHT:
 		return point{X: float32(screenWidth) - win.GetSize().X - win.GetPos().X, Y: float32(screenHeight) - win.GetSize().Y - win.GetPos().Y}
 	default:


### PR DESCRIPTION
## Summary
- fix center pin positioning by dividing after converting to float
- add regression test for center pin on odd screen dimensions

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./...` *(fails: undefined DebugMode, undefined: windows)*


------
https://chatgpt.com/codex/tasks/task_e_6898081defbc832a87e7af11d81e075b