### PR TITLE
Normalize CenterOffset to return normalized offset

### DIFF
--- a/api.md
+++ b/api.md
@@ -485,6 +485,7 @@ func (win *WindowData) Toggle()
 
 func (win *WindowData) CenterOffset(p Point) Point
     CenterOffset subtracts half of the window size from p, returning
-    coordinates relative to the window's center.
+    coordinates relative to the window's center. Both the input point and
+    the returned offset use normalized screen coordinates.
 
 ```

--- a/eui/util.go
+++ b/eui/util.go
@@ -652,11 +652,11 @@ func (win *windowData) GetPos() point {
 	return point{X: win.Position.X * float32(screenWidth), Y: win.Position.Y * float32(screenHeight)}
 }
 
-// CenterOffset converts a point relative to the window's top-left corner
-// into coordinates using the window's center as the origin by subtracting
-// half of the window size.
+// CenterOffset converts a normalized point relative to the window's top-left
+// corner into coordinates using the window's center as the origin by
+// subtracting half of the window size. The returned offset is also normalized.
 func (win *windowData) CenterOffset(p point) point {
-	sz := win.GetSize()
+	sz := win.Size
 	return point{X: p.X - sz.X/2, Y: p.Y - sz.Y/2}
 }
 

--- a/eui/util_test.go
+++ b/eui/util_test.go
@@ -52,9 +52,9 @@ func TestCenterOffset(t *testing.T) {
 	screenWidth = 800
 	screenHeight = 600
 	win := &windowData{Size: normPoint(200, 100)}
-	pos := point{X: 150, Y: 80}
+	pos := normPoint(150, 80)
 	got := win.CenterOffset(pos)
-	want := point{X: pos.X - win.GetSize().X/2, Y: pos.Y - win.GetSize().Y/2}
+	want := point{X: pos.X - win.Size.X/2, Y: pos.Y - win.Size.Y/2}
 	if got != want {
 		t.Errorf("center offset got %+v want %+v", got, want)
 	}


### PR DESCRIPTION
## Summary
- ensure `CenterOffset` uses the window's normalized `Size` so the returned offset stays normalized
- adjust unit test to provide and expect normalized coordinates
- document that `CenterOffset` operates on normalized screen coordinates

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./...` *(fails: undefined: DebugMode)*

------
https://chatgpt.com/codex/tasks/task_e_689a8d08d31c832a998e5570defe0b81