### PR TITLE
Clamp pinned windows and redraw dropdowns each frame

### DIFF
--- a/eui/util.go
+++ b/eui/util.go
@@ -240,61 +240,47 @@ func (win *windowData) clampToScreen() {
 	size := win.GetSize()
 	m := win.Margin * uiScale
 
-	switch win.PinTo {
-	case PIN_TOP_LEFT, PIN_MID_LEFT, PIN_BOTTOM_LEFT:
-		off := win.GetPos().X
-		min := float32(0)
-		max := float32(screenWidth) - size.X - m
-		if off < min {
-			win.Position.X = min / uiScale
-		} else if off > max {
-			win.Position.X = max / uiScale
+	// Clamp horizontal position based on the resolved screen coordinate.
+	pos := win.PinTo.getWinPosition(win)
+	minX := float32(0)
+	maxX := float32(screenWidth) - size.X - m
+	if pos.X < minX {
+		delta := minX - pos.X
+		switch win.PinTo {
+		case PIN_TOP_RIGHT, PIN_MID_RIGHT, PIN_BOTTOM_RIGHT:
+			win.Position.X -= delta / uiScale
+		default:
+			win.Position.X += delta / uiScale
 		}
-	case PIN_TOP_RIGHT, PIN_MID_RIGHT, PIN_BOTTOM_RIGHT:
-		off := win.GetPos().X
-		min := float32(0)
-		max := float32(screenWidth) - size.X - m
-		if off < min {
-			win.Position.X = min / uiScale
-		} else if off > max {
-			win.Position.X = max / uiScale
-		}
-	case PIN_TOP_CENTER, PIN_MID_CENTER, PIN_BOTTOM_CENTER:
-		off := win.GetPos().X
-		max := float32(screenWidth)/2 - size.X/2
-		if off < -max {
-			win.Position.X = -max / uiScale
-		} else if off > max {
-			win.Position.X = max / uiScale
+	} else if pos.X > maxX {
+		delta := pos.X - maxX
+		switch win.PinTo {
+		case PIN_TOP_RIGHT, PIN_MID_RIGHT, PIN_BOTTOM_RIGHT:
+			win.Position.X += delta / uiScale
+		default:
+			win.Position.X -= delta / uiScale
 		}
 	}
 
-	switch win.PinTo {
-	case PIN_TOP_LEFT, PIN_TOP_CENTER, PIN_TOP_RIGHT:
-		off := win.GetPos().Y
-		min := float32(0)
-		max := float32(screenHeight) - size.Y - m
-		if off < min {
-			win.Position.Y = min / uiScale
-		} else if off > max {
-			win.Position.Y = max / uiScale
+	// Clamp vertical position using the resolved screen coordinate.
+	pos = win.PinTo.getWinPosition(win)
+	minY := float32(0)
+	maxY := float32(screenHeight) - size.Y - m
+	if pos.Y < minY {
+		delta := minY - pos.Y
+		switch win.PinTo {
+		case PIN_BOTTOM_LEFT, PIN_BOTTOM_CENTER, PIN_BOTTOM_RIGHT:
+			win.Position.Y -= delta / uiScale
+		default:
+			win.Position.Y += delta / uiScale
 		}
-	case PIN_BOTTOM_LEFT, PIN_BOTTOM_CENTER, PIN_BOTTOM_RIGHT:
-		off := win.GetPos().Y
-		min := float32(0)
-		max := float32(screenHeight) - size.Y - m
-		if off < min {
-			win.Position.Y = min / uiScale
-		} else if off > max {
-			win.Position.Y = max / uiScale
-		}
-	case PIN_MID_LEFT, PIN_MID_CENTER, PIN_MID_RIGHT:
-		off := win.GetPos().Y
-		max := float32(screenHeight)/2 - size.Y/2
-		if off < -max {
-			win.Position.Y = -max / uiScale
-		} else if off > max {
-			win.Position.Y = max / uiScale
+	} else if pos.Y > maxY {
+		delta := pos.Y - maxY
+		switch win.PinTo {
+		case PIN_BOTTOM_LEFT, PIN_BOTTOM_CENTER, PIN_BOTTOM_RIGHT:
+			win.Position.Y += delta / uiScale
+		default:
+			win.Position.Y -= delta / uiScale
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Prevent pinned windows from drifting off-screen by clamping using resolved screen coordinates
- Always render dropdown menus by collecting open dropdowns after each window draw

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./...` *(fails: undefined: DebugMode)*

------
https://chatgpt.com/codex/tasks/task_e_6899b2583a90832ab341ee31bb96941b