### PR TITLE
Refactor window closing and refresh behavior

### DIFF
--- a/api.md
+++ b/api.md
@@ -420,11 +420,20 @@ func Windows() []*WindowData
     Windows returns the list of active windows.
 
 func (win *WindowData) AddItem(child *ItemData)
-func (win *WindowData) Close()
-func (win *WindowData) Destroy()
-func (win *WindowData) IsOpen() bool
-func (win *WindowData) Open()
-func (win *WindowData) Toggle()
     AddItem appends a child item to the window.
+
+func (win *WindowData) Close()
+    Close marks the window closed without removing it from the window list.
+
+func (win *WindowData) Destroy()
+
+func (win *WindowData) IsOpen() bool
+
+func (win *WindowData) Open()
+
+func (win *WindowData) Refresh()
+    Refresh marks the window dirty and recalculates layout if open.
+
+func (win *WindowData) Toggle()
 
 ```

--- a/eui/close_window_test.go
+++ b/eui/close_window_test.go
@@ -1,0 +1,64 @@
+//go:build test
+
+package eui
+
+import (
+	"testing"
+
+	"github.com/hajimehoshi/ebiten/v2"
+)
+
+func TestCloseMarksWindowNotOpen(t *testing.T) {
+	win1 := &windowData{Title: "win1", open: true}
+	win2 := &windowData{Title: "win2", open: true}
+
+	windows = []*windowData{win1, win2}
+	activeWindow = win2
+
+	win2.Close()
+
+	if win2.open {
+		t.Fatalf("expected win2 to be closed")
+	}
+	if len(windows) != 2 {
+		t.Fatalf("expected windows slice to remain, got %d", len(windows))
+	}
+	if activeWindow != win1 {
+		t.Fatalf("expected active window to be win1, got %v", activeWindow)
+	}
+}
+
+func TestRefreshClosedWindowRerendersOnOpen(t *testing.T) {
+	DebugMode = true
+	defer func() { DebugMode = false }()
+
+	textItem := *defaultText
+	textItem.Text = "before"
+	textItem.Theme = baseTheme
+
+	win := *defaultTheme
+	win.Theme = baseTheme
+	win.Contents = []*itemData{&textItem}
+
+	windows = nil
+	win.Open()
+	screen := ebiten.NewImage(200, 200)
+
+	win.Dirty = true
+	Draw(screen)
+	rc0 := textItem.RenderCount
+
+	win.Close()
+	textItem.Text = "after"
+	win.Refresh()
+	Draw(screen)
+	if textItem.RenderCount != rc0 {
+		t.Fatalf("expected render count unchanged while closed")
+	}
+
+	win.Open()
+	Draw(screen)
+	if textItem.RenderCount <= rc0 {
+		t.Fatalf("expected render count to increase after reopening")
+	}
+}

--- a/eui/public.go
+++ b/eui/public.go
@@ -15,8 +15,8 @@ func Overlays() []*ItemData { return overlays }
 // Open sets the window as open and adds it to the window list if needed.
 func (win *WindowData) Open() { win.MarkOpen() }
 
-// Close removes the window from the window list and marks it closed.
-func (win *WindowData) Close() { win.RemoveWindow() }
+// Close marks the window closed without removing it from the window list.
+func (win *WindowData) Close() { win.MarkClosed() }
 
 // Destroy closes the window and releases any cached resources.
 func (win *WindowData) Destroy() {

--- a/eui/window.go
+++ b/eui/window.go
@@ -344,6 +344,23 @@ func (target *windowData) MarkOpen() {
 	} else {
 		target.BringForward()
 	}
+	if target.Dirty {
+		target.Refresh()
+	}
+}
+
+// MarkClosed marks the window as closed and updates the active window.
+func (target *windowData) MarkClosed() {
+	target.open = false
+	if activeWindow == target {
+		activeWindow = nil
+		for j := len(windows) - 1; j >= 0; j-- {
+			if windows[j].open {
+				activeWindow = windows[j]
+				break
+			}
+		}
+	}
 }
 
 // Send a window to the back
@@ -561,6 +578,13 @@ func (win windowData) itemOverlap(size point) (bool, bool) {
 // Refresh forces the window to recalculate layout, resize to its contents,
 // and adjust scrolling after modifying contents.
 func (win *windowData) Refresh() {
+	if !win.open {
+		for _, it := range win.Contents {
+			markItemTreeDirty(it)
+		}
+		win.Dirty = true
+		return
+	}
 	win.resizeFlows()
 	if win.AutoSize {
 		win.updateAutoSize()


### PR DESCRIPTION
## Summary
- Refactor `MarkOpen` and new `MarkClosed` to track open state without removing windows
- Skip refresh work on closed windows but mark them dirty for later re-render
- Document new `Close`/`Refresh` behavior and add regression tests

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./...` *(fails: undefined DebugMode, windows, mplusFaceSource, uiScale)*

------
https://chatgpt.com/codex/tasks/task_e_68985bd21ca4832a8fac055d10360893