### PR TITLE
Fix logarithmic slider value display

### DIFF
--- a/eui/render.go
+++ b/eui/render.go
@@ -1070,16 +1070,9 @@ func (item *itemData) drawItemInternal(parent *itemData, offset point, clip rect
 		}
 
 		valueText := fmt.Sprintf("%.2f", item.Value)
-		if item.Log && item.MinValue > 0 && item.MaxValue > 0 {
-			valueText = fmt.Sprintf("%.2f", valueLog)
-		}
 		if item.IntOnly {
 			width := len(maxLabel)
-			if item.Log && item.MinValue > 0 && item.MaxValue > 0 {
-				valueText = fmt.Sprintf("%*d", width, int(valueLog+0.5))
-			} else {
-				valueText = fmt.Sprintf("%*d", width, int(item.Value))
-			}
+			valueText = fmt.Sprintf("%*d", width, int(item.Value))
 		}
 
 		if item.Vertical {


### PR DESCRIPTION
## Summary
- ensure sliders in logarithmic mode display the actual value

## Testing
- `go vet ./...` *(fails: X11/extensions/Xrandr.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6899b4e14390832abb83cd15ce20d466