### PR TITLE
test: add options pool reset tests

### DIFF
--- a/eui/options_pool_test.go
+++ b/eui/options_pool_test.go
@@ -1,6 +1,10 @@
 package eui
 
-import "testing"
+import (
+	"testing"
+
+	etext "github.com/hajimehoshi/ebiten/v2/text/v2"
+)
 
 func BenchmarkAcquireDrawImageOptions(b *testing.B) {
 	b.ReportAllocs()
@@ -18,4 +22,45 @@ func BenchmarkAcquireTextDrawOptions(b *testing.B) {
 		op.DrawImageOptions.GeoM.Translate(1, 1)
 		releaseTextDrawOptions(op)
 	}
+}
+
+func TestDrawImageOptionsPoolResets(t *testing.T) {
+	op := acquireDrawImageOptions()
+	op.GeoM.Translate(1, 1)
+	op.ColorScale.Scale(0.5, 0.25, 0.75, 0.5)
+	releaseDrawImageOptions(op)
+
+	op = acquireDrawImageOptions()
+	if tx, ty := op.GeoM.Apply(0, 0); tx != 0 || ty != 0 {
+		t.Fatalf("GeoM not reset: translation (%f,%f)", tx, ty)
+	}
+	if op.ColorScale.R() != 1 || op.ColorScale.G() != 1 || op.ColorScale.B() != 1 || op.ColorScale.A() != 1 {
+		t.Fatalf("ColorScale not reset: %v", op.ColorScale)
+	}
+	releaseDrawImageOptions(op)
+}
+
+func TestTextDrawOptionsPoolResets(t *testing.T) {
+	op := acquireTextDrawOptions()
+	op.DrawImageOptions.GeoM.Translate(1, 1)
+	op.DrawImageOptions.ColorScale.Scale(0.5, 0.25, 0.75, 0.5)
+	op.LayoutOptions = etext.LayoutOptions{
+		LineSpacing:    1,
+		PrimaryAlign:   etext.AlignCenter,
+		SecondaryAlign: etext.AlignEnd,
+	}
+	op.ColorScale.Scale(0.5, 0.5, 0.5, 0.5)
+	releaseTextDrawOptions(op)
+
+	op = acquireTextDrawOptions()
+	if tx, ty := op.GeoM.Apply(0, 0); tx != 0 || ty != 0 {
+		t.Fatalf("GeoM not reset: translation (%f,%f)", tx, ty)
+	}
+	if op.ColorScale.R() != 1 || op.ColorScale.G() != 1 || op.ColorScale.B() != 1 || op.ColorScale.A() != 1 {
+		t.Fatalf("ColorScale not reset: %v", op.ColorScale)
+	}
+	if op.LayoutOptions != (etext.LayoutOptions{}) {
+		t.Fatalf("LayoutOptions not reset: %#v", op.LayoutOptions)
+	}
+	releaseTextDrawOptions(op)
 }


### PR DESCRIPTION
## Summary
- add tests confirming DrawImageOptions are reset when reused
- add tests confirming text.DrawOptions reset all fields when reused

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./...` *(fails: undefined: DebugMode)*

------
https://chatgpt.com/codex/tasks/task_e_68982c97422c832aa50df75c58f746d5