### PR TITLE
Normalize minimum window size handling

### DIFF
--- a/eui/const.go
+++ b/eui/const.go
@@ -1,10 +1,10 @@
 package eui
 
 const (
-	// minWinSizeX and MinWinSizeY enforce a sane minimum window size.
-	// Windows should never be smaller than 100x100 pixels.
-	minWinSizeX = 100
-	minWinSizeY = 100
+	// minWinSizeX and minWinSizeY enforce a sane minimum window size.
+	// Values are normalized (0-1) fractions of the screen dimensions.
+	minWinSizeX float32 = 0.1
+	minWinSizeY float32 = 0.1
 
 	defaultTabWidth  = 128
 	defaultTabHeight = 24

--- a/eui/glob_test.go
+++ b/eui/glob_test.go
@@ -38,9 +38,6 @@ var (
 	currentThemeName string
 
 	notoTTF = defaultTTF
-
-	MinWinSizeX float32 = float32(minWinSizeX) / float32(screenWidth)
-	MinWinSizeY float32 = float32(minWinSizeY) / float32(screenHeight)
 )
 
 func init() {

--- a/eui/util.go
+++ b/eui/util.go
@@ -179,8 +179,8 @@ func (win *windowData) setSize(size point) bool {
 func (win *windowData) clampSize(size point) (point, bool) {
 	tooSmall := false
 
-	minX := float32(minWinSizeX) / float32(screenWidth)
-	minY := float32(minWinSizeY) / float32(screenHeight)
+	minX := minWinSizeX
+	minY := minWinSizeY
 	if win.MinSize.X > minX {
 		minX = win.MinSize.X
 	}
@@ -631,8 +631,8 @@ func (win *windowData) GetTitleSize() float32 {
 func (win *windowData) GetSize() point {
 	sx := win.Size.X
 	sy := win.Size.Y
-	minX := float32(minWinSizeX) / float32(screenWidth)
-	minY := float32(minWinSizeY) / float32(screenHeight)
+	minX := minWinSizeX
+	minY := minWinSizeY
 	if win.MinSize.X > minX {
 		minX = win.MinSize.X
 	}

--- a/eui/util_test.go
+++ b/eui/util_test.go
@@ -485,7 +485,7 @@ func TestSetSizeClampAndScroll(t *testing.T) {
 	// content smaller than window
 	win.Contents = []*itemData{{Size: point{X: 50, Y: 50}}}
 	win.setSize(point{-10, -10})
-	if win.Size.X < MinWinSizeX || win.Size.Y < MinWinSizeY {
+	if win.Size.X < minWinSizeX || win.Size.Y < minWinSizeY {
 		t.Errorf("size not clamped: %+v", win.Size)
 	}
 	// enlarge window so scroll should reset


### PR DESCRIPTION
## Summary
- use normalized values for minimum window dimensions
- simplify window size clamping to work with normalized constants
- update tests to rely on normalized minimum size

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./...` *(fails: undefined: DebugMode)*

------
https://chatgpt.com/codex/tasks/task_e_689ab136cfe0832a9126f171abf3cd3c