### PR TITLE
Simplify default widget constructors

### DIFF
--- a/api.md
+++ b/api.md
@@ -222,28 +222,28 @@ func LoadTheme(name string) error
     LoadTheme reads a theme JSON file from the themes directory and sets it as
     the current theme without modifying existing windows.
 
-func NewButton(item *itemData) (*itemData, *EventHandler)
+func NewButton() (*itemData, *EventHandler)
     Create a new button from the default theme
 
-func NewCheckbox(item *itemData) (*itemData, *EventHandler)
+func NewCheckbox() (*itemData, *EventHandler)
     Create a new checkbox from the default theme
 
-func NewColorWheel(item *itemData) (*itemData, *EventHandler)
+func NewColorWheel() (*itemData, *EventHandler)
     Create a new color wheel from the default theme
 
-func NewDropdown(item *itemData) (*itemData, *EventHandler)
+func NewDropdown() (*itemData, *EventHandler)
     Create a new dropdown from the default theme
 
-func NewInput(item *itemData) (*itemData, *EventHandler)
+func NewInput() (*itemData, *EventHandler)
     Create a new input box from the default theme
 
-func NewRadio(item *itemData) (*itemData, *EventHandler)
+func NewRadio() (*itemData, *EventHandler)
     Create a new radio button from the default theme
 
-func NewSlider(item *itemData) (*itemData, *EventHandler)
+func NewSlider() (*itemData, *EventHandler)
     Create a new slider from the default theme
 
-func NewText(item *itemData) (*itemData, *EventHandler)
+func NewText() (*itemData, *EventHandler)
     Create a new textbox from the default theme
 
 func SaveTheme(name string) error
@@ -283,7 +283,7 @@ func Update() error
     Update processes input and updates window state. Programs embedding the UI
     can call this from their Ebiten Update handler.
 
-func NewWindow(win *windowData) *windowData
+func NewWindow() *windowData
     Create a new window from the default theme
 
 

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -67,7 +67,9 @@ func main() {
 		Position: eui.Point{X: 110, Y: 0},
 		PinTo:    eui.PIN_BOTTOM_LEFT,
 	}
-	statusText, _ = eui.NewText(&eui.ItemData{Size: eui.Point{X: 300, Y: 24}, FontSize: 8})
+	statusText, _ = eui.NewText()
+	statusText.Size = eui.Point{X: 300, Y: 24}
+	statusText.FontSize = 8
 	statusOverlay.AddItem(statusText)
 	eui.AddOverlayFlow(statusOverlay)
 
@@ -77,10 +79,15 @@ func main() {
 		PinTo:    eui.PIN_BOTTOM_LEFT,
 	}
 
-	textItem, _ := eui.NewText(&eui.ItemData{FontSize: 8, Size: eui.Point{X: 80, Y: 24}})
+	textItem, _ := eui.NewText()
+	textItem.FontSize = 8
+	textItem.Size = eui.Point{X: 80, Y: 24}
 	textItem.Text = fmt.Sprintf("Scale: %2.2f", currentScale)
 
-	minusBtn, minusEvents := eui.NewButton(&eui.ItemData{Text: "-", Size: eui.Point{X: 24, Y: 24}, FontSize: 8})
+	minusBtn, minusEvents := eui.NewButton()
+	minusBtn.Text = "-"
+	minusBtn.Size = eui.Point{X: 24, Y: 24}
+	minusBtn.FontSize = 8
 	minusEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventClick {
 			currentScale = eui.UIScale()
@@ -90,7 +97,10 @@ func main() {
 			textItem.Text = fmt.Sprintf("Scale: %2.2f", currentScale)
 		}
 	}
-	plusBtn, plusEvents := eui.NewButton(&eui.ItemData{Text: "+", Size: eui.Point{X: 24, Y: 24}, FontSize: 8})
+	plusBtn, plusEvents := eui.NewButton()
+	plusBtn.Text = "+"
+	plusBtn.Size = eui.Point{X: 24, Y: 24}
+	plusBtn.FontSize = 8
 	plusEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventClick {
 			currentScale = eui.UIScale()

--- a/cmd/demo/showcase.go
+++ b/cmd/demo/showcase.go
@@ -8,16 +8,15 @@ import (
 
 // makeShowcaseWindow creates a window demonstrating most widget types.
 func makeShowcaseWindow() *eui.WindowData {
-	win := eui.NewWindow(&eui.WindowData{
-		Title:     "Showcase",
-		Size:      eui.Point{X: 400, Y: 420},
-		Position:  eui.Point{X: 8, Y: 8},
-		AutoSize:  true,
-		Open:      true,
-		Movable:   true,
-		Resizable: true,
-		Closable:  false,
-	})
+	win := eui.NewWindow()
+	win.Title = "Showcase"
+	win.Size = eui.Point{X: 400, Y: 420}
+	win.Position = eui.Point{X: 8, Y: 8}
+	win.AutoSize = true
+	win.Open = true
+	win.Movable = true
+	win.Resizable = true
+	win.Closable = false
 
 	mainFlow := &eui.ItemData{
 		ItemType: eui.ITEM_FLOW,
@@ -26,10 +25,16 @@ func makeShowcaseWindow() *eui.WindowData {
 	}
 	win.AddItem(mainFlow)
 
-	titleText, _ := eui.NewText(&eui.ItemData{Text: "Demonstration of widgets", Size: eui.Point{X: 380, Y: 32}, FontSize: 10})
+	titleText, _ := eui.NewText()
+	titleText.Text = "Demonstration of widgets"
+	titleText.Size = eui.Point{X: 380, Y: 32}
+	titleText.FontSize = 10
 	mainFlow.AddItem(titleText)
 
-	btnText, btnTextEvents := eui.NewButton(&eui.ItemData{Text: "Text Button", Size: eui.Point{X: 100, Y: 24}, FontSize: 8})
+	btnText, btnTextEvents := eui.NewButton()
+	btnText.Text = "Text Button"
+	btnText.Size = eui.Point{X: 100, Y: 24}
+	btnText.FontSize = 8
 	btnTextEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventClick {
 			setStatus("Text Button clicked")
@@ -37,7 +42,11 @@ func makeShowcaseWindow() *eui.WindowData {
 	}
 	mainFlow.AddItem(btnText)
 
-	chk, chkEvents := eui.NewCheckbox(&eui.ItemData{Text: "Enable option", Size: eui.Point{X: 140, Y: 24}, FontSize: 8, Checked: true})
+	chk, chkEvents := eui.NewCheckbox()
+	chk.Text = "Enable option"
+	chk.Size = eui.Point{X: 140, Y: 24}
+	chk.FontSize = 8
+	chk.Checked = true
 	chkEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventCheckboxChanged {
 			if ev.Checked {
@@ -49,13 +58,22 @@ func makeShowcaseWindow() *eui.WindowData {
 	}
 	mainFlow.AddItem(chk)
 
-	radioA, radioAEvents := eui.NewRadio(&eui.ItemData{Text: "Choice A", RadioGroup: "grp1", Size: eui.Point{X: 140, Y: 24}, FontSize: 8, Checked: true})
+	radioA, radioAEvents := eui.NewRadio()
+	radioA.Text = "Choice A"
+	radioA.RadioGroup = "grp1"
+	radioA.Size = eui.Point{X: 140, Y: 24}
+	radioA.FontSize = 8
+	radioA.Checked = true
 	radioAEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventRadioSelected {
 			setStatus("Selected Choice A")
 		}
 	}
-	radioB, radioBEvents := eui.NewRadio(&eui.ItemData{Text: "Choice B", RadioGroup: "grp1", Size: eui.Point{X: 140, Y: 24}, FontSize: 8})
+	radioB, radioBEvents := eui.NewRadio()
+	radioB.Text = "Choice B"
+	radioB.RadioGroup = "grp1"
+	radioB.Size = eui.Point{X: 140, Y: 24}
+	radioB.FontSize = 8
 	radioBEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventRadioSelected {
 			setStatus("Selected Choice B")
@@ -64,7 +82,14 @@ func makeShowcaseWindow() *eui.WindowData {
 	mainFlow.AddItem(radioA)
 	mainFlow.AddItem(radioB)
 
-	slider, sliderEvents := eui.NewSlider(&eui.ItemData{Label: "Float Slider", Size: eui.Point{X: 180, Y: 24}, MinValue: 0, MaxValue: 100, IntOnly: false, FontSize: 8, Value: 46.2})
+	slider, sliderEvents := eui.NewSlider()
+	slider.Label = "Float Slider"
+	slider.Size = eui.Point{X: 180, Y: 24}
+	slider.MinValue = 0
+	slider.MaxValue = 100
+	slider.IntOnly = false
+	slider.FontSize = 8
+	slider.Value = 46.2
 	sliderEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventSliderChanged {
 			setStatus(fmt.Sprintf("Float Slider changed: %.2f", ev.Value))
@@ -72,7 +97,14 @@ func makeShowcaseWindow() *eui.WindowData {
 	}
 	mainFlow.AddItem(slider)
 
-	intSlider, intSliderEvents := eui.NewSlider(&eui.ItemData{Label: "Int Slider", Size: eui.Point{X: 180, Y: 24}, MinValue: 0, MaxValue: 10, IntOnly: true, FontSize: 8, Value: 3})
+	intSlider, intSliderEvents := eui.NewSlider()
+	intSlider.Label = "Int Slider"
+	intSlider.Size = eui.Point{X: 180, Y: 24}
+	intSlider.MinValue = 0
+	intSlider.MaxValue = 10
+	intSlider.IntOnly = true
+	intSlider.FontSize = 8
+	intSlider.Value = 3
 	intSliderEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventSliderChanged {
 			setStatus(fmt.Sprintf("Int Slider changed: %.0f", ev.Value))
@@ -80,7 +112,11 @@ func makeShowcaseWindow() *eui.WindowData {
 	}
 	mainFlow.AddItem(intSlider)
 
-	input, inputEvents := eui.NewInput(&eui.ItemData{Label: "Text Field", Text: "Text Text!", Size: eui.Point{X: 180, Y: 24}, FontSize: 8})
+	input, inputEvents := eui.NewInput()
+	input.Label = "Text Field"
+	input.Text = "Text Text!"
+	input.Size = eui.Point{X: 180, Y: 24}
+	input.FontSize = 8
 	input.Action = func() { setStatus("Text Field focused") }
 	inputEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventInputChanged {
@@ -89,7 +125,10 @@ func makeShowcaseWindow() *eui.WindowData {
 	}
 	mainFlow.AddItem(input)
 
-	dropdown, dropdownEvents := eui.NewDropdown(&eui.ItemData{Label: "Select Option", Size: eui.Point{X: 180, Y: 24}, FontSize: 8})
+	dropdown, dropdownEvents := eui.NewDropdown()
+	dropdown.Label = "Select Option"
+	dropdown.Size = eui.Point{X: 180, Y: 24}
+	dropdown.FontSize = 8
 	dropdown.Options = []string{"First", "Second", "Third", "Fourth"}
 	dropdown.HoverIndex = -1
 	dropdownEvents.Handle = func(ev eui.UIEvent) {
@@ -109,7 +148,10 @@ func makeShowcaseWindow() *eui.WindowData {
 		Scrollable: true,
 	}
 	mainFlow.AddItem(hFlow)
-	if btn, ev := eui.NewButton(&eui.ItemData{Text: "One", Size: eui.Point{X: 60, Y: 24}, FontSize: 8}); btn != nil {
+	if btn, ev := eui.NewButton(); btn != nil {
+		btn.Text = "One"
+		btn.Size = eui.Point{X: 60, Y: 24}
+		btn.FontSize = 8
 		ev.Handle = func(ev eui.UIEvent) {
 			if ev.Type == eui.EventClick {
 				setStatus("Button One clicked")
@@ -117,7 +159,10 @@ func makeShowcaseWindow() *eui.WindowData {
 		}
 		hFlow.AddItem(btn)
 	}
-	if btn, ev := eui.NewButton(&eui.ItemData{Text: "Two", Size: eui.Point{X: 60, Y: 24}, FontSize: 8}); btn != nil {
+	if btn, ev := eui.NewButton(); btn != nil {
+		btn.Text = "Two"
+		btn.Size = eui.Point{X: 60, Y: 24}
+		btn.FontSize = 8
 		ev.Handle = func(ev eui.UIEvent) {
 			if ev.Type == eui.EventClick {
 				setStatus("Button Two clicked")
@@ -125,7 +170,10 @@ func makeShowcaseWindow() *eui.WindowData {
 		}
 		hFlow.AddItem(btn)
 	}
-	if btn, ev := eui.NewButton(&eui.ItemData{Text: "Three", Size: eui.Point{X: 60, Y: 24}, FontSize: 8}); btn != nil {
+	if btn, ev := eui.NewButton(); btn != nil {
+		btn.Text = "Three"
+		btn.Size = eui.Point{X: 60, Y: 24}
+		btn.FontSize = 8
 		ev.Handle = func(ev eui.UIEvent) {
 			if ev.Type == eui.EventClick {
 				setStatus("Button Three clicked")
@@ -133,7 +181,10 @@ func makeShowcaseWindow() *eui.WindowData {
 		}
 		hFlow.AddItem(btn)
 	}
-	if btn, ev := eui.NewButton(&eui.ItemData{Text: "Four", Size: eui.Point{X: 60, Y: 24}, FontSize: 8}); btn != nil {
+	if btn, ev := eui.NewButton(); btn != nil {
+		btn.Text = "Four"
+		btn.Size = eui.Point{X: 60, Y: 24}
+		btn.FontSize = 8
 		ev.Handle = func(ev eui.UIEvent) {
 			if ev.Type == eui.EventClick {
 				setStatus("Button Four clicked")
@@ -156,10 +207,16 @@ func makeShowcaseWindow() *eui.WindowData {
 		},
 	}
 	mainFlow.AddItem(tabFlow)
-	if txt, _ := eui.NewText(&eui.ItemData{Text: "Tab 1 content", Size: eui.Point{X: 100, Y: 32}, FontSize: 8}); txt != nil {
+	if txt, _ := eui.NewText(); txt != nil {
+		txt.Text = "Tab 1 content"
+		txt.Size = eui.Point{X: 100, Y: 32}
+		txt.FontSize = 8
 		tabFlow.Tabs[0].AddItem(txt)
 	}
-	if txt, _ := eui.NewText(&eui.ItemData{Text: "Tab 2 content", Size: eui.Point{X: 100, Y: 32}, FontSize: 8}); txt != nil {
+	if txt, _ := eui.NewText(); txt != nil {
+		txt.Text = "Tab 2 content"
+		txt.Size = eui.Point{X: 100, Y: 32}
+		txt.FontSize = 8
 		tabFlow.Tabs[1].AddItem(txt)
 	}
 

--- a/cmd/demo/theme_selector.go
+++ b/cmd/demo/theme_selector.go
@@ -15,14 +15,13 @@ func makeThemeSelector() *eui.WindowData {
 	if eui.CurrentThemeName() == "" {
 		eui.SetCurrentThemeName(names[0])
 	}
-	win := eui.NewWindow(&eui.WindowData{
-		Title:     "Themes",
-		Resizable: true,
-		Closable:  false,
-		PinTo:     eui.PIN_TOP_RIGHT,
-		AutoSize:  true,
-		Open:      true,
-	})
+	win := eui.NewWindow()
+	win.Title = "Themes"
+	win.Resizable = true
+	win.Closable = false
+	win.PinTo = eui.PIN_TOP_RIGHT
+	win.AutoSize = true
+	win.Open = true
 	mainFlow := &eui.ItemData{ItemType: eui.ITEM_FLOW, Size: win.Size, FlowType: eui.FLOW_VERTICAL}
 	win.AddItem(mainFlow)
 
@@ -32,7 +31,10 @@ func makeThemeSelector() *eui.WindowData {
 		log.Printf("listStyles error: %v", serr)
 	}
 
-	dd, ddEvents := eui.NewDropdown(&eui.ItemData{Label: "Palette", Size: eui.Point{X: 150, Y: 24}, FontSize: 8})
+	dd, ddEvents := eui.NewDropdown()
+	dd.Label = "Palette"
+	dd.Size = eui.Point{X: 150, Y: 24}
+	dd.FontSize = 8
 	dd.Options = names
 	for i, n := range names {
 		if n == eui.CurrentThemeName() {
@@ -56,7 +58,10 @@ func makeThemeSelector() *eui.WindowData {
 	mainFlow.AddItem(dd)
 
 	if len(styleNames) > 0 {
-		ldd, lddEvents := eui.NewDropdown(&eui.ItemData{Label: "Style", Size: eui.Point{X: 150, Y: 24}, FontSize: 8})
+		ldd, lddEvents := eui.NewDropdown()
+		ldd.Label = "Style"
+		ldd.Size = eui.Point{X: 150, Y: 24}
+		ldd.FontSize = 8
 		ldd.Options = styleNames
 		for i, n := range styleNames {
 			if n == eui.CurrentStyleName() {
@@ -77,7 +82,8 @@ func makeThemeSelector() *eui.WindowData {
 		mainFlow.AddItem(ldd)
 	}
 
-	cw, _ := eui.NewColorWheel(&eui.ItemData{Size: eui.Point{X: 160, Y: 128}})
+	cw, _ := eui.NewColorWheel()
+	cw.Size = eui.Point{X: 160, Y: 128}
 	cw.OnColorChange = func(col eui.Color) {
 		eui.SetAccentColor(col)
 		if satSlider != nil {
@@ -86,7 +92,12 @@ func makeThemeSelector() *eui.WindowData {
 	}
 	mainFlow.AddItem(cw)
 
-	satSlider, satEvents := eui.NewSlider(&eui.ItemData{Label: "Color Intensity", Size: eui.Point{X: 128, Y: 24}, MinValue: 0, MaxValue: 1, FontSize: 8})
+	satSlider, satEvents := eui.NewSlider()
+	satSlider.Label = "Color Intensity"
+	satSlider.Size = eui.Point{X: 128, Y: 24}
+	satSlider.MinValue = 0
+	satSlider.MaxValue = 1
+	satSlider.FontSize = 8
 	satSlider.Value = float32(eui.AccentSaturation())
 	satEvents.Handle = func(ev eui.UIEvent) {
 		if ev.Type == eui.EventSliderChanged {

--- a/cmd/settings/main.go
+++ b/cmd/settings/main.go
@@ -38,33 +38,48 @@ func main() {
 	currentScale = 1.5
 	eui.SetUIScale(currentScale)
 
-	win := eui.NewWindow(&eui.WindowData{
-		Open: true, Resizable: true,
-		Closable: true, Title: "Settings",
-		AutoSize: true, Movable: true,
-	})
+	win := eui.NewWindow()
+	win.Open = true
+	win.Resizable = true
+	win.Closable = true
+	win.Title = "Settings"
+	win.AutoSize = true
+	win.Movable = true
 
 	mainFlow := &eui.ItemData{
 		ItemType: eui.ITEM_FLOW,
 		FlowType: eui.FLOW_VERTICAL,
 	}
 
-	b1, _ := eui.NewCheckbox(&eui.ItemData{Text: "Show Item Names", Size: eui.Point{X: 150, Y: 24}})
+	b1, _ := eui.NewCheckbox()
+	b1.Text = "Show Item Names"
+	b1.Size = eui.Point{X: 150, Y: 24}
 	mainFlow.AddItem(b1)
-	b2, _ := eui.NewCheckbox(&eui.ItemData{Text: "Show Legends", Size: eui.Point{X: 150, Y: 24}})
+	b2, _ := eui.NewCheckbox()
+	b2.Text = "Show Legends"
+	b2.Size = eui.Point{X: 150, Y: 24}
 	mainFlow.AddItem(b2)
-	b3, _ := eui.NewCheckbox(&eui.ItemData{Text: "Use Item Numbers", Size: eui.Point{X: 150, Y: 24}})
+	b3, _ := eui.NewCheckbox()
+	b3.Text = "Use Item Numbers"
+	b3.Size = eui.Point{X: 150, Y: 24}
 	mainFlow.AddItem(b3)
 
 	IconFlow := &eui.ItemData{
 		ItemType: eui.ITEM_FLOW,
 		FlowType: eui.FLOW_HORIZONTAL,
 	}
-	t1, _ := eui.NewText(&eui.ItemData{Text: "Icon Size:", FontSize: 9, Size: eui.Point{X: 50, Y: 24}})
+	t1, _ := eui.NewText()
+	t1.Text = "Icon Size:"
+	t1.FontSize = 9
+	t1.Size = eui.Point{X: 50, Y: 24}
 	IconFlow.AddItem(t1)
-	t2, _ := eui.NewButton(&eui.ItemData{Text: "-", Size: eui.Point{X: 16, Y: 16}})
+	t2, _ := eui.NewButton()
+	t2.Text = "-"
+	t2.Size = eui.Point{X: 16, Y: 16}
 	IconFlow.AddItem(t2)
-	t3, _ := eui.NewButton(&eui.ItemData{Text: "+", Size: eui.Point{X: 16, Y: 16}})
+	t3, _ := eui.NewButton()
+	t3.Text = "+"
+	t3.Size = eui.Point{X: 16, Y: 16}
 	IconFlow.AddItem(t3)
 	mainFlow.AddItem(IconFlow)
 
@@ -72,31 +87,54 @@ func main() {
 		ItemType: eui.ITEM_FLOW,
 		FlowType: eui.FLOW_HORIZONTAL,
 	}
-	u1, _ := eui.NewText(&eui.ItemData{Text: "UI Scale:", FontSize: 9, Size: eui.Point{X: 50, Y: 24}})
+	u1, _ := eui.NewText()
+	u1.Text = "UI Scale:"
+	u1.FontSize = 9
+	u1.Size = eui.Point{X: 50, Y: 24}
 	ScaleFlow.AddItem(u1)
-	u2, _ := eui.NewButton(&eui.ItemData{Text: "-", Size: eui.Point{X: 16, Y: 16}})
+	u2, _ := eui.NewButton()
+	u2.Text = "-"
+	u2.Size = eui.Point{X: 16, Y: 16}
 	ScaleFlow.AddItem(u2)
-	u3, _ := eui.NewButton(&eui.ItemData{Text: "+", Size: eui.Point{X: 16, Y: 16}})
+	u3, _ := eui.NewButton()
+	u3.Text = "+"
+	u3.Size = eui.Point{X: 16, Y: 16}
 	ScaleFlow.AddItem(u3)
 	mainFlow.AddItem(ScaleFlow)
 
-	c1, _ := eui.NewCheckbox(&eui.ItemData{Text: "Textures", Size: eui.Point{X: 150, Y: 24}})
+	c1, _ := eui.NewCheckbox()
+	c1.Text = "Textures"
+	c1.Size = eui.Point{X: 150, Y: 24}
 	mainFlow.AddItem(c1)
-	c2, _ := eui.NewCheckbox(&eui.ItemData{Text: "VSync", Size: eui.Point{X: 150, Y: 24}})
+	c2, _ := eui.NewCheckbox()
+	c2.Text = "VSync"
+	c2.Size = eui.Point{X: 150, Y: 24}
 	mainFlow.AddItem(c2)
-	c3, _ := eui.NewCheckbox(&eui.ItemData{Text: "Power Saver", Size: eui.Point{X: 150, Y: 24}})
+	c3, _ := eui.NewCheckbox()
+	c3.Text = "Power Saver"
+	c3.Size = eui.Point{X: 150, Y: 24}
 	mainFlow.AddItem(c3)
-	c4, _ := eui.NewCheckbox(&eui.ItemData{Text: "Linear Filtering", Size: eui.Point{X: 150, Y: 24}})
+	c4, _ := eui.NewCheckbox()
+	c4.Text = "Linear Filtering"
+	c4.Size = eui.Point{X: 150, Y: 24}
 	mainFlow.AddItem(c4)
-	c5, _ := eui.NewCheckbox(&eui.ItemData{Text: "HiDPI", Size: eui.Point{X: 150, Y: 24}})
+	c5, _ := eui.NewCheckbox()
+	c5.Text = "HiDPI"
+	c5.Size = eui.Point{X: 150, Y: 24}
 	mainFlow.AddItem(c5)
 
 	cFPS := fmt.Sprintf("FPS: %2.2f", ebiten.ActualFPS())
-	tt1, _ := eui.NewText(&eui.ItemData{Text: cFPS, FontSize: 9, Size: eui.Point{X: 150, Y: 12}})
+	tt1, _ := eui.NewText()
+	tt1.Text = cFPS
+	tt1.FontSize = 9
+	tt1.Size = eui.Point{X: 150, Y: 12}
 	mainFlow.AddItem(tt1)
 
 	vers := fmt.Sprintf("Version: %v", "v0.0.9-012345")
-	tt2, _ := eui.NewText(&eui.ItemData{Text: vers, FontSize: 9, Size: eui.Point{X: 150, Y: 12}})
+	tt2, _ := eui.NewText()
+	tt2.Text = vers
+	tt2.FontSize = 9
+	tt2.Size = eui.Point{X: 150, Y: 12}
 	mainFlow.AddItem(tt2)
 
 	win.AddItem(mainFlow)

--- a/eui/options_pool_test.go
+++ b/eui/options_pool_test.go
@@ -89,10 +89,10 @@ func TestTextDrawOptionsPoolResets(t *testing.T) {
 	op := acquireTextDrawOptions()
 	op.DrawImageOptions.GeoM.Translate(1, 1)
 	op.DrawImageOptions.ColorScale.Scale(0.5, 0.25, 0.75, 0.5)
-	op.LayoutOptions = etext.LayoutOptions{
+	op.LayoutOptions = text.LayoutOptions{
 		LineSpacing:    1,
-		PrimaryAlign:   etext.AlignCenter,
-		SecondaryAlign: etext.AlignEnd,
+		PrimaryAlign:   text.AlignCenter,
+		SecondaryAlign: text.AlignEnd,
 	}
 	op.ColorScale.Scale(0.5, 0.5, 0.5, 0.5)
 	releaseTextDrawOptions(op)
@@ -104,7 +104,7 @@ func TestTextDrawOptionsPoolResets(t *testing.T) {
 	if op.ColorScale.R() != 1 || op.ColorScale.G() != 1 || op.ColorScale.B() != 1 || op.ColorScale.A() != 1 {
 		t.Fatalf("ColorScale not reset: %v", op.ColorScale)
 	}
-	if op.LayoutOptions != (etext.LayoutOptions{}) {
+	if op.LayoutOptions != (text.LayoutOptions{}) {
 		t.Fatalf("LayoutOptions not reset: %#v", op.LayoutOptions)
 	}
 	releaseTextDrawOptions(op)

--- a/eui/window.go
+++ b/eui/window.go
@@ -169,15 +169,12 @@ func (target *windowData) RemoveWindow() {
 }
 
 // Create a new window from the default theme
-func NewWindow(win *windowData) *windowData {
+func NewWindow() *windowData {
 	if currentTheme == nil {
 		currentTheme = baseTheme
 	}
 	newWindow := currentTheme.Window
 	stripWindowColors(&newWindow)
-	if win != nil {
-		mergeData(&newWindow, win)
-	}
 	if newWindow.Theme == nil {
 		newWindow.Theme = currentTheme
 	}
@@ -185,15 +182,12 @@ func NewWindow(win *windowData) *windowData {
 }
 
 // Create a new button from the default theme
-func NewButton(item *itemData) (*itemData, *EventHandler) {
+func NewButton() (*itemData, *EventHandler) {
 	if currentTheme == nil {
 		currentTheme = baseTheme
 	}
 	newItem := currentTheme.Button
 	stripItemColors(&newItem)
-	if item != nil {
-		mergeData(&newItem, item)
-	}
 	if newItem.Theme == nil {
 		newItem.Theme = currentTheme
 	}
@@ -204,15 +198,12 @@ func NewButton(item *itemData) (*itemData, *EventHandler) {
 }
 
 // Create a new checkbox from the default theme
-func NewCheckbox(item *itemData) (*itemData, *EventHandler) {
+func NewCheckbox() (*itemData, *EventHandler) {
 	if currentTheme == nil {
 		currentTheme = baseTheme
 	}
 	newItem := currentTheme.Checkbox
 	stripItemColors(&newItem)
-	if item != nil {
-		mergeData(&newItem, item)
-	}
 	if newItem.Theme == nil {
 		newItem.Theme = currentTheme
 	}
@@ -223,15 +214,12 @@ func NewCheckbox(item *itemData) (*itemData, *EventHandler) {
 }
 
 // Create a new radio button from the default theme
-func NewRadio(item *itemData) (*itemData, *EventHandler) {
+func NewRadio() (*itemData, *EventHandler) {
 	if currentTheme == nil {
 		currentTheme = baseTheme
 	}
 	newItem := currentTheme.Radio
 	stripItemColors(&newItem)
-	if item != nil {
-		mergeData(&newItem, item)
-	}
 	if newItem.Theme == nil {
 		newItem.Theme = currentTheme
 	}
@@ -242,15 +230,12 @@ func NewRadio(item *itemData) (*itemData, *EventHandler) {
 }
 
 // Create a new input box from the default theme
-func NewInput(item *itemData) (*itemData, *EventHandler) {
+func NewInput() (*itemData, *EventHandler) {
 	if currentTheme == nil {
 		currentTheme = baseTheme
 	}
 	newItem := currentTheme.Input
 	stripItemColors(&newItem)
-	if item != nil {
-		mergeData(&newItem, item)
-	}
 	if newItem.Theme == nil {
 		newItem.Theme = currentTheme
 	}
@@ -266,15 +251,12 @@ func NewInput(item *itemData) (*itemData, *EventHandler) {
 }
 
 // Create a new slider from the default theme
-func NewSlider(item *itemData) (*itemData, *EventHandler) {
+func NewSlider() (*itemData, *EventHandler) {
 	if currentTheme == nil {
 		currentTheme = baseTheme
 	}
 	newItem := currentTheme.Slider
 	stripItemColors(&newItem)
-	if item != nil {
-		mergeData(&newItem, item)
-	}
 	if newItem.Theme == nil {
 		newItem.Theme = currentTheme
 	}
@@ -285,15 +267,12 @@ func NewSlider(item *itemData) (*itemData, *EventHandler) {
 }
 
 // Create a new dropdown from the default theme
-func NewDropdown(item *itemData) (*itemData, *EventHandler) {
+func NewDropdown() (*itemData, *EventHandler) {
 	if currentTheme == nil {
 		currentTheme = baseTheme
 	}
 	newItem := currentTheme.Dropdown
 	stripItemColors(&newItem)
-	if item != nil {
-		mergeData(&newItem, item)
-	}
 	if newItem.Theme == nil {
 		newItem.Theme = currentTheme
 	}
@@ -304,15 +283,12 @@ func NewDropdown(item *itemData) (*itemData, *EventHandler) {
 }
 
 // Create a new color wheel from the default theme
-func NewColorWheel(item *itemData) (*itemData, *EventHandler) {
+func NewColorWheel() (*itemData, *EventHandler) {
 	if currentTheme == nil {
 		currentTheme = baseTheme
 	}
 	newItem := baseColorWheel
 	stripItemColors(&newItem)
-	if item != nil {
-		mergeData(&newItem, item)
-	}
 	if ac, ok := namedColors["accent"]; ok && newItem.WheelColor == (Color{}) {
 		newItem.WheelColor = ac
 	}
@@ -326,15 +302,12 @@ func NewColorWheel(item *itemData) (*itemData, *EventHandler) {
 }
 
 // Create a new textbox from the default theme
-func NewText(item *itemData) (*itemData, *EventHandler) {
+func NewText() (*itemData, *EventHandler) {
 	if currentTheme == nil {
 		currentTheme = baseTheme
 	}
 	newItem := currentTheme.Text
 	stripItemColors(&newItem)
-	if item != nil {
-		mergeData(&newItem, item)
-	}
 	if newItem.Theme == nil {
 		newItem.Theme = currentTheme
 	}


### PR DESCRIPTION
## Summary
- Make NewWindow/NewButton/etc parameterless to return theme defaults and simplify configuration
- Update demos and settings apps to configure widgets after creation
- Fix options pool tests and refresh API docs for new constructor signatures

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./...` *(fails: undefined DebugMode and other globals)*


------
https://chatgpt.com/codex/tasks/task_e_6898302ec5e0832abb1019c03ec51df0