### PR TITLE
Use screen-scaled delta for draw rect shift on window drag

### DIFF
--- a/eui/input.go
+++ b/eui/input.go
@@ -172,7 +172,7 @@ func Update() error {
 				win.clampToScreen()
 				delta := pointSub(win.Position, origPos)
 				if delta.X != 0 || delta.Y != 0 {
-					shiftDrawRects(win, delta)
+					shiftDrawRects(win, pointScaleMul(delta))
 				}
 				return true
 			}


### PR DESCRIPTION
## Summary
- shift window draw rects using screen-space delta

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./...` *(fails: undefined: DebugMode, undefined: uiScale)*

------
https://chatgpt.com/codex/tasks/task_e_6899b0cac7d0832a9c2e5b27326e72d3