### PR TITLE
Mark windows dirty on resize

### DIFF
--- a/eui/public.go
+++ b/eui/public.go
@@ -55,6 +55,7 @@ func SetScreenSize(w, h int) {
 		if resized {
 			win.resizeFlows()
 			win.adjustScrollForResize()
+			win.Dirty = true
 		}
 		win.clampToScreen()
 	}

--- a/eui/util.go
+++ b/eui/util.go
@@ -133,6 +133,8 @@ func (win *windowData) dragbarRect() rect {
 }
 
 func (win *windowData) setSize(size point) bool {
+	orig := win.Size
+
 	size = win.applyAspect(size, true)
 	size, tooSmall := win.clampSize(size)
 	size = win.applyAspect(size, false)
@@ -154,6 +156,10 @@ func (win *windowData) setSize(size point) bool {
 	win.resizeFlows()
 	win.adjustScrollForResize()
 	win.clampToScreen()
+
+	if win.Size != orig {
+		win.Dirty = true
+	}
 
 	return tooSmall
 }

--- a/eui/util_test.go
+++ b/eui/util_test.go
@@ -398,6 +398,14 @@ func TestSetSizeClampAndScroll(t *testing.T) {
 	}
 }
 
+func TestResizeMarksDirty(t *testing.T) {
+	win := &windowData{Size: point{X: 100, Y: 100}}
+	win.setSize(point{X: 150, Y: 150})
+	if !win.Dirty {
+		t.Fatalf("expected window marked dirty after resize")
+	}
+}
+
 func TestFixedAspectRatio(t *testing.T) {
 	win := &windowData{Size: point{X: 100, Y: 50}, TitleHeight: 10, AspectA: 16, AspectB: 9, FixedRatio: true}
 


### PR DESCRIPTION
## Summary
- mark windows as dirty when size changes so layouts redraw
- flag windows dirty when clamped by SetScreenSize
- add regression test ensuring resize sets Dirty

## Testing
- `go vet ./...`
- `go build ./...`
- `xvfb-run go test -tags test ./eui` *(fails: ui: ReadPixels cannot be called before the game starts)*

------
https://chatgpt.com/codex/tasks/task_e_6898ed4d0e88832ab6152fbf53e3a6d7