### PR TITLE
Display log-scaled slider values

### DIFF
--- a/eui/render.go
+++ b/eui/render.go
@@ -1009,13 +1009,7 @@ func (item *itemData) drawItemInternal(parent *itemData, offset point, clip rect
 		// slider track remains consistent length. Use a constant max
 		// label so sliders have consistent track lengths regardless of
 		// their numeric range.
-		valueText := fmt.Sprintf("%.2f", item.Value)
 		maxLabel := sliderMaxLabel
-		if item.IntOnly {
-			width := len(maxLabel)
-			valueText = fmt.Sprintf("%*d", width, int(item.Value))
-		}
-
 		textSize := (item.FontSize * uiScale) + 2
 		face := textFace(textSize)
 		maxW, maxH := text.Measure(maxLabel, face, 0)
@@ -1025,11 +1019,12 @@ func (item *itemData) drawItemInternal(parent *itemData, offset point, clip rect
 		knobH := item.AuxSize.Y * uiScale
 
 		ratio := 0.0
+		var valueLog float64
 		if item.MaxValue > item.MinValue {
 			if item.Log && item.MinValue > 0 && item.MaxValue > 0 {
 				minLog := math.Log(float64(item.MinValue)) / math.Log(float64(item.LogValue))
 				maxLog := math.Log(float64(item.MaxValue)) / math.Log(float64(item.LogValue))
-				valueLog := math.Log(float64(item.Value)) / math.Log(float64(item.LogValue))
+				valueLog = math.Log(float64(item.Value)) / math.Log(float64(item.LogValue))
 				ratio = (valueLog - minLog) / (maxLog - minLog)
 			} else {
 				ratio = float64((item.Value - item.MinValue) / (item.MaxValue - item.MinValue))
@@ -1039,6 +1034,19 @@ func (item *itemData) drawItemInternal(parent *itemData, offset point, clip rect
 			ratio = 0
 		} else if ratio > 1 {
 			ratio = 1
+		}
+
+		valueText := fmt.Sprintf("%.2f", item.Value)
+		if item.Log && item.MinValue > 0 && item.MaxValue > 0 {
+			valueText = fmt.Sprintf("%.2f", valueLog)
+		}
+		if item.IntOnly {
+			width := len(maxLabel)
+			if item.Log && item.MinValue > 0 && item.MaxValue > 0 {
+				valueText = fmt.Sprintf("%*d", width, int(valueLog+0.5))
+			} else {
+				valueText = fmt.Sprintf("%*d", width, int(item.Value))
+			}
 		}
 
 		if item.Vertical {


### PR DESCRIPTION
## Summary
- show logarithmic value on log sliders

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./eui` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689970c62c54832a876200e78c13874c