### PR TITLE
Use ceil for render size

### DIFF
--- a/eui/render.go
+++ b/eui/render.go
@@ -1287,7 +1287,7 @@ func (item *itemData) ensureRender() {
 		return
 	}
 	size := item.GetSize()
-	w, h := int(size.X), int(size.Y)
+	w, h := int(math.Ceil(float64(size.X))), int(math.Ceil(float64(size.Y)))
 	if item.Render == nil || item.Render.Bounds().Dx() != w || item.Render.Bounds().Dy() != h {
 		item.Render = ebiten.NewImage(w, h)
 		item.Dirty = true


### PR DESCRIPTION
## Summary
- avoid truncating fractional item sizes when allocating render buffers

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./...` *(fails: undefined variables: DebugMode, windows, overlays, mplusFaceSource, uiScale)*

------
https://chatgpt.com/codex/tasks/task_e_6899b51d7ae4832aa32e45835beae3c7