### PR TITLE
Fix missing bottom/right window borders

### DIFF
--- a/eui/render.go
+++ b/eui/render.go
@@ -1457,8 +1457,8 @@ func drawRoundRect(screen *ebiten.Image, rrect *roundRect) {
 
 	x := float32(math.Round(float64(rrect.Position.X))) + off
 	y := float32(math.Round(float64(rrect.Position.Y))) + off
-	x1 := float32(math.Round(float64(rrect.Position.X+rrect.Size.X))) + off
-	y1 := float32(math.Round(float64(rrect.Position.Y+rrect.Size.Y))) + off
+	x1 := float32(math.Round(float64(rrect.Position.X+rrect.Size.X))) - off
+	y1 := float32(math.Round(float64(rrect.Position.Y+rrect.Size.Y))) - off
 	w := x1 - x
 	h := y1 - y
 	fillet := rrect.Fillet


### PR DESCRIPTION
## Summary
- ensure round-rect stroking subtracts pixel offset from bottom/right edges

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./...` *(fails: undefined: DebugMode, windows, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689977fedbbc832a992d1c1f0ed62107