### PR TITLE
Scale pointer coordinates with device scale

### DIFF
--- a/eui/pointer.go
+++ b/eui/pointer.go
@@ -24,10 +24,18 @@ const touchScrollScale = 0.05
 // If a touch is active, the first touch is used. Otherwise the mouse cursor position is returned.
 func pointerPosition() (int, int) {
 	touchIDs = ebiten.AppendTouchIDs(touchIDs[:0])
+	var x, y int
 	if len(touchIDs) > 0 {
-		return ebiten.TouchPosition(touchIDs[0])
+		x, y = ebiten.TouchPosition(touchIDs[0])
+	} else {
+		x, y = ebiten.CursorPosition()
 	}
-	return ebiten.CursorPosition()
+	if AutoHiDPI {
+		scale := lastDeviceScale
+		x = int(float64(x) * scale)
+		y = int(float64(y) * scale)
+	}
+	return x, y
 }
 
 // pointerWheel returns the wheel delta for mouse or two-finger touch scrolling.


### PR DESCRIPTION
## Summary
- Scale pointer coordinates by `lastDeviceScale` when `AutoHiDPI` is enabled to keep cursor and touch positions in sync with device pixel ratio.

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./...` *(fails: undefined DebugMode in dispose.go)*

------
https://chatgpt.com/codex/tasks/task_e_6898291d29a8832ab81eab08dd49c8eb