### PR TITLE
eui: keep round-rect stroke inside bounds

### DIFF
--- a/eui/render.go
+++ b/eui/render.go
@@ -1409,8 +1409,8 @@ func drawRoundRect(screen *ebiten.Image, rrect *roundRect) {
 		inset := width / 2
 		x += inset
 		y += inset
-		w -= width
-		h -= width
+		w -= width + 1
+		h -= width + 1
 		if w < 0 {
 			w = 0
 		}


### PR DESCRIPTION
## Summary
- keep stroke inside drawRoundRect by subtracting an extra pixel from width and height when unfilled

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./...` *(fails: undefined: DebugMode, windows, overlays, mplusFaceSource, uiScale)*

------
https://chatgpt.com/codex/tasks/task_e_6898d29331c4832ab585518c07257a2a