### PR TITLE
Ensure embedded theme and style loading works on all platforms

### DIFF
--- a/eui/style.go
+++ b/eui/style.go
@@ -124,7 +124,8 @@ func LoadStyle(name string) error {
 	file := filepath.Join("themes", "styles", name+".json")
 	data, err := os.ReadFile(file)
 	if err != nil {
-		data, err = embeddedStyles.ReadFile(filepath.Join("themes", "styles", name+".json"))
+		embeddedPath := filepath.ToSlash(file)
+		data, err = embeddedStyles.ReadFile(embeddedPath)
 		if err != nil {
 			return err
 		}

--- a/eui/theme.go
+++ b/eui/theme.go
@@ -69,7 +69,8 @@ func LoadTheme(name string) error {
 	file := filepath.Join("themes", "palettes", name+".json")
 	data, err := os.ReadFile(file)
 	if err != nil {
-		data, err = embeddedThemes.ReadFile(filepath.Join("themes", "palettes", name+".json"))
+		embeddedPath := filepath.ToSlash(file)
+		data, err = embeddedThemes.ReadFile(embeddedPath)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary
- fix embedded theme loading by converting file paths to slash form
- do the same for embedded style loading

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./...` *(fails: undefined DebugMode, windows, overlays, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6898d2fa477c832ab0ac028d28695706