### PR TITLE
Ensure rounded rect stroke stays inside bounds

### DIFF
--- a/eui/render.go
+++ b/eui/render.go
@@ -1451,8 +1451,8 @@ func drawRoundRect(screen *ebiten.Image, rrect *roundRect) {
 		inset := width / 2
 		x += inset
 		y += inset
-		w -= width + 1
-		h -= width + 1
+		w -= width
+		h -= width
 		if w < 0 {
 			w = 0
 		}


### PR DESCRIPTION
## Summary
- keep rounded rectangle strokes within original bounds by subtracting only the stroke width

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./...` *(fails: undefined: DebugMode)*

------
https://chatgpt.com/codex/tasks/task_e_6898f27e8cb4832a93ca724a7248d3e2