### PR TITLE
Ensure window adjusts after title changes

### DIFF
--- a/eui/util.go
+++ b/eui/util.go
@@ -453,12 +453,16 @@ func (win *windowData) titleTextWidth() point {
 func (win *windowData) SetTitleSize(size float32) {
 	win.TitleHeight = size / uiScale
 	win.invalidateTitleCache()
+	win.Dirty = true
+	win.resizeFlows()
 }
 
 func (win *windowData) SetTitle(title string) {
 	if win.Title != title {
 		win.Title = title
 		win.invalidateTitleCache()
+		win.Dirty = true
+		win.resizeFlows()
 	}
 }
 

--- a/eui/window_refresh_test.go
+++ b/eui/window_refresh_test.go
@@ -36,3 +36,27 @@ func TestWindowRefreshRerenders(t *testing.T) {
 		t.Fatalf("expected render count to increase after Refresh")
 	}
 }
+
+func TestWindowRefreshTitleUpdates(t *testing.T) {
+	DebugMode = true
+	defer func() { DebugMode = false }()
+
+	win := *defaultTheme
+	win.Theme = baseTheme
+	win.Open = true
+	win.SetTitle("short")
+
+	windows = []*windowData{&win}
+	screen := ebiten.NewImage(200, 200)
+
+	win.Dirty = true
+	Draw(screen)
+	w0 := win.titleTextW
+
+	win.SetTitle("a much longer title")
+	Draw(screen)
+
+	if win.titleTextW <= w0 {
+		t.Fatalf("expected title width to increase after title update")
+	}
+}


### PR DESCRIPTION
## Summary
- Recalculate window layout when titles or title sizes change
- Test window refresh now validates title updates

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./...` *(fails: undefined: DebugMode)*

------
https://chatgpt.com/codex/tasks/task_e_68982c994ff4832aa8b29e11a12777c5