### PR TITLE
Mark window dirty when title changes

### DIFF
--- a/eui/title_cache_test.go
+++ b/eui/title_cache_test.go
@@ -1,0 +1,76 @@
+//go:build test
+
+package eui
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/text/v2"
+)
+
+// helper to ensure font source for title rendering
+func ensureFont(t *testing.T) {
+	if mplusFaceSource == nil {
+		s, err := text.NewGoTextFaceSource(bytes.NewReader(notoTTF))
+		if err != nil {
+			t.Fatalf("font init: %v", err)
+		}
+		mplusFaceSource = s
+	}
+}
+
+func TestSetTitleUpdatesRender(t *testing.T) {
+	ensureFont(t)
+
+	win := *defaultTheme
+	win.Theme = baseTheme
+	win.Title = "before"
+	win.Open = true
+
+	screen := ebiten.NewImage(200, 200)
+	win.Dirty = true
+	win.Draw(screen)
+	buf1 := make([]byte, 4*win.Render.Bounds().Dx()*win.Render.Bounds().Dy())
+	win.Render.ReadPixels(buf1)
+
+	win.SetTitle("after")
+	if !win.Dirty {
+		t.Fatalf("expected window marked dirty after SetTitle")
+	}
+	win.Draw(screen)
+	buf2 := make([]byte, 4*win.Render.Bounds().Dx()*win.Render.Bounds().Dy())
+	win.Render.ReadPixels(buf2)
+
+	if bytes.Equal(buf1, buf2) {
+		t.Fatalf("expected cached image to change after title update")
+	}
+}
+
+func TestSetTitleSizeUpdatesRender(t *testing.T) {
+	ensureFont(t)
+
+	win := *defaultTheme
+	win.Theme = baseTheme
+	win.Title = "title"
+	win.Open = true
+
+	screen := ebiten.NewImage(200, 200)
+	win.Dirty = true
+	win.Draw(screen)
+	buf1 := make([]byte, 4*win.Render.Bounds().Dx()*win.Render.Bounds().Dy())
+	win.Render.ReadPixels(buf1)
+
+	win.SetTitleSize(win.GetTitleSize() + 10)
+	if !win.Dirty {
+		t.Fatalf("expected window marked dirty after SetTitleSize")
+	}
+	win.Draw(screen)
+	buf2 := make([]byte, 4*win.Render.Bounds().Dx()*win.Render.Bounds().Dy())
+	win.Render.ReadPixels(buf2)
+
+	if bytes.Equal(buf1, buf2) {
+		t.Fatalf("expected cached image to change after title size update")
+	}
+}

--- a/eui/util.go
+++ b/eui/util.go
@@ -453,12 +453,14 @@ func (win *windowData) titleTextWidth() point {
 func (win *windowData) SetTitleSize(size float32) {
 	win.TitleHeight = size / uiScale
 	win.invalidateTitleCache()
+	win.Dirty = true
 }
 
 func (win *windowData) SetTitle(title string) {
 	if win.Title != title {
 		win.Title = title
 		win.invalidateTitleCache()
+		win.Dirty = true
 	}
 }
 


### PR DESCRIPTION
## Summary
- mark window as dirty when title text or size changes to refresh cache
- add tests verifying title updates re-render window

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./...` *(fails: undefined: DebugMode, undefined: windows, undefined: overlays, undefined: mplusFaceSource, undefined: uiScale)*

------
https://chatgpt.com/codex/tasks/task_e_68982c8edd60832ab0033d0b677f2d59