### PR TITLE
Apply theme before auto-size to ensure correct titlebar height

### DIFF
--- a/eui/window.go
+++ b/eui/window.go
@@ -121,6 +121,17 @@ func (target *windowData) AddWindow(toBack bool) {
 		target.Movable = false
 	}
 
+	var customTitleHeight float32
+	if currentTheme != nil {
+		if target.TitleHeight > 0 {
+			customTitleHeight = target.TitleHeight
+		}
+		applyThemeToWindow(target)
+		if customTitleHeight > 0 {
+			target.TitleHeight = customTitleHeight
+		}
+	}
+
 	if target.AutoSize {
 		target.updateAutoSize()
 		target.AutoSizeOnScale = true
@@ -133,10 +144,6 @@ func (target *windowData) AddWindow(toBack bool) {
 	}
 
 	target.clampToScreen()
-
-	if currentTheme != nil {
-		applyThemeToWindow(target)
-	}
 
 	// Closed windows shouldn't steal focus, so add them to the back by
 	// default and don't update the active window.


### PR DESCRIPTION
## Summary
- Apply window theme before auto-sizing and retain custom titlebar height
- Run auto-sizing only after final titlebar height is set

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./...` *(fails: undefined: DebugMode, windows, overlays, mplusFaceSource, uiScale, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6898f2c5fd80832a8e0e6c61dd360b73