### PR TITLE
Add window control helpers and fix pin-to placement

### DIFF
--- a/api.md
+++ b/api.md
@@ -420,6 +420,11 @@ func Windows() []*WindowData
     Windows returns the list of active windows.
 
 func (win *WindowData) AddItem(child *ItemData)
+func (win *WindowData) Close()
+func (win *WindowData) Destroy()
+func (win *WindowData) IsOpen() bool
+func (win *WindowData) Open()
+func (win *WindowData) Toggle()
     AddItem appends a child item to the window.
 
 ```

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -52,13 +52,9 @@ func main() {
 	currentScale = 1.5
 	eui.SetUIScale(currentScale)
 
-	showcase := makeShowcaseWindow()
-	showcase.AddWindow(false)
+	makeShowcaseWindow()
 
 	themeSel = makeThemeSelector()
-	if themeSel != nil {
-		themeSel.AddWindow(false)
-	}
 
 	statusOverlay := &eui.ItemData{
 		ItemType: eui.ITEM_FLOW,

--- a/cmd/demo/showcase.go
+++ b/cmd/demo/showcase.go
@@ -13,7 +13,7 @@ func makeShowcaseWindow() *eui.WindowData {
 	win.Size = eui.Point{X: 400, Y: 420}
 	win.Position = eui.Point{X: 8, Y: 8}
 	win.AutoSize = true
-	win.Open = true
+	win.Open()
 	win.Movable = true
 	win.Resizable = true
 	win.Closable = false

--- a/cmd/demo/theme_selector.go
+++ b/cmd/demo/theme_selector.go
@@ -21,7 +21,7 @@ func makeThemeSelector() *eui.WindowData {
 	win.Closable = false
 	win.PinTo = eui.PIN_TOP_RIGHT
 	win.AutoSize = true
-	win.Open = true
+	win.Open()
 	mainFlow := &eui.ItemData{ItemType: eui.ITEM_FLOW, Size: win.Size, FlowType: eui.FLOW_VERTICAL}
 	win.AddItem(mainFlow)
 

--- a/cmd/settings/main.go
+++ b/cmd/settings/main.go
@@ -39,7 +39,7 @@ func main() {
 	eui.SetUIScale(currentScale)
 
 	win := eui.NewWindow()
-	win.Open = true
+	win.Open()
 	win.Resizable = true
 	win.Closable = true
 	win.Title = "Settings"
@@ -138,7 +138,6 @@ func main() {
 	mainFlow.AddItem(tt2)
 
 	win.AddItem(mainFlow)
-	win.AddWindow(false)
 	go startEbiten()
 
 	<-signalHandle

--- a/eui/defaults.go
+++ b/eui/defaults.go
@@ -25,7 +25,7 @@ var defaultTheme = &windowData{
 	ShadowSize:  16,
 	ShadowColor: NewColor(0, 0, 0, 160),
 
-	Movable: true, Closable: true, Resizable: true, Open: true, AutoSize: false,
+	Movable: true, Closable: true, Resizable: true, open: true, AutoSize: false,
 	FixedRatio: false, AspectA: 0, AspectB: 0,
 }
 

--- a/eui/hidden_input_test.go
+++ b/eui/hidden_input_test.go
@@ -20,9 +20,9 @@ func TestHiddenInputCached(t *testing.T) {
 	win := *defaultTheme
 	win.Theme = baseTheme
 	win.Contents = []*itemData{&input}
-	win.Open = true
 
-	windows = []*windowData{&win}
+	windows = nil
+	win.Open()
 	screen := ebiten.NewImage(200, 200)
 
 	win.Dirty = true

--- a/eui/input.go
+++ b/eui/input.go
@@ -82,7 +82,7 @@ func Update() error {
 	// receive input first.
 	handled := false
 	handleWindow := func(win *windowData) bool {
-		if !win.Open {
+		if !win.open {
 			return false
 		}
 
@@ -114,8 +114,7 @@ func Update() error {
 
 			if click && dragPart == PART_NONE {
 				if part == PART_CLOSE {
-					win.Open = false
-					win.RemoveWindow()
+					win.Close()
 					return false
 				}
 				dragPart = part
@@ -193,7 +192,7 @@ func Update() error {
 
 	for i := len(windows) - 1; i >= 0; i-- {
 		win := windows[i]
-		if !win.Open || win.MainPortal {
+		if !win.open || win.MainPortal {
 			continue
 		}
 		if handleWindow(win) {
@@ -204,7 +203,7 @@ func Update() error {
 	if !handled {
 		for i := len(windows) - 1; i >= 0; i-- {
 			win := windows[i]
-			if !win.Open || !win.MainPortal {
+			if !win.open || !win.MainPortal {
 				continue
 			}
 			if handleWindow(win) {
@@ -268,7 +267,7 @@ func Update() error {
 	if wheelDelta.X != 0 || wheelDelta.Y != 0 {
 		for i := len(windows) - 1; i >= 0; i-- {
 			win := windows[i]
-			if !win.Open {
+			if !win.open {
 				continue
 			}
 			if win.getMainRect().containsPoint(mpos) || dropdownOpenContains(win.Contents, mpos) {
@@ -912,7 +911,7 @@ func clickOpenDropdown(items []*itemData, mpos point, click bool) bool {
 
 func dropdownOpenContainsAnywhere(mpos point) bool {
 	for _, win := range windows {
-		if win.Open && dropdownOpenContains(win.Contents, mpos) {
+		if win.open && dropdownOpenContains(win.Contents, mpos) {
 			return true
 		}
 	}
@@ -941,7 +940,7 @@ func closeDropdowns(items []*itemData) {
 
 func closeAllDropdowns() {
 	for _, win := range windows {
-		if win.Open {
+		if win.open {
 			closeDropdowns(win.Contents)
 		}
 	}
@@ -969,7 +968,7 @@ func collectInputItems(items []*itemData, list []*itemData) []*itemData {
 func gatherAllInputItems() []*itemData {
 	var list []*itemData
 	for _, win := range windows {
-		if win.Open {
+		if win.open {
 			list = collectInputItems(win.Contents, list)
 		}
 	}

--- a/eui/public.go
+++ b/eui/public.go
@@ -12,6 +12,31 @@ func Windows() []*WindowData { return windows }
 // Overlays returns the list of active overlays.
 func Overlays() []*ItemData { return overlays }
 
+// Open sets the window as open and adds it to the window list if needed.
+func (win *WindowData) Open() { win.MarkOpen() }
+
+// Close removes the window from the window list and marks it closed.
+func (win *WindowData) Close() { win.RemoveWindow() }
+
+// Destroy closes the window and releases any cached resources.
+func (win *WindowData) Destroy() {
+	win.deallocImages()
+	win.RemoveWindow()
+	win.Contents = nil
+}
+
+// Toggle opens the window if closed, or closes it if open.
+func (win *WindowData) Toggle() {
+	if win.IsOpen() {
+		win.Close()
+	} else {
+		win.Open()
+	}
+}
+
+// IsOpen reports whether the window is currently open.
+func (win *WindowData) IsOpen() bool { return win.open }
+
 // SetScreenSize sets the current screen size used for layout calculations.
 func SetScreenSize(w, h int) {
 	screenWidth = w

--- a/eui/remove_window_test.go
+++ b/eui/remove_window_test.go
@@ -5,9 +5,9 @@ package eui
 import "testing"
 
 func TestRemoveWindowUpdatesActiveWindow(t *testing.T) {
-	win0 := &windowData{Title: "win0", Open: false}
-	win1 := &windowData{Title: "win1", Open: true}
-	win2 := &windowData{Title: "win2", Open: true}
+	win0 := &windowData{Title: "win0", open: false}
+	win1 := &windowData{Title: "win1", open: true}
+	win2 := &windowData{Title: "win2", open: true}
 
 	windows = []*windowData{win0, win1, win2}
 	activeWindow = win2

--- a/eui/render.go
+++ b/eui/render.go
@@ -44,7 +44,7 @@ func Draw(screen *ebiten.Image) {
 	// Draw main portal windows first so game content can render beneath
 	// other UI elements.
 	for _, win := range windows {
-		if !win.Open || !win.MainPortal {
+		if !win.open || !win.MainPortal {
 			continue
 		}
 		if win.Dirty {
@@ -57,7 +57,7 @@ func Draw(screen *ebiten.Image) {
 
 	// Draw the remaining windows on top.
 	for _, win := range windows {
-		if !win.Open || win.MainPortal {
+		if !win.open || win.MainPortal {
 			continue
 		}
 		if win.Dirty {

--- a/eui/struct.go
+++ b/eui/struct.go
@@ -31,7 +31,8 @@ type windowData struct {
 	Fillet    float32
 	Outlined  bool
 
-	Open, Hovered, Flow,
+	open bool
+	Hovered, Flow,
 	Closable, Movable, Resizable,
 	HoverClose, HoverDragbar,
 	AutoSize, AutoSizeOnScale, FixedRatio bool

--- a/eui/title_cache_test.go
+++ b/eui/title_cache_test.go
@@ -27,7 +27,8 @@ func TestSetTitleUpdatesRender(t *testing.T) {
 	win := *defaultTheme
 	win.Theme = baseTheme
 	win.Title = "before"
-	win.Open = true
+	windows = nil
+	win.Open()
 
 	screen := ebiten.NewImage(200, 200)
 	win.Dirty = true
@@ -54,7 +55,8 @@ func TestSetTitleSizeUpdatesRender(t *testing.T) {
 	win := *defaultTheme
 	win.Theme = baseTheme
 	win.Title = "title"
-	win.Open = true
+	windows = nil
+	win.Open()
 
 	screen := ebiten.NewImage(200, 200)
 	win.Dirty = true

--- a/eui/util.go
+++ b/eui/util.go
@@ -237,25 +237,65 @@ func (win *windowData) adjustScrollForResize() {
 }
 
 func (win *windowData) clampToScreen() {
-	pos := win.getPosition()
 	size := win.GetSize()
+	m := win.Margin * uiScale
 
-	if pos.X < 0 {
-		win.Position.X -= pos.X / uiScale
-		pos.X = 0
-	}
-	if pos.Y < 0 {
-		win.Position.Y -= pos.Y / uiScale
-		pos.Y = 0
+	switch win.PinTo {
+	case PIN_TOP_LEFT, PIN_MID_LEFT, PIN_BOTTOM_LEFT:
+		off := win.GetPos().X
+		min := float32(0)
+		max := float32(screenWidth) - size.X - m
+		if off < min {
+			win.Position.X = min / uiScale
+		} else if off > max {
+			win.Position.X = max / uiScale
+		}
+	case PIN_TOP_RIGHT, PIN_MID_RIGHT, PIN_BOTTOM_RIGHT:
+		off := win.GetPos().X
+		min := -m
+		max := float32(screenWidth) - size.X - m
+		if off < min {
+			win.Position.X = min / uiScale
+		} else if off > max {
+			win.Position.X = max / uiScale
+		}
+	case PIN_TOP_CENTER, PIN_MID_CENTER, PIN_BOTTOM_CENTER:
+		off := win.GetPos().X
+		max := float32(screenWidth)/2 - size.X/2
+		if off < -max {
+			win.Position.X = -max / uiScale
+		} else if off > max {
+			win.Position.X = max / uiScale
+		}
 	}
 
-	overX := pos.X + size.X - float32(screenWidth)
-	if overX > 0 {
-		win.Position.X -= overX / uiScale
-	}
-	overY := pos.Y + size.Y - float32(screenHeight)
-	if overY > 0 {
-		win.Position.Y -= overY / uiScale
+	switch win.PinTo {
+	case PIN_TOP_LEFT, PIN_TOP_CENTER, PIN_TOP_RIGHT:
+		off := win.GetPos().Y
+		min := float32(0)
+		max := float32(screenHeight) - size.Y - m
+		if off < min {
+			win.Position.Y = min / uiScale
+		} else if off > max {
+			win.Position.Y = max / uiScale
+		}
+	case PIN_BOTTOM_LEFT, PIN_BOTTOM_CENTER, PIN_BOTTOM_RIGHT:
+		off := win.GetPos().Y
+		min := -m
+		max := float32(screenHeight) - size.Y - m
+		if off < min {
+			win.Position.Y = min / uiScale
+		} else if off > max {
+			win.Position.Y = max / uiScale
+		}
+	case PIN_MID_LEFT, PIN_MID_CENTER, PIN_MID_RIGHT:
+		off := win.GetPos().Y
+		max := float32(screenHeight)/2 - size.Y/2
+		if off < -max {
+			win.Position.Y = -max / uiScale
+		} else if off > max {
+			win.Position.Y = max / uiScale
+		}
 	}
 }
 

--- a/eui/util_test.go
+++ b/eui/util_test.go
@@ -250,12 +250,12 @@ func TestSliderTrackLengthMatch(t *testing.T) {
 }
 
 func TestMarkOpen(t *testing.T) {
-	win1 := &windowData{Title: "win1", Open: true}
-	win2 := &windowData{Title: "win2", Open: false}
+	win1 := &windowData{Title: "win1", open: true}
+	win2 := &windowData{Title: "win2", open: false}
 	windows = []*windowData{win2, win1}
 	activeWindow = win1
 	win2.MarkOpen()
-	if !win2.Open {
+	if !win2.IsOpen() {
 		t.Errorf("expected window to be open")
 	}
 	if activeWindow != win2 {
@@ -267,8 +267,8 @@ func TestMarkOpen(t *testing.T) {
 }
 
 func TestAddWindowReorders(t *testing.T) {
-	win1 := &windowData{Title: "win1", Open: true}
-	win2 := &windowData{Title: "win2", Open: true}
+	win1 := &windowData{Title: "win1", open: true}
+	win2 := &windowData{Title: "win2", open: true}
 	windows = nil
 
 	win1.AddWindow(false)

--- a/eui/window.go
+++ b/eui/window.go
@@ -130,7 +130,7 @@ func (target *windowData) AddWindow(toBack bool) {
 
 	// Closed windows shouldn't steal focus, so add them to the back by
 	// default and don't update the active window.
-	if !target.Open {
+	if !target.open {
 		toBack = true
 	}
 
@@ -151,11 +151,11 @@ func (target *windowData) RemoveWindow() {
 		if win == target { // Compare pointers
 			win.deallocImages()
 			windows = append(windows[:i], windows[i+1:]...)
-			win.Open = false
+			win.open = false
 			if activeWindow == target {
 				activeWindow = nil
 				for j := len(windows) - 1; j >= 0; j-- {
-					if windows[j].Open {
+					if windows[j].open {
 						activeWindow = windows[j]
 						break
 					}
@@ -331,7 +331,7 @@ func (target *windowData) BringForward() {
 
 // MarkOpen sets the window to open and brings it forward if necessary.
 func (target *windowData) MarkOpen() {
-	target.Open = true
+	target.open = true
 	found := false
 	for _, win := range windows {
 		if win == target {

--- a/eui/window_refresh_test.go
+++ b/eui/window_refresh_test.go
@@ -19,9 +19,9 @@ func TestWindowRefreshRerenders(t *testing.T) {
 	win := *defaultTheme
 	win.Theme = baseTheme
 	win.Contents = []*itemData{&textItem}
-	win.Open = true
 
-	windows = []*windowData{&win}
+	windows = nil
+	win.Open()
 	screen := ebiten.NewImage(200, 200)
 
 	win.Dirty = true
@@ -43,10 +43,9 @@ func TestWindowRefreshTitleUpdates(t *testing.T) {
 
 	win := *defaultTheme
 	win.Theme = baseTheme
-	win.Open = true
+	windows = nil
+	win.Open()
 	win.SetTitle("short")
-
-	windows = []*windowData{&win}
 	screen := ebiten.NewImage(200, 200)
 
 	win.Dirty = true


### PR DESCRIPTION
## Summary
- add `Open`, `Close`, `Destroy`, `Toggle`, and `IsOpen` helpers on `WindowData`
- rename window `Open` state to private field
- fix `clampToScreen` logic so pinned windows stay within view

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./eui` *(fails: undefined: AutoHiDPI, withinRange, pointMul, pointDiv)*

------
https://chatgpt.com/codex/tasks/task_e_6898411f3888832aa34dbbc7b602469f