### PR TITLE
Use noninteractive apt-get installs in setup script

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2,5 +2,5 @@
 set -e
 sudo apt-get update
 sudo apt-get install -y libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxxf86vm-dev libgl1-mesa-dev brotli
-sudo aptitude -f install build-essential
-sudo apt install libc6-dev libgl1-mesa-dev libxcursor-dev libxi-dev libxinerama-dev libxrandr-dev libxxf86vm-dev libasound2-dev pkg-config
+sudo apt-get install -y build-essential
+sudo apt-get install -y libc6-dev libgl1-mesa-dev libxcursor-dev libxi-dev libxinerama-dev libxrandr-dev libxxf86vm-dev libasound2-dev pkg-config


### PR DESCRIPTION
## Summary
- Ensure setup script uses `apt-get` consistently
- Run package installs with `-y` to avoid manual prompts

## Testing
- `./scripts/setup.sh`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689812631f74832ab45114996d4a32b4