### PR TITLE
Clamp windows on resize and enforce minimum size

### DIFF
--- a/eui/const.go
+++ b/eui/const.go
@@ -2,9 +2,9 @@ package eui
 
 const (
 	// minWinSizeX and MinWinSizeY enforce a sane minimum window size.
-	// Windows should never be smaller than 64x64 pixels.
-	minWinSizeX = 64
-	minWinSizeY = 64
+	// Windows should never be smaller than 100x100 pixels.
+	minWinSizeX = 100
+	minWinSizeY = 100
 
 	defaultTabWidth  = 128
 	defaultTabHeight = 24

--- a/eui/public.go
+++ b/eui/public.go
@@ -56,9 +56,8 @@ func SetScreenSize(w, h int) {
 			win.resizeFlows()
 			win.adjustScrollForResize()
 			win.Dirty = true
-			win.clampToScreen()
 		}
-
+		win.clampToScreen()
 	}
 }
 

--- a/eui/util_test.go
+++ b/eui/util_test.go
@@ -774,7 +774,8 @@ func TestClampToScreen(t *testing.T) {
 
 func TestSetScreenSizeClamps(t *testing.T) {
 	win := &windowData{Size: point{X: 100, Y: 50}, Position: point{X: 80, Y: 60}}
-	windows = []*windowData{win}
+	win2 := &windowData{Size: point{X: 50, Y: 50}, Position: point{X: 80, Y: 60}}
+	windows = []*windowData{win, win2}
 	oldW, oldH := screenWidth, screenHeight
 	defer func() {
 		screenWidth, screenHeight = oldW, oldH
@@ -784,6 +785,10 @@ func TestSetScreenSizeClamps(t *testing.T) {
 	pos := win.getPosition()
 	if pos.X+win.GetSize().X > float32(screenWidth) || pos.Y+win.GetSize().Y > float32(screenHeight) {
 		t.Errorf("window not clamped after SetScreenSize: %+v", pos)
+	}
+	pos2 := win2.getPosition()
+	if pos2.X+win2.GetSize().X > float32(screenWidth) || pos2.Y+win2.GetSize().Y > float32(screenHeight) {
+		t.Errorf("window not clamped after SetScreenSize: %+v", pos2)
 	}
 }
 


### PR DESCRIPTION
## Summary
- prevent windows from shrinking below 100x100
- always clamp windows to screen boundaries when Ebiten window size changes
- test window clamping when screen shrinks

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./eui` *(fails: glfw: X11: The DISPLAY environment variable is missing: a platform-specific error occurred)*

------
https://chatgpt.com/codex/tasks/task_e_68998baa1ffc832aa2263fa8cf105b18