### PR TITLE
Normalize window coordinates

### DIFF
--- a/cmd/demo/showcase.go
+++ b/cmd/demo/showcase.go
@@ -10,7 +10,7 @@ import (
 func makeShowcaseWindow() *eui.WindowData {
 	win := eui.NewWindow()
 	win.Title = "Showcase"
-	win.Position = eui.Point{X: 8, Y: 8}
+	win.Position = eui.ScreenToNorm(eui.Point{X: 8, Y: 8})
 	win.AutoSize = true
 	win.Movable = true
 	win.Resizable = true

--- a/eui/hidden_input_test.go
+++ b/eui/hidden_input_test.go
@@ -19,7 +19,7 @@ func TestHiddenInputCached(t *testing.T) {
 
 	win := *defaultTheme
 	win.Theme = baseTheme
-	win.Size = point{X: 100, Y: 100}
+	win.Size = normPoint(100, 100)
 	win.Contents = []*itemData{&input}
 
 	windows = nil

--- a/eui/title_cache_test.go
+++ b/eui/title_cache_test.go
@@ -27,7 +27,7 @@ func TestSetTitleUpdatesRender(t *testing.T) {
 	win := *defaultTheme
 	win.Theme = baseTheme
 	win.Title = "before"
-	win.Size = point{X: 100, Y: 100}
+	win.Size = normPoint(100, 100)
 	windows = nil
 	win.Open()
 
@@ -56,7 +56,7 @@ func TestSetTitleSizeUpdatesRender(t *testing.T) {
 	win := *defaultTheme
 	win.Theme = baseTheme
 	win.Title = "title"
-	win.Size = point{X: 100, Y: 100}
+	win.Size = normPoint(100, 100)
 	windows = nil
 	win.Open()
 

--- a/eui/util_test.go
+++ b/eui/util_test.go
@@ -418,7 +418,7 @@ func TestAddWindowRejectsInvalidSize(t *testing.T) {
 		t.Fatalf("expected window with zero width rejected, got %d", len(windows))
 	}
 
-	win.Size = point{X: 50, Y: -10}
+	win.Size = normPoint(50, -10)
 	win.AddWindow(false)
 	if len(windows) != 0 {
 		t.Fatalf("expected window with negative height rejected, got %d", len(windows))
@@ -900,25 +900,25 @@ func TestClampToScreenCenterMove(t *testing.T) {
 	m := float32(10)
 	win := &windowData{Size: normPoint(50, 50), PinTo: PIN_MID_CENTER, Margin: m}
 
-	win.Position = point{X: -1000, Y: 0}
+	win.Position = normPoint(-1000, 0)
 	win.clampToScreen()
 	if pos := win.getPosition(); pos.X != m {
 		t.Fatalf("left edge X=%v want %v", pos.X, m)
 	}
 
-	win.Position = point{X: 1000, Y: 0}
+	win.Position = normPoint(1000, 0)
 	win.clampToScreen()
 	if pos := win.getPosition(); pos.X != float32(screenWidth)-win.GetSize().X-m {
 		t.Fatalf("right edge X=%v", pos.X)
 	}
 
-	win.Position = point{X: 0, Y: -1000}
+	win.Position = normPoint(0, -1000)
 	win.clampToScreen()
 	if pos := win.getPosition(); pos.Y != m {
 		t.Fatalf("top edge Y=%v want %v", pos.Y, m)
 	}
 
-	win.Position = point{X: 0, Y: 1000}
+	win.Position = normPoint(0, 1000)
 	win.clampToScreen()
 	if pos := win.getPosition(); pos.Y != float32(screenHeight)-win.GetSize().Y-m {
 		t.Fatalf("bottom edge Y=%v", pos.Y)


### PR DESCRIPTION
## Summary
- use normalized screen coordinates for demo window position
- normalize window size and position values in tests

## Testing
- `go vet ./...`
- `go build ./...`
- `xvfb-run -a go test -tags test ./...` *(fails: undefined: DebugMode, windows, overlays)*
- `xvfb-run -a go test -tags test ./eui` *(fails: LoadTheme error and ReadPixels before game start)*

------
https://chatgpt.com/codex/tasks/task_e_689a896eaa3c832a86736d2e331055c3