### PR TITLE
Add window alpha scaling for transparent windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ building a game UI. Highlights include:
 - **Window management** – draggable, resizable windows with optional pinning and fixed aspect ratios.
 - **Main portal windows** – draw before other UI, black out the rest of the
   screen and leave the window background transparent for game content.
+- **Window transparency** – set `Transparent` with an `Alpha` value to draw
+  windows with partial opacity.
 - **Flow layouts** – vertical or horizontal flows for composing widgets.
 - **Overlay items** – keep controls always on screen.
 - **Palette and style themes** – JSON files define colors and spacing. Switch

--- a/api.md
+++ b/api.md
@@ -7,6 +7,7 @@ This document lists all exported functions, types and constants in the
 
 - [Setup](#setup)
 - [Pinning Windows and Items](#pinning-windows-and-items)
+- [Window Transparency](#window-transparency)
 
 ## Setup
 
@@ -37,6 +38,12 @@ Windows and items can be anchored to specific corners or edges by setting
 the `PinTo` field. When a value other than `PIN_TOP_LEFT` is used, the
 position is calculated relative to that anchor instead of the top-left
 origin.
+
+## Window Transparency
+
+Windows can render with partial opacity by setting `Transparent` to true and
+providing an `Alpha` value between 0 and 1. The off-screen image is drawn with
+this alpha multiplier when transparency is enabled.
 
 Available anchors:
 

--- a/eui/defaults.go
+++ b/eui/defaults.go
@@ -21,6 +21,8 @@ var defaultTheme = &windowData{
 	HoverColor:      NewColor(127, 127, 127, 255),
 	BGColor:         NewColor(32, 35, 38, 255),
 	ActiveColor:     NewColor(60, 173, 232, 255),
+	Transparent:     false,
+	Alpha:           1,
 
 	ShadowSize:  16,
 	ShadowColor: NewColor(0, 0, 0, 160),

--- a/eui/render.go
+++ b/eui/render.go
@@ -206,6 +206,9 @@ func (win *windowData) Draw(screen *ebiten.Image) {
 	if win.Render != nil {
 		op := ebiten.DrawImageOptions{}
 		op.GeoM.Translate(float64(shift.X), float64(shift.Y))
+		if win.Transparent {
+			op.ColorScale.Scale(1, 1, 1, win.Alpha)
+		}
 		screen.DrawImage(win.Render, &op)
 	}
 }

--- a/eui/struct.go
+++ b/eui/struct.go
@@ -42,6 +42,9 @@ type windowData struct {
 	// underlying content can show through.
 	MainPortal bool
 
+	Transparent bool
+	Alpha       float32
+
 	// Scroll position and behavior
 	Scroll     point
 	NoScroll   bool


### PR DESCRIPTION
## Summary
- add `Transparent` and `Alpha` fields to windows
- scale cached window alpha during rendering when transparency is enabled
- document window transparency controls

## Testing
- `./scripts/setup.sh`
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./...` *(fails: undefined: DebugMode)*

------
https://chatgpt.com/codex/tasks/task_e_689958c521a8832aaf06afa2f4cfc53e