### PR TITLE
Use math.Ceil for window render size

### DIFF
--- a/eui/render.go
+++ b/eui/render.go
@@ -173,7 +173,7 @@ func (win *windowData) Draw(screen *ebiten.Image) {
 
 	if win.Render == nil || win.Dirty || win.itemsDirty() {
 		size := win.GetSize()
-		w, h := int(size.X), int(size.Y)
+		w, h := int(math.Ceil(float64(size.X))), int(math.Ceil(float64(size.Y)))
 		if win.Render == nil || win.Render.Bounds().Dx() != w || win.Render.Bounds().Dy() != h {
 			if win.Render != nil {
 				win.Render.Deallocate()


### PR DESCRIPTION
## Summary
- avoid truncating fractional window sizes by using `math.Ceil` when allocating render buffer

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./...` *(fails: undefined: DebugMode)*

------
https://chatgpt.com/codex/tasks/task_e_6899b4fbec00832aac0bc1fab56e47c4