### PR TITLE
Ensure center-pinned windows honor margins

### DIFF
--- a/eui/util.go
+++ b/eui/util.go
@@ -261,7 +261,7 @@ func (win *windowData) clampToScreen() {
 		}
 	case PIN_TOP_CENTER, PIN_MID_CENTER, PIN_BOTTOM_CENTER:
 		off := win.GetPos().X
-		max := float32(screenWidth)/2 - size.X/2
+		max := float32(screenWidth)/2 - size.X/2 - m
 		if off < -max {
 			win.Position.X = -max / uiScale
 		} else if off > max {
@@ -290,7 +290,7 @@ func (win *windowData) clampToScreen() {
 		}
 	case PIN_MID_LEFT, PIN_MID_CENTER, PIN_MID_RIGHT:
 		off := win.GetPos().Y
-		max := float32(screenHeight)/2 - size.Y/2
+		max := float32(screenHeight)/2 - size.Y/2 - m
 		if off < -max {
 			win.Position.Y = -max / uiScale
 		} else if off > max {

--- a/eui/util_test.go
+++ b/eui/util_test.go
@@ -875,3 +875,68 @@ func TestStrokeRectBorderRendering(t *testing.T) {
 		}
 	}
 }
+
+func TestClampToScreenCenterMove(t *testing.T) {
+	uiScale = 1
+	oldW, oldH := screenWidth, screenHeight
+	screenWidth, screenHeight = 200, 200
+	defer func() {
+		screenWidth, screenHeight = oldW, oldH
+		uiScale = 1
+	}()
+
+	m := float32(10)
+	win := &windowData{Size: point{X: 50, Y: 50}, PinTo: PIN_MID_CENTER, Margin: m}
+
+	win.Position = point{X: -1000, Y: 0}
+	win.clampToScreen()
+	if pos := win.getPosition(); pos.X != m {
+		t.Fatalf("left edge X=%v want %v", pos.X, m)
+	}
+
+	win.Position = point{X: 1000, Y: 0}
+	win.clampToScreen()
+	if pos := win.getPosition(); pos.X != float32(screenWidth)-win.GetSize().X-m {
+		t.Fatalf("right edge X=%v", pos.X)
+	}
+
+	win.Position = point{X: 0, Y: -1000}
+	win.clampToScreen()
+	if pos := win.getPosition(); pos.Y != m {
+		t.Fatalf("top edge Y=%v want %v", pos.Y, m)
+	}
+
+	win.Position = point{X: 0, Y: 1000}
+	win.clampToScreen()
+	if pos := win.getPosition(); pos.Y != float32(screenHeight)-win.GetSize().Y-m {
+		t.Fatalf("bottom edge Y=%v", pos.Y)
+	}
+}
+
+func TestClampToScreenCenterResize(t *testing.T) {
+	uiScale = 1
+	oldW, oldH := screenWidth, screenHeight
+	screenWidth, screenHeight = 200, 200
+	defer func() {
+		screenWidth, screenHeight = oldW, oldH
+		uiScale = 1
+	}()
+
+	m := float32(10)
+
+	win := &windowData{Size: point{X: 50, Y: 50}, PinTo: PIN_MID_CENTER, Margin: m, Position: point{X: 1000, Y: 0}}
+	win.clampToScreen()
+	win.Size = point{X: 80, Y: 50}
+	win.clampToScreen()
+	if pos := win.getPosition(); pos.X != float32(screenWidth)-win.GetSize().X-m {
+		t.Fatalf("right resize X=%v", pos.X)
+	}
+
+	win = &windowData{Size: point{X: 50, Y: 50}, PinTo: PIN_MID_CENTER, Margin: m, Position: point{X: 0, Y: 1000}}
+	win.clampToScreen()
+	win.Size = point{X: 50, Y: 80}
+	win.clampToScreen()
+	if pos := win.getPosition(); pos.Y != float32(screenHeight)-win.GetSize().Y-m {
+		t.Fatalf("bottom resize Y=%v", pos.Y)
+	}
+}


### PR DESCRIPTION
## Summary
- Respect margins when clamping center-pinned windows to the screen
- Add tests verifying center-pinned windows stay on-screen when moved or resized near edges

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./...` *(fails: undefined DebugMode and other globals)*
- `go test -tags test ./eui` *(fails: missing DISPLAY environment variable for GLFW)*

------
https://chatgpt.com/codex/tasks/task_e_6899b3877954832aa0168ff801eaea34