### PR TITLE
Reset draw image options from pool

### DIFF
--- a/eui/options_pool.go
+++ b/eui/options_pool.go
@@ -15,6 +15,7 @@ var drawImageOptionsPool = sync.Pool{
 
 func acquireDrawImageOptions() *ebiten.DrawImageOptions {
 	op := drawImageOptionsPool.Get().(*ebiten.DrawImageOptions)
+	*op = ebiten.DrawImageOptions{}
 	op.GeoM.Reset()
 	op.ColorScale.Reset()
 	return op

--- a/eui/options_pool_test.go
+++ b/eui/options_pool_test.go
@@ -1,6 +1,55 @@
 package eui
 
-import "testing"
+import (
+	"image"
+	"reflect"
+	"testing"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	text "github.com/hajimehoshi/ebiten/v2/text/v2"
+)
+
+func mutateDrawImageOptions(op *ebiten.DrawImageOptions) {
+	op.GeoM.Translate(1, 1)
+	op.ColorScale.Scale(1, 2, 3, 4)
+	op.Filter = ebiten.FilterLinear
+	op.CompositeMode = ebiten.CompositeModeSourceOver
+
+	v := reflect.ValueOf(op).Elem()
+	if f := v.FieldByName("Address"); f.IsValid() && f.CanSet() {
+		f.Set(reflect.ValueOf(ebiten.AddressClampToZero))
+	}
+	if f := v.FieldByName("SourceRect"); f.IsValid() && f.CanSet() {
+		r := image.Rect(1, 2, 3, 4)
+		f.Set(reflect.ValueOf(&r))
+	}
+}
+
+func TestAcquireDrawImageOptions(t *testing.T) {
+	op := acquireDrawImageOptions()
+	mutateDrawImageOptions(op)
+	releaseDrawImageOptions(op)
+
+	op = acquireDrawImageOptions()
+	var expected ebiten.DrawImageOptions
+	if !reflect.DeepEqual(*op, expected) {
+		t.Errorf("acquired options not reset: %+v", op)
+	}
+}
+
+func TestAcquireTextDrawOptions(t *testing.T) {
+	op := acquireTextDrawOptions()
+	mutateDrawImageOptions(&op.DrawImageOptions)
+	op.LayoutOptions.LineSpacing = 1
+	op.LayoutOptions.PrimaryAlign = text.AlignCenter
+	releaseTextDrawOptions(op)
+
+	op = acquireTextDrawOptions()
+	var expected text.DrawOptions
+	if !reflect.DeepEqual(*op, expected) {
+		t.Errorf("acquired text options not reset: %+v", op)
+	}
+}
 
 func BenchmarkAcquireDrawImageOptions(b *testing.B) {
 	b.ReportAllocs()


### PR DESCRIPTION
## Summary
- ensure draw image options pulled from pool are fully reset
- add tests validating option pools return default state

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./...` *(fails: eui/dispose.go:8:6: undefined: DebugMode)*

------
https://chatgpt.com/codex/tasks/task_e_68982c8a9bd0832ab99fa37a0c6678da