### PR TITLE
Bring clicked window to front before item processing

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -173,9 +173,6 @@ func Update() error {
 			}
 		}
 
-		//Window items
-		win.clickWindowItems(mpos, click)
-
 		// Bring window forward on click if the cursor is over it or an
 		// expanded dropdown. Break so windows behind don't receive the
 		// event.
@@ -185,8 +182,12 @@ func Update() error {
 					win.BringForward()
 				}
 			}
+			win.clickWindowItems(mpos, click)
 			return true
 		}
+
+		// Window items
+		win.clickWindowItems(mpos, click)
 		return false
 	}
 


### PR DESCRIPTION
## Summary
- bring active window forward before processing window items to prevent behind windows from receiving click events

## Testing
- `go vet ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*
- `go build ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*
- `go test -tags test ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689958425654832a81e400610437be2c