### PR TITLE
Clamp UI scale minimum to 1 and guard render sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ building a game UI. Highlights include:
 - **Palette and style themes** – JSON files define colors and spacing. Switch
   them at runtime or reload automatically while iterating.
 - **UI scaling** – call `eui.SetUIScale()` to adapt to any resolution or
-  `eui.UIScale()` to read the current value. The scale is clamped between 0.5
+  `eui.UIScale()` to read the current value. The scale is clamped between 1.0
   and 2.5. Windows using `AutoSize` adjust their dimensions automatically when
   the scale changes, and all windows remain within the screen bounds.
 - **Image caching** – widgets cache their drawing for better performance.

--- a/eui/render.go
+++ b/eui/render.go
@@ -174,6 +174,12 @@ func (win *windowData) Draw(screen *ebiten.Image) {
 	if win.Render == nil || win.Dirty || win.itemsDirty() {
 		size := win.GetSize()
 		w, h := int(size.X), int(size.Y)
+		if w < 1 {
+			w = 1
+		}
+		if h < 1 {
+			h = 1
+		}
 		if win.Render == nil || win.Render.Bounds().Dx() != w || win.Render.Bounds().Dy() != h {
 			if win.Render != nil {
 				win.Render.Deallocate()
@@ -1255,6 +1261,12 @@ func (item *itemData) ensureRender() {
 	}
 	size := item.GetSize()
 	w, h := int(size.X), int(size.Y)
+	if w < 1 {
+		w = 1
+	}
+	if h < 1 {
+		h = 1
+	}
 	if item.Render == nil || item.Render.Bounds().Dx() != w || item.Render.Bounds().Dy() != h {
 		item.Render = ebiten.NewImage(w, h)
 		item.Dirty = true

--- a/eui/util.go
+++ b/eui/util.go
@@ -559,8 +559,8 @@ func (win *windowData) updateTitleCache(face text.Face, size float32) {
 }
 
 func SetUIScale(scale float32) {
-	if scale < 0.5 {
-		scale = 0.5
+	if scale < 1.0 {
+		scale = 1.0
 	}
 	if scale > 2.5 {
 		scale = 2.5


### PR DESCRIPTION
## Summary
- Clamp `SetUIScale` to a minimum of 1.0 to avoid undersized scaling
- Ensure render targets in `windowData.Draw` and `itemData.ensureRender` are at least 1x1 pixels
- Document new scale range in README

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./...` *(fails: undefined variables such as DebugMode, windows)*


------
https://chatgpt.com/codex/tasks/task_e_6899b4381440832ab90584c85d99789c