### PR TITLE
Respect margins in layout bounds

### DIFF
--- a/eui/util.go
+++ b/eui/util.go
@@ -624,16 +624,17 @@ func (win *windowData) itemsDirty() bool {
 }
 
 func (item *itemData) bounds(offset point) rect {
+	m := item.Margin * uiScale
 	var r rect
 	if item.ItemType == ITEM_FLOW && !item.Fixed {
 		// Unfixed flows should report bounds based solely on their content
-		r = rect{X0: offset.X, Y0: offset.Y, X1: offset.X, Y1: offset.Y}
+		r = rect{X0: offset.X, Y0: offset.Y, X1: offset.X + m, Y1: offset.Y + m}
 	} else {
 		r = rect{
 			X0: offset.X,
 			Y0: offset.Y,
-			X1: offset.X + item.GetSize().X,
-			Y1: offset.Y + item.GetSize().Y,
+			X1: offset.X + item.GetSize().X + m,
+			Y1: offset.Y + item.GetSize().Y + m,
 		}
 	}
 	if item.ItemType == ITEM_FLOW {
@@ -648,25 +649,27 @@ func (item *itemData) bounds(offset point) rect {
 			subItems = item.Contents
 		}
 		for _, sub := range subItems {
+			sm := sub.Margin * uiScale
 			var off point
 			if item.FlowType == FLOW_HORIZONTAL {
-				off = pointAdd(offset, point{X: flowOffset.X + sub.GetPos().X, Y: sub.GetPos().Y})
+				off = pointAdd(offset, point{X: flowOffset.X + sub.GetPos().X + sm, Y: sub.GetPos().Y + sm})
 			} else if item.FlowType == FLOW_VERTICAL {
-				off = pointAdd(offset, point{X: sub.GetPos().X, Y: flowOffset.Y + sub.GetPos().Y})
+				off = pointAdd(offset, point{X: sub.GetPos().X + sm, Y: flowOffset.Y + sub.GetPos().Y + sm})
 			} else {
-				off = pointAdd(offset, pointAdd(flowOffset, sub.GetPos()))
+				off = pointAdd(offset, pointAdd(flowOffset, point{X: sub.GetPos().X + sm, Y: sub.GetPos().Y + sm}))
 			}
 			sr := sub.bounds(off)
 			r = unionRect(r, sr)
 			if item.FlowType == FLOW_HORIZONTAL {
-				flowOffset.X += sub.GetSize().X + sub.GetPos().X
+				flowOffset.X += sub.GetSize().X + sub.GetPos().X + sm
 			} else if item.FlowType == FLOW_VERTICAL {
-				flowOffset.Y += sub.GetSize().Y + sub.GetPos().Y
+				flowOffset.Y += sub.GetSize().Y + sub.GetPos().Y + sm
 			}
 		}
 	} else {
 		for _, sub := range item.Contents {
-			off := pointAdd(offset, sub.GetPos())
+			sm := sub.Margin * uiScale
+			off := pointAdd(offset, point{X: sub.GetPos().X + sm, Y: sub.GetPos().Y + sm})
 			r = unionRect(r, sub.bounds(off))
 		}
 	}
@@ -684,16 +687,18 @@ func (win *windowData) contentBounds() point {
 
 	for _, item := range win.Contents {
 		var r rect
+		m := item.Margin * uiScale
 		if item.ItemType == ITEM_FLOW {
 			cb := item.contentBounds()
 			r = rect{
-				X0: base.X + item.GetPos().X,
-				Y0: base.Y + item.GetPos().Y,
-				X1: base.X + item.GetPos().X + cb.X,
-				Y1: base.Y + item.GetPos().Y + cb.Y,
+				X0: base.X + item.GetPos().X + m,
+				Y0: base.Y + item.GetPos().Y + m,
+				X1: base.X + item.GetPos().X + cb.X + m,
+				Y1: base.Y + item.GetPos().Y + cb.Y + m,
 			}
 		} else {
-			r = item.bounds(pointAdd(base, item.GetPos()))
+			off := pointAdd(base, point{X: item.GetPos().X + m, Y: item.GetPos().Y + m})
+			r = item.bounds(off)
 		}
 		if first {
 			b = r
@@ -751,14 +756,15 @@ func (item *itemData) contentBounds() point {
 	var flowOffset point
 
 	for _, sub := range list {
-		off := pointAdd(base, sub.GetPos())
+		sm := sub.Margin * uiScale
+		off := pointAdd(base, point{X: sub.GetPos().X + sm, Y: sub.GetPos().Y + sm})
 		if item.ItemType == ITEM_FLOW {
 			if item.FlowType == FLOW_HORIZONTAL {
-				off = pointAdd(base, point{X: flowOffset.X + sub.GetPos().X, Y: sub.GetPos().Y})
+				off = pointAdd(base, point{X: flowOffset.X + sub.GetPos().X + sm, Y: sub.GetPos().Y + sm})
 			} else if item.FlowType == FLOW_VERTICAL {
-				off = pointAdd(base, point{X: sub.GetPos().X, Y: flowOffset.Y + sub.GetPos().Y})
+				off = pointAdd(base, point{X: sub.GetPos().X + sm, Y: flowOffset.Y + sub.GetPos().Y + sm})
 			} else {
-				off = pointAdd(base, pointAdd(flowOffset, sub.GetPos()))
+				off = pointAdd(base, pointAdd(flowOffset, point{X: sub.GetPos().X + sm, Y: sub.GetPos().Y + sm}))
 			}
 		}
 
@@ -772,9 +778,9 @@ func (item *itemData) contentBounds() point {
 
 		if item.ItemType == ITEM_FLOW {
 			if item.FlowType == FLOW_HORIZONTAL {
-				flowOffset.X += sub.GetSize().X + sub.GetPos().X
+				flowOffset.X += sub.GetSize().X + sub.GetPos().X + sm
 			} else if item.FlowType == FLOW_VERTICAL {
-				flowOffset.Y += sub.GetSize().Y + sub.GetPos().Y
+				flowOffset.Y += sub.GetSize().Y + sub.GetPos().Y + sm
 			}
 		}
 	}

--- a/eui/util_test.go
+++ b/eui/util_test.go
@@ -326,6 +326,34 @@ func TestFlowContentBounds(t *testing.T) {
 	}
 }
 
+func TestMarginAffectsBounds(t *testing.T) {
+	uiScale = 1
+
+	vflow := &itemData{ItemType: ITEM_FLOW, FlowType: FLOW_VERTICAL}
+	vflow.addItemTo(&itemData{ItemType: ITEM_BUTTON, Size: point{X: 10, Y: 20}, Margin: 5})
+	vflow.addItemTo(&itemData{ItemType: ITEM_BUTTON, Size: point{X: 15, Y: 30}, Margin: 5})
+	wantV := point{X: 25, Y: 65}
+	if got := vflow.contentBounds(); got != wantV {
+		t.Errorf("vertical bounds with margin got %+v want %+v", got, wantV)
+	}
+
+	hflow := &itemData{ItemType: ITEM_FLOW, FlowType: FLOW_HORIZONTAL}
+	hflow.addItemTo(&itemData{ItemType: ITEM_BUTTON, Size: point{X: 10, Y: 20}, Margin: 5})
+	hflow.addItemTo(&itemData{ItemType: ITEM_BUTTON, Size: point{X: 15, Y: 30}, Margin: 5})
+	wantH := point{X: 40, Y: 40}
+	if got := hflow.contentBounds(); got != wantH {
+		t.Errorf("horizontal bounds with margin got %+v want %+v", got, wantH)
+	}
+
+	win := &windowData{AutoSize: true, TitleHeight: 0}
+	win.addItemTo(&itemData{ItemType: ITEM_BUTTON, Size: point{X: 10, Y: 20}, Margin: 5})
+	win.Refresh()
+	wantWin := point{X: 20, Y: 30}
+	if got := win.GetSize(); got != wantWin {
+		t.Errorf("window size with margin got %+v want %+v", got, wantWin)
+	}
+}
+
 func TestWindowRefreshRecalculatesFlow(t *testing.T) {
 	uiScale = 1
 


### PR DESCRIPTION
## Summary
- account for item margins when computing bounds and content sizes
- use margin-aware bounds for window auto-sizing and flow resizing
- test window and flow expansion with non-zero margins

## Testing
- `go vet ./...`
- `go build ./...`
- `EBITENGINE_HEADLESS=1 go test ./...` *(fails: `glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred`)*

------
https://chatgpt.com/codex/tasks/task_e_689808331880832aab7a41f0e6c7869c