### PR TITLE
Add window NoTitlebar and honor custom title size

### DIFF
--- a/api.md
+++ b/api.md
@@ -430,6 +430,10 @@ func (win *WindowData) Open()
     Open marks the window open and brings it forward if necessary. Windows
     with zero or negative dimensions are ignored.
 
+func (win *WindowData) NoTitlebar()
+    NoTitlebar removes the title bar and prevents themed title sizes from
+    overriding it.
+
 func (win *WindowData) Refresh()
     Refresh marks the window dirty and recalculates layout if open.
 

--- a/eui/struct.go
+++ b/eui/struct.go
@@ -43,11 +43,13 @@ type windowData struct {
 	MainPortal bool
 
 	// Scroll position and behavior
-	Scroll   point
-	NoScroll bool
-	NoTitle  bool
+	Scroll     point
+	NoScroll   bool
+	NoTitle    bool
+	NoTitleSet bool
 
-	TitleHeight float32
+	TitleHeight    float32
+	TitleHeightSet bool
 
 	// cached title text metrics
 	titleRaw      string

--- a/eui/theme.go
+++ b/eui/theme.go
@@ -225,8 +225,12 @@ func copyWindowStyle(dst, src *windowData) {
 	dst.BorderPad = src.BorderPad
 	dst.Fillet = src.Fillet
 	dst.Outlined = src.Outlined
-	dst.NoTitle = src.NoTitle
-	dst.TitleHeight = src.TitleHeight
+	if !dst.NoTitleSet {
+		dst.NoTitle = src.NoTitle
+	}
+	if !dst.TitleHeightSet {
+		dst.TitleHeight = src.TitleHeight
+	}
 	dst.DragbarSpacing = src.DragbarSpacing
 	dst.ShowDragbar = src.ShowDragbar
 }

--- a/eui/util.go
+++ b/eui/util.go
@@ -517,6 +517,7 @@ func (win *windowData) titleTextWidth() point {
 
 func (win *windowData) SetTitleSize(size float32) {
 	win.TitleHeight = size / uiScale
+	win.TitleHeightSet = true
 	win.invalidateTitleCache()
 	win.Dirty = true
 	win.resizeFlows()
@@ -529,6 +530,17 @@ func (win *windowData) SetTitle(title string) {
 		win.Dirty = true
 		win.resizeFlows()
 	}
+}
+
+func (win *windowData) NoTitlebar() {
+	win.NoTitle = true
+	win.NoTitleSet = true
+	win.TitleHeight = 0
+	win.TitleHeightSet = true
+	win.ShowDragbar = false
+	win.invalidateTitleCache()
+	win.Dirty = true
+	win.resizeFlows()
 }
 
 func (win *windowData) invalidateTitleCache() {

--- a/eui/util_test.go
+++ b/eui/util_test.go
@@ -389,6 +389,37 @@ func TestAddWindowNoTitle(t *testing.T) {
 	}
 	currentTheme = prevTheme
 }
+
+func TestSetTitleSizeOverridesTheme(t *testing.T) {
+	windows = nil
+	prevTheme := currentTheme
+	win := &windowData{Title: "win", Size: point{X: 100, Y: 100}}
+	win.AddWindow(false)
+	win.SetTitleSize(30)
+	currentTheme = &Theme{Window: windowData{TitleHeight: 24}}
+	applyThemeToAll()
+	if win.TitleHeight != 30 {
+		t.Fatalf("expected TitleHeight 30, got %v", win.TitleHeight)
+	}
+	currentTheme = prevTheme
+}
+
+func TestNoTitlebar(t *testing.T) {
+	windows = nil
+	prevTheme := currentTheme
+	currentTheme = &Theme{Window: windowData{TitleHeight: 24}}
+	win := &windowData{Title: "win", Size: point{X: 100, Y: 100}}
+	win.AddWindow(false)
+	win.NoTitlebar()
+	if !win.NoTitle || win.TitleHeight != 0 {
+		t.Fatalf("expected no titlebar, got NoTitle=%v TitleHeight=%v", win.NoTitle, win.TitleHeight)
+	}
+	applyThemeToAll()
+	if !win.NoTitle || win.TitleHeight != 0 {
+		t.Fatalf("expected NoTitlebar override to persist, got NoTitle=%v TitleHeight=%v", win.NoTitle, win.TitleHeight)
+	}
+	currentTheme = prevTheme
+}
 func TestSetSizeClampAndScroll(t *testing.T) {
 	win := &windowData{
 		Size:        point{X: 100, Y: 100},

--- a/eui/window.go
+++ b/eui/window.go
@@ -121,22 +121,17 @@ func (target *windowData) AddWindow(toBack bool) {
 		target.Movable = false
 	}
 
-	var customTitleHeight float32
-	customNoTitle := target.NoTitle
+	if target.NoTitle {
+		target.NoTitleSet = true
+		target.TitleHeightSet = true
+		target.TitleHeight = 0
+	} else if target.TitleHeight > 0 {
+		target.TitleHeightSet = true
+	}
 	if currentTheme != nil {
-		if !customNoTitle && target.TitleHeight > 0 {
-			customTitleHeight = target.TitleHeight
-		}
 		applyThemeToWindow(target)
-		if customNoTitle {
-			target.NoTitle = true
-		}
-		if target.NoTitle {
-			target.TitleHeight = 0
-		} else if customTitleHeight > 0 {
-			target.TitleHeight = customTitleHeight
-		}
-	} else if target.NoTitle {
+	}
+	if target.NoTitle {
 		target.TitleHeight = 0
 	}
 


### PR DESCRIPTION
## Summary
- add `NoTitlebar()` to remove a window's title bar
- ensure `SetTitleSize` and `NoTitlebar` override themed sizes
- document `NoTitlebar` and add tests for custom title size and title bar removal

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./...` *(fails: undefined: DebugMode, undefined: windows)*

------
https://chatgpt.com/codex/tasks/task_e_6898fa2cb440832aa8d490f13e8f2d7d