### PR TITLE
Align item draw rects with window moves

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -120,6 +120,7 @@ func Update() error {
 				dragPart = part
 				dragWin = win
 			} else if clickDrag && dragPart != PART_NONE && dragWin == win {
+				origPos := win.Position
 				switch dragPart {
 				case PART_BAR:
 					if win.PinTo == PIN_TOP_LEFT {
@@ -169,6 +170,10 @@ func Update() error {
 					dragWindowScroll(win, mpos, false)
 				}
 				win.clampToScreen()
+				delta := pointSub(win.Position, origPos)
+				if delta.X != 0 || delta.Y != 0 {
+					shiftDrawRects(win, delta)
+				}
 				return true
 			}
 		}


### PR DESCRIPTION
## Summary
- Track original window position before processing drag logic
- Shift item DrawRects when a window moves to stay aligned

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./...` *(fails: undefined variables)*

------
https://chatgpt.com/codex/tasks/task_e_6899a0439e58832a9726ee798e0e7f2b