### PR TITLE
validate window sizes

### DIFF
--- a/api.md
+++ b/api.md
@@ -427,6 +427,8 @@ func (win *WindowData) Destroy()
 func (win *WindowData) IsOpen() bool
 
 func (win *WindowData) Open()
+    Open marks the window open and brings it forward if necessary. Windows
+    with zero or negative dimensions are ignored.
 
 func (win *WindowData) Refresh()
     Refresh marks the window dirty and recalculates layout if open.

--- a/eui/close_window_test.go
+++ b/eui/close_window_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 func TestCloseMarksWindowNotOpen(t *testing.T) {
-	win1 := &windowData{Title: "win1", open: true}
-	win2 := &windowData{Title: "win2", open: true}
+	win1 := &windowData{Title: "win1", open: true, Size: point{X: 100, Y: 100}}
+	win2 := &windowData{Title: "win2", open: true, Size: point{X: 100, Y: 100}}
 
 	windows = []*windowData{win1, win2}
 	activeWindow = win2
@@ -38,6 +38,7 @@ func TestRefreshClosedWindowRerendersOnOpen(t *testing.T) {
 
 	win := *defaultTheme
 	win.Theme = baseTheme
+	win.Size = point{X: 100, Y: 100}
 	win.Contents = []*itemData{&textItem}
 
 	windows = nil

--- a/eui/hidden_input_test.go
+++ b/eui/hidden_input_test.go
@@ -19,6 +19,7 @@ func TestHiddenInputCached(t *testing.T) {
 
 	win := *defaultTheme
 	win.Theme = baseTheme
+	win.Size = point{X: 100, Y: 100}
 	win.Contents = []*itemData{&input}
 
 	windows = nil

--- a/eui/options_pool.go
+++ b/eui/options_pool.go
@@ -33,6 +33,7 @@ var textDrawOptionsPool = sync.Pool{
 
 func acquireTextDrawOptions() *text.DrawOptions {
 	op := textDrawOptionsPool.Get().(*text.DrawOptions)
+	op.DrawImageOptions = ebiten.DrawImageOptions{}
 	op.DrawImageOptions.GeoM.Reset()
 	op.DrawImageOptions.ColorScale.Reset()
 	op.LayoutOptions = text.LayoutOptions{}

--- a/eui/title_cache_test.go
+++ b/eui/title_cache_test.go
@@ -27,6 +27,7 @@ func TestSetTitleUpdatesRender(t *testing.T) {
 	win := *defaultTheme
 	win.Theme = baseTheme
 	win.Title = "before"
+	win.Size = point{X: 100, Y: 100}
 	windows = nil
 	win.Open()
 
@@ -55,6 +56,7 @@ func TestSetTitleSizeUpdatesRender(t *testing.T) {
 	win := *defaultTheme
 	win.Theme = baseTheme
 	win.Title = "title"
+	win.Size = point{X: 100, Y: 100}
 	windows = nil
 	win.Open()
 

--- a/eui/util_test.go
+++ b/eui/util_test.go
@@ -317,8 +317,8 @@ func TestVerticalSliderTrackLengthMatch(t *testing.T) {
 }
 
 func TestMarkOpen(t *testing.T) {
-	win1 := &windowData{Title: "win1", open: true}
-	win2 := &windowData{Title: "win2", open: false}
+	win1 := &windowData{Title: "win1", open: true, Size: point{X: 100, Y: 100}}
+	win2 := &windowData{Title: "win2", open: false, Size: point{X: 100, Y: 100}}
 	windows = []*windowData{win2, win1}
 	activeWindow = win1
 	win2.MarkOpen()
@@ -334,8 +334,8 @@ func TestMarkOpen(t *testing.T) {
 }
 
 func TestAddWindowReorders(t *testing.T) {
-	win1 := &windowData{Title: "win1", open: true}
-	win2 := &windowData{Title: "win2", open: true}
+	win1 := &windowData{Title: "win1", open: true, Size: point{X: 100, Y: 100}}
+	win2 := &windowData{Title: "win2", open: true, Size: point{X: 100, Y: 100}}
 	windows = nil
 
 	win1.AddWindow(false)
@@ -352,6 +352,29 @@ func TestAddWindowReorders(t *testing.T) {
 	win1.AddWindow(true)
 	if windows[0] != win1 {
 		t.Errorf("expected win1 moved to back: %v", windows)
+	}
+}
+
+func TestAddWindowRejectsInvalidSize(t *testing.T) {
+	windows = nil
+
+	win := &windowData{Title: "bad", Size: point{X: 0, Y: 50}}
+	win.AddWindow(false)
+	if len(windows) != 0 {
+		t.Fatalf("expected window with zero width rejected, got %d", len(windows))
+	}
+
+	win.Size = point{X: 50, Y: -10}
+	win.AddWindow(false)
+	if len(windows) != 0 {
+		t.Fatalf("expected window with negative height rejected, got %d", len(windows))
+	}
+
+	var nilWin *windowData
+	// Ensure nil windows are ignored without panic
+	nilWin.AddWindow(false)
+	if len(windows) != 0 {
+		t.Fatalf("expected nil window ignored, got %d", len(windows))
 	}
 }
 func TestSetSizeClampAndScroll(t *testing.T) {

--- a/eui/window.go
+++ b/eui/window.go
@@ -101,6 +101,11 @@ func stripItemColors(it *itemData) {
 
 // Add window to window list
 func (target *windowData) AddWindow(toBack bool) {
+	if target == nil {
+		log.Println("AddWindow: target is nil")
+		return
+	}
+
 	for _, win := range windows {
 		if win == target {
 			if toBack {
@@ -120,6 +125,11 @@ func (target *windowData) AddWindow(toBack bool) {
 		target.updateAutoSize()
 		target.AutoSizeOnScale = true
 		target.AutoSize = false
+	}
+
+	if target.Size.X <= 0 || target.Size.Y <= 0 {
+		log.Printf("AddWindow: rejecting window with non-positive size: %+v", target.Size)
+		return
 	}
 
 	target.clampToScreen()
@@ -147,6 +157,11 @@ func (target *windowData) AddWindow(toBack bool) {
 // RemoveWindow removes a window from the active list. Any cached images
 // belonging to the window are disposed and pointers cleared.
 func (target *windowData) RemoveWindow() {
+	if target == nil {
+		log.Println("RemoveWindow: target is nil")
+		return
+	}
+
 	for i, win := range windows {
 		if win == target { // Compare pointers
 			win.deallocImages()

--- a/eui/window_refresh_test.go
+++ b/eui/window_refresh_test.go
@@ -18,6 +18,7 @@ func TestWindowRefreshRerenders(t *testing.T) {
 
 	win := *defaultTheme
 	win.Theme = baseTheme
+	win.Size = point{X: 100, Y: 100}
 	win.Contents = []*itemData{&textItem}
 
 	windows = nil
@@ -43,6 +44,7 @@ func TestWindowRefreshTitleUpdates(t *testing.T) {
 
 	win := *defaultTheme
 	win.Theme = baseTheme
+	win.Size = point{X: 100, Y: 100}
 	windows = nil
 	win.Open()
 	win.SetTitle("short")


### PR DESCRIPTION
## Summary
- guard against nil windows and reject windows with non-positive dimensions before adding them
- document that Open ignores windows lacking valid size
- cover size validation in tests and ensure text draw options are fully reset

## Testing
- `go vet ./...`
- `go build ./...`
- `xvfb-run go test -tags test ./eui` *(fails: ui: ReadPixels cannot be called before the game starts)*

------
https://chatgpt.com/codex/tasks/task_e_6898dbb20f40832a8be4b6bf760a0239