### PR TITLE
Ensure autosize windows rescale correctly

### DIFF
--- a/eui/struct.go
+++ b/eui/struct.go
@@ -34,7 +34,7 @@ type windowData struct {
 	Open, Hovered, Flow,
 	Closable, Movable, Resizable,
 	HoverClose, HoverDragbar,
-	AutoSize, FixedRatio bool
+	AutoSize, AutoSizeOnScale, FixedRatio bool
 
 	// MainPortal renders the window before others, draws a scaled black
 	// pixel over the area outside it and skips drawing the background so

--- a/eui/util.go
+++ b/eui/util.go
@@ -486,7 +486,7 @@ func SetUIScale(scale float32) {
 	}
 	uiScale = scale
 	for _, win := range windows {
-		if win.AutoSize {
+		if win.AutoSize || win.AutoSizeOnScale {
 			win.updateAutoSize()
 		} else {
 			win.resizeFlows()

--- a/eui/util_test.go
+++ b/eui/util_test.go
@@ -529,3 +529,25 @@ func TestSetScreenSizeClamps(t *testing.T) {
 		t.Errorf("window not clamped after SetScreenSize: %+v", pos)
 	}
 }
+
+func TestAutoSizeWindowResizesWithScale(t *testing.T) {
+	uiScale = 1
+	oldW, oldH := screenWidth, screenHeight
+	windows = nil
+	overlays = nil
+	screenWidth, screenHeight = 210, 200
+	defer func() {
+		screenWidth, screenHeight = oldW, oldH
+		uiScale = 1
+		windows = nil
+	}()
+
+	win := &windowData{AutoSize: true, TitleHeight: 0, Padding: 10}
+	win.addItemTo(&itemData{ItemType: ITEM_BUTTON, Size: point{X: 100, Y: 50}})
+	win.AddWindow(false)
+
+	SetUIScale(2)
+	if got := win.GetSize().X; got != float32(screenWidth) {
+		t.Fatalf("scaled window width got %v want %v", got, screenWidth)
+	}
+}

--- a/eui/window.go
+++ b/eui/window.go
@@ -118,6 +118,7 @@ func (target *windowData) AddWindow(toBack bool) {
 
 	if target.AutoSize {
 		target.updateAutoSize()
+		target.AutoSizeOnScale = true
 		target.AutoSize = false
 	}
 


### PR DESCRIPTION
## Summary
- Track windows created with `AutoSize` to reapply auto sizing on UI scale changes
- Update `AddWindow` to record autosized windows and revise `SetUIScale`
- Add regression test for autosized window resizing when UI scale changes

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags=test ./eui` *(fails: undefined: withinRange)*


------
https://chatgpt.com/codex/tasks/task_e_6898082eb35c832abb4581c7cc8fe5ac