### PR TITLE
Default windows to start closed

### DIFF
--- a/api.md
+++ b/api.md
@@ -284,7 +284,8 @@ func Update() error
     can call this from their Ebiten Update handler.
 
 func NewWindow() *windowData
-    Create a new window from the default theme
+    Create a new window from the default theme. Windows start closed; call
+    Open to display them.
 
 
 TYPES

--- a/eui/defaults.go
+++ b/eui/defaults.go
@@ -25,7 +25,7 @@ var defaultTheme = &windowData{
 	ShadowSize:  16,
 	ShadowColor: NewColor(0, 0, 0, 160),
 
-	Movable: true, Closable: true, Resizable: true, open: true, AutoSize: false,
+	Movable: true, Closable: true, Resizable: true, open: false, AutoSize: false,
 	FixedRatio: false, AspectA: 0, AspectB: 0,
 }
 

--- a/eui/new_window_test.go
+++ b/eui/new_window_test.go
@@ -1,0 +1,16 @@
+//go:build test
+
+package eui
+
+import "testing"
+
+// TestNewWindowDefaultsClosed ensures that newly created windows start closed.
+func TestNewWindowDefaultsClosed(t *testing.T) {
+	prevTheme := currentTheme
+	currentTheme = nil
+	win := NewWindow()
+	if win.open {
+		t.Fatalf("expected new window to be closed by default")
+	}
+	currentTheme = prevTheme
+}


### PR DESCRIPTION
## Summary
- set new windows to start closed rather than open
- document and test the closed-by-default window behavior

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./...` *(fails: undefined: DebugMode)*

------
https://chatgpt.com/codex/tasks/task_e_6898602834e0832a8c8d5eeb09670a70