### PR TITLE
Ensure clampToScreen converges for oversized windows

### DIFF
--- a/eui/util.go
+++ b/eui/util.go
@@ -267,6 +267,9 @@ func (win *windowData) clampToScreen() {
 		off := win.GetPos().X
 		min := float32(0)
 		max := float32(screenWidth) - size.X - m
+		if max < min {
+			max = min
+		}
 		if off < min {
 			win.Position.X = min / float32(screenWidth)
 		} else if off > max {
@@ -276,6 +279,9 @@ func (win *windowData) clampToScreen() {
 		off := win.GetPos().X
 		min := float32(0)
 		max := float32(screenWidth) - size.X - m
+		if max < min {
+			max = min
+		}
 		if off < min {
 			win.Position.X = min / float32(screenWidth)
 		} else if off > max {
@@ -284,6 +290,9 @@ func (win *windowData) clampToScreen() {
 	case PIN_TOP_CENTER, PIN_MID_CENTER, PIN_BOTTOM_CENTER:
 		off := win.GetPos().X
 		max := float32(screenWidth)/2 - size.X/2 - m
+		if max < 0 {
+			max = 0
+		}
 		if off < -max {
 			win.Position.X = -max / float32(screenWidth)
 		} else if off > max {
@@ -296,6 +305,9 @@ func (win *windowData) clampToScreen() {
 		off := win.GetPos().Y
 		min := float32(0)
 		max := float32(screenHeight) - size.Y - m
+		if max < min {
+			max = min
+		}
 		if off < min {
 			win.Position.Y = min / float32(screenHeight)
 		} else if off > max {
@@ -305,6 +317,9 @@ func (win *windowData) clampToScreen() {
 		off := win.GetPos().Y
 		min := float32(0)
 		max := float32(screenHeight) - size.Y - m
+		if max < min {
+			max = min
+		}
 		if off < min {
 			win.Position.Y = min / float32(screenHeight)
 		} else if off > max {
@@ -313,6 +328,9 @@ func (win *windowData) clampToScreen() {
 	case PIN_MID_LEFT, PIN_MID_CENTER, PIN_MID_RIGHT:
 		off := win.GetPos().Y
 		max := float32(screenHeight)/2 - size.Y/2 - m
+		if max < 0 {
+			max = 0
+		}
 		if off < -max {
 			win.Position.Y = -max / float32(screenHeight)
 		} else if off > max {

--- a/eui/util_test.go
+++ b/eui/util_test.go
@@ -952,3 +952,45 @@ func TestClampToScreenCenterResize(t *testing.T) {
 		t.Fatalf("bottom resize Y=%v", pos.Y)
 	}
 }
+
+func TestClampToScreenLargeWindow(t *testing.T) {
+	oldW, oldH := screenWidth, screenHeight
+	screenWidth, screenHeight = 100, 100
+	defer func() {
+		screenWidth, screenHeight = oldW, oldH
+	}()
+
+	win := &windowData{Size: normPoint(200, 200), Position: normPoint(0, 0)}
+	win.clampToScreen()
+	pos := win.Position
+	if pos != normPoint(0, 0) {
+		t.Fatalf("first clamp pos=%v", pos)
+	}
+	for i := 0; i < 5; i++ {
+		win.clampToScreen()
+		if win.Position != pos {
+			t.Fatalf("position changed at iter %d: %v -> %v", i, pos, win.Position)
+		}
+	}
+}
+
+func TestClampToScreenLargeWindowCenter(t *testing.T) {
+	oldW, oldH := screenWidth, screenHeight
+	screenWidth, screenHeight = 100, 100
+	defer func() {
+		screenWidth, screenHeight = oldW, oldH
+	}()
+
+	win := &windowData{Size: normPoint(200, 200), PinTo: PIN_MID_CENTER, Position: normPoint(0, 0)}
+	win.clampToScreen()
+	pos := win.Position
+	if pos != normPoint(0, 0) {
+		t.Fatalf("first clamp pos=%v", pos)
+	}
+	for i := 0; i < 5; i++ {
+		win.clampToScreen()
+		if win.Position != pos {
+			t.Fatalf("position changed at iter %d: %v -> %v", i, pos, win.Position)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- prevent clampToScreen from oscillating when window exceeds screen size
- add tests verifying clampToScreen stabilizes for oversized windows pinned left or centered

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./...` *(fails: undefined: DebugMode)*

------
https://chatgpt.com/codex/tasks/task_e_689a8025c4a8832aac0486dae6f7e766