### PR TITLE
Replace Layout with RenderSize and drop HiDPI scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,7 @@ building a game UI. Highlights include:
 - **UI scaling** – call `eui.SetUIScale()` to adapt to any resolution or
   `eui.UIScale()` to read the current value. The scale is clamped between 0.5
   and 2.5. Windows using `AutoSize` adjust their dimensions automatically when
-  the scale changes. When HiDPI scaling is enabled the effective scale may
-  change on the first layout pass. Call `eui.UIScale()` after `eui.Layout` to
-  obtain the final value.
-- **HiDPI support** – automatically adjusts the UI scale and screen resolution
-  to match the device scale factor. Disable by setting `eui.AutoHiDPI = false`.
+  the scale changes.
 - **Image caching** – widgets cache their drawing for better performance.
   Enable `eui.DumpMode` to write the cached images to disk for inspection.
 - **Tree dump** – press <kbd>Shift</kbd>+<kbd>`</kbd> or run the demo with
@@ -98,8 +94,6 @@ The library loads the built in `AccentDark` palette, `RoundHybrid` style and a d
 // _ = eui.LoadTheme("MyTheme")
 // _ = eui.LoadStyle("MyStyle")
 ```
-HiDPI scaling is enabled by default so the UI keeps the same size on screen when switching between standard and high‑DPI displays. `eui.Layout` automatically scales the game screen to the device resolution. Set `eui.AutoHiDPI = false` to disable this behavior.
-
 See [themes/README.md](eui/themes/README.md) for a list of the bundled schemes and details on creating your own.
 
 ## Project Layout

--- a/api.md
+++ b/api.md
@@ -165,10 +165,6 @@ var (
 	// before exiting when enabled.
 	TreeMode bool
 
-	// AutoHiDPI enables automatic scaling when the device scale factor
-	// changes, keeping the UI size consistent on HiDPI displays. It is
-	// enabled by default and can be disabled if needed.
-	AutoHiDPI bool = true
 )
 var (
 
@@ -207,9 +203,9 @@ func EnsureFontSource(ttf []byte) error
 func FontSource() *text.GoTextFaceSource
     FontSource returns the current text face source.
 
-func Layout(outsideWidth, outsideHeight int) (int, int)
-    Layout reports the dimensions for the game's screen. Pass Ebiten's outside
-    size values to this from your Layout function.
+func RenderSize(outsideWidth, outsideHeight int)
+    RenderSize sets the current screen size from Ebiten's layout values. Pass
+    Ebiten's outside size values to this from your Layout function.
 
 func ListStyles() ([]string, error)
     ListStyles returns the available style theme names.
@@ -273,8 +269,6 @@ func SetScreenSize(w, h int)
     SetScreenSize sets the current screen size used for layout calculations.
 
 func SetUIScale(scale float32)
-func SyncHiDPIScale()
-    SyncHiDPIScale adjusts the UI scale when the device scale factor changes.
     It preserves the current UI scale relative to the previous factor so the
     interface keeps the same on-screen size.
 

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -135,7 +135,7 @@ func (g *demoGame) Draw(screen *ebiten.Image) {
 	eui.Draw(screen)
 }
 func (g *demoGame) Layout(outsideWidth, outsideHeight int) (int, int) {
-	eui.Layout(outsideWidth, outsideHeight)
+	eui.RenderSize(outsideWidth, outsideHeight)
 	return outsideWidth, outsideHeight
 }
 

--- a/cmd/settings/main.go
+++ b/cmd/settings/main.go
@@ -176,7 +176,8 @@ func (g *demoGame) Draw(screen *ebiten.Image) {
 }
 func (g *demoGame) Layout(outsideWidth, outsideHeight int) (int, int) {
 	//Your layout handling code here
-	return eui.Layout(outsideWidth, outsideHeight)
+	eui.RenderSize(outsideWidth, outsideHeight)
+	return outsideWidth, outsideHeight
 }
 
 func newGame() *demoGame {

--- a/eui/geometry.go
+++ b/eui/geometry.go
@@ -20,6 +20,10 @@ func (r rect) getRectangle() image.Rectangle {
 
 func pointAdd(a, b point) point { return point{X: a.X + b.X, Y: a.Y + b.Y} }
 func pointSub(a, b point) point { return point{X: a.X - b.X, Y: a.Y - b.Y} }
+func pointMul(a, b point) point { return point{X: a.X * b.X, Y: a.Y * b.Y} }
+func pointDiv(a, b point) point { return point{X: a.X / b.X, Y: a.Y / b.Y} }
+
+func withinRange(a, b, tol float64) bool { return math.Abs(a-b) <= tol }
 
 func pointScaleMul(a point) point { return point{X: a.X * uiScale, Y: a.Y * uiScale} }
 func pointScaleDiv(a point) point { return point{X: a.X / uiScale, Y: a.Y / uiScale} }

--- a/eui/glob.go
+++ b/eui/glob.go
@@ -39,12 +39,6 @@ var (
 
 	whiteImage    = ebiten.NewImage(3, 3)
 	whiteSubImage = whiteImage.SubImage(image.Rect(1, 1, 2, 2)).(*ebiten.Image)
-
-	// AutoHiDPI enables automatic scaling when the device scale factor
-	// changes, keeping the UI size consistent on HiDPI displays. It is
-	// enabled by default and can be disabled if needed.
-	AutoHiDPI       bool    = true
-	lastDeviceScale float64 = 1.0
 )
 
 func init() {
@@ -53,25 +47,10 @@ func init() {
 
 // constants moved to const.go
 
-// Layout reports the dimensions for the game's screen.
+// RenderSize sets the current screen size from Ebiten's layout values.
 // Pass Ebiten's outside size values to this from your Layout function.
-func Layout(outsideWidth, outsideHeight int) (int, int) {
-	scale := 1.0
-	if AutoHiDPI {
-		scale = ebiten.Monitor().DeviceScaleFactor()
-		if scale <= 0 {
-			scale = 1
-		}
-		if scale != lastDeviceScale {
-			SetUIScale(uiScale * float32(scale/lastDeviceScale))
-			lastDeviceScale = scale
-		}
+func RenderSize(outsideWidth, outsideHeight int) {
+	if outsideWidth != screenWidth || outsideHeight != screenHeight {
+		SetScreenSize(outsideWidth, outsideHeight)
 	}
-
-	scaledW := int(float64(outsideWidth) * scale)
-	scaledH := int(float64(outsideHeight) * scale)
-	if scaledW != screenWidth || scaledH != screenHeight {
-		SetScreenSize(scaledW, scaledH)
-	}
-	return scaledW, scaledH
 }

--- a/eui/glob_test.go
+++ b/eui/glob_test.go
@@ -37,8 +37,7 @@ var (
 	currentTheme     *Theme
 	currentThemeName string
 
-	lastDeviceScale float64 = 1.0
-	notoTTF                 = defaultTTF
+	notoTTF = defaultTTF
 
 	MinWinSizeX float32 = minWinSizeX
 	MinWinSizeY float32 = minWinSizeY

--- a/eui/pointer.go
+++ b/eui/pointer.go
@@ -30,11 +30,6 @@ func pointerPosition() (int, int) {
 	} else {
 		x, y = ebiten.CursorPosition()
 	}
-	if AutoHiDPI {
-		scale := lastDeviceScale
-		x = int(float64(x) * scale)
-		y = int(float64(y) * scale)
-	}
 	return x, y
 }
 

--- a/eui/util.go
+++ b/eui/util.go
@@ -536,20 +536,6 @@ func SetUIScale(scale float32) {
 	markAllDirty()
 }
 
-// SyncHiDPIScale adjusts the UI scale when the device scale factor changes.
-// It preserves the current UI scale relative to the previous factor so the
-// interface keeps the same on-screen size.
-func SyncHiDPIScale() {
-	ds := ebiten.Monitor().DeviceScaleFactor()
-	if ds <= 0 {
-		ds = 1
-	}
-	if ds != lastDeviceScale {
-		SetUIScale(uiScale * float32(ds/lastDeviceScale))
-		lastDeviceScale = ds
-	}
-}
-
 func UIScale() float32 { return uiScale }
 
 func (win *windowData) GetTitleSize() float32 {


### PR DESCRIPTION
## Summary
- remove automatic HiDPI scaling and rename `Layout` to `RenderSize`
- stop DPI scaling in pointer handling and add missing point helpers
- adjust demos, README, and API docs to the new window sizing API

## Testing
- `go vet ./...`
- `go build ./...`
- `xvfb-run -a go test -tags test ./eui` *(fails: LoadTheme error and panic: ebiten: width at NewImage must be positive but 0)*
- `xvfb-run -a go test -tags test ./...` *(fails: undefined: DebugMode)*

------
https://chatgpt.com/codex/tasks/task_e_6898cac748d8832a9b577ed77b6dda1e