### PR TITLE
Preserve window title height overrides

### DIFF
--- a/eui/struct.go
+++ b/eui/struct.go
@@ -46,7 +46,8 @@ type windowData struct {
 	Scroll   point
 	NoScroll bool
 
-	TitleHeight float32
+	TitleHeight    float32
+	TitleHeightSet bool
 
 	// cached title text metrics
 	titleRaw      string

--- a/eui/theme.go
+++ b/eui/theme.go
@@ -225,7 +225,9 @@ func copyWindowStyle(dst, src *windowData) {
 	dst.BorderPad = src.BorderPad
 	dst.Fillet = src.Fillet
 	dst.Outlined = src.Outlined
-	dst.TitleHeight = src.TitleHeight
+	if !dst.TitleHeightSet {
+		dst.TitleHeight = src.TitleHeight
+	}
 	dst.DragbarSpacing = src.DragbarSpacing
 	dst.ShowDragbar = src.ShowDragbar
 }

--- a/eui/title_size_zero_open_test.go
+++ b/eui/title_size_zero_open_test.go
@@ -1,0 +1,29 @@
+package eui
+
+import "testing"
+
+func TestSetTitleSizeZeroBeforeOpen(t *testing.T) {
+	uiScale = 1
+	screenWidth, screenHeight = 800, 600
+	windows = nil
+
+	win := NewWindow()
+	win.AutoSize = true
+	item := &itemData{ItemType: ITEM_BUTTON, Size: point{X: 100, Y: 50}}
+	win.addItemTo(item)
+
+	win.SetTitleSize(0)
+	win.Open()
+
+	if got := win.GetTitleSize(); got != 0 {
+		t.Fatalf("title size got %v want %v", got, 0)
+	}
+
+	pad := (win.Padding + win.BorderPad) * uiScale
+	wantHeight := item.GetSize().Y + 2*pad
+	if got := win.GetSize().Y; got != wantHeight {
+		t.Fatalf("window height got %v want %v", got, wantHeight)
+	}
+
+	windows = nil
+}

--- a/eui/util.go
+++ b/eui/util.go
@@ -517,6 +517,7 @@ func (win *windowData) titleTextWidth() point {
 
 func (win *windowData) SetTitleSize(size float32) {
 	win.TitleHeight = size / uiScale
+	win.TitleHeightSet = true
 	win.invalidateTitleCache()
 	win.Dirty = true
 	win.resizeFlows()


### PR DESCRIPTION
## Summary
- prevent theme application from overwriting a window's custom title height
- track when a window's title height has been manually set
- test that SetTitleSize(0) before Open hides the title bar and keeps autosizing correct

## Testing
- `go vet ./...`
- `go build ./...`
- `xvfb-run -a go test -tags test ./eui -run TestSetTitleSizeZeroBeforeOpen -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6898f2cb4208832aa403cc11687cbbc0