### PR TITLE
feat: add center offset helper

### DIFF
--- a/api.md
+++ b/api.md
@@ -482,4 +482,8 @@ func (win *WindowData) Refresh()
 
 func (win *WindowData) Toggle()
 
+func (win *WindowData) CenterOffset(p Point) Point
+    CenterOffset subtracts half of the window size from p, returning
+    coordinates relative to the window's center.
+
 ```

--- a/eui/util.go
+++ b/eui/util.go
@@ -634,6 +634,14 @@ func (win *windowData) GetPos() point {
 	return point{X: win.Position.X * float32(screenWidth), Y: win.Position.Y * float32(screenHeight)}
 }
 
+// CenterOffset converts a point relative to the window's top-left corner
+// into coordinates using the window's center as the origin by subtracting
+// half of the window size.
+func (win *windowData) CenterOffset(p point) point {
+	sz := win.GetSize()
+	return point{X: p.X - sz.X/2, Y: p.Y - sz.Y/2}
+}
+
 func (item *itemData) labelHeight() float32 {
 	var imgH, textH float32
 	if item.LabelImage != nil {

--- a/eui/util_test.go
+++ b/eui/util_test.go
@@ -48,6 +48,18 @@ func TestPointOperations(t *testing.T) {
 	uiScale = 1
 }
 
+func TestCenterOffset(t *testing.T) {
+	screenWidth = 800
+	screenHeight = 600
+	win := &windowData{Size: normPoint(200, 100)}
+	pos := point{X: 150, Y: 80}
+	got := win.CenterOffset(pos)
+	want := point{X: pos.X - win.GetSize().X/2, Y: pos.Y - win.GetSize().Y/2}
+	if got != want {
+		t.Errorf("center offset got %+v want %+v", got, want)
+	}
+}
+
 func TestUnionRect(t *testing.T) {
 	a := rect{X0: 0, Y0: 0, X1: 10, Y1: 10}
 	b := rect{X0: 5, Y0: 5, X1: 15, Y1: 20}


### PR DESCRIPTION
## Summary
- add `CenterOffset` to compute coordinates relative to a window's center
- document new helper in API guide
- cover center offset logic with unit test

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./...` *(fails: undefined: DebugMode)*
- `go test -tags test ./eui` *(fails: glfw: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689a70c1448c832a97b823f4d68aaa93