### PR TITLE
Floor window translations to avoid rescale jitter

### DIFF
--- a/eui/geometry.go
+++ b/eui/geometry.go
@@ -22,11 +22,22 @@ func pointAdd(a, b point) point { return point{X: a.X + b.X, Y: a.Y + b.Y} }
 func pointSub(a, b point) point { return point{X: a.X - b.X, Y: a.Y - b.Y} }
 func pointMul(a, b point) point { return point{X: a.X * b.X, Y: a.Y * b.Y} }
 func pointDiv(a, b point) point { return point{X: a.X / b.X, Y: a.Y / b.Y} }
+func pointFloor(a point) point {
+	return point{X: float32(math.Floor(float64(a.X))), Y: float32(math.Floor(float64(a.Y)))}
+}
 
 func withinRange(a, b, tol float64) bool { return math.Abs(a-b) <= tol }
 
 func pointScaleMul(a point) point { return point{X: a.X * uiScale, Y: a.Y * uiScale} }
 func pointScaleDiv(a point) point { return point{X: a.X / uiScale, Y: a.Y / uiScale} }
+func rectFloor(r rect) rect {
+	return rect{
+		X0: float32(math.Floor(float64(r.X0))),
+		Y0: float32(math.Floor(float64(r.Y0))),
+		X1: float32(math.Floor(float64(r.X1))),
+		Y1: float32(math.Floor(float64(r.Y1))),
+	}
+}
 
 // unionRect expands a to encompass b and returns the result.
 func unionRect(a, b rect) rect {

--- a/eui/render.go
+++ b/eui/render.go
@@ -194,12 +194,12 @@ func (win *windowData) Draw(screen *ebiten.Image) {
 		win.drawBorder(win.Render, win.getWinRect())
 		win.drawDebug(win.Render)
 		win.Position = origPos
-		shift := pointSub(pos, localPos)
+		shift := pointFloor(pointSub(pos, localPos))
 		shiftDrawRects(win, shift)
 		win.Dirty = false
 	}
 
-	shift := pointSub(pos, localPos)
+	shift := pointFloor(pointSub(pos, localPos))
 	if win.MainPortal {
 		win.drawPortalMask(screen)
 	}
@@ -211,7 +211,7 @@ func (win *windowData) Draw(screen *ebiten.Image) {
 }
 
 func (win *windowData) drawPortalMask(screen *ebiten.Image) {
-	r := win.getWinRect()
+	r := rectFloor(win.getWinRect())
 	w := float32(screenWidth)
 	h := float32(screenHeight)
 


### PR DESCRIPTION
## Summary
- add helpers to floor point and rect values
- align window shifts and portal masks to floored coordinates

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./...` *(fails: undefined DebugMode and other missing symbols)*

------
https://chatgpt.com/codex/tasks/task_e_689957bba508832a92e36352573d7fcc