### PR TITLE
Implement standalone Sinc function

### DIFF
--- a/eui/sinc.go
+++ b/eui/sinc.go
@@ -1,0 +1,14 @@
+package eui
+
+import "math"
+
+// Sinc returns sin(πx)/(πx) with the special case
+// that Sinc(0) returns 1. This implementation avoids
+// referencing any undefined helper functions.
+func Sinc(x float64) float64 {
+	if x == 0 {
+		return 1
+	}
+	xpi := math.Pi * x
+	return math.Sin(xpi) / xpi
+}


### PR DESCRIPTION
## Summary
- add a proper Sinc implementation that doesn't reference the missing sincSums helper

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./...` *(fails: undefined: DebugMode, undefined: windows, undefined: overlays, undefined: mplusFaceSource, undefined: uiScale)*

------
https://chatgpt.com/codex/tasks/task_e_689959d17ac4832a808ee6ffe12e2022