### PR TITLE
Normalize window resize tolerances

### DIFF
--- a/eui/const.go
+++ b/eui/const.go
@@ -10,11 +10,13 @@ const (
 	defaultTabHeight = 24
 
 	// scrollTolerance defines the padding around window edges used to detect
-	// resize drags along the sides.
-	scrollTolerance = 2
+	// resize drags along the sides, expressed as a fraction of the screen
+	// dimension.
+	scrollTolerance float32 = 2.0 / 1024.0
 	// cornerTolerance defines the larger area around window corners used to
-	// detect diagonal resizing.
-	cornerTolerance = 16
+	// detect diagonal resizing, expressed as a fraction of the screen
+	// dimension.
+	cornerTolerance float32 = 16.0 / 1024.0
 
 	// sliderMaxLabel defines the formatted text used to measure the value
 	// field of sliders. Using a constant ensures int and float sliders have

--- a/eui/util.go
+++ b/eui/util.go
@@ -440,33 +440,35 @@ func (win *windowData) getResizePart(mpos point) dragType {
 		return PART_NONE
 	}
 
-	t := scrollTolerance * uiScale
-	ct := cornerTolerance * uiScale
+	tX := scrollTolerance * float32(screenWidth) * uiScale
+	tY := scrollTolerance * float32(screenHeight) * uiScale
+	ctX := cornerTolerance * float32(screenWidth) * uiScale
+	ctY := cornerTolerance * float32(screenHeight) * uiScale
 	winRect := win.getWinRect()
 	// Check enlarged corner areas first
-	if mpos.X >= winRect.X0-ct && mpos.X <= winRect.X0+ct && mpos.Y >= winRect.Y0-ct && mpos.Y <= winRect.Y0+ct {
+	if mpos.X >= winRect.X0-ctX && mpos.X <= winRect.X0+ctX && mpos.Y >= winRect.Y0-ctY && mpos.Y <= winRect.Y0+ctY {
 		return PART_TOP_LEFT
 	}
-	if mpos.X >= winRect.X1-ct && mpos.X <= winRect.X1+ct && mpos.Y >= winRect.Y0-ct && mpos.Y <= winRect.Y0+ct {
+	if mpos.X >= winRect.X1-ctX && mpos.X <= winRect.X1+ctX && mpos.Y >= winRect.Y0-ctY && mpos.Y <= winRect.Y0+ctY {
 		return PART_TOP_RIGHT
 	}
-	if mpos.X >= winRect.X0-ct && mpos.X <= winRect.X0+ct && mpos.Y >= winRect.Y1-ct && mpos.Y <= winRect.Y1+ct {
+	if mpos.X >= winRect.X0-ctX && mpos.X <= winRect.X0+ctX && mpos.Y >= winRect.Y1-ctY && mpos.Y <= winRect.Y1+ctY {
 		return PART_BOTTOM_LEFT
 	}
-	if mpos.X >= winRect.X1-ct && mpos.X <= winRect.X1+ct && mpos.Y >= winRect.Y1-ct && mpos.Y <= winRect.Y1+ct {
+	if mpos.X >= winRect.X1-ctX && mpos.X <= winRect.X1+ctX && mpos.Y >= winRect.Y1-ctY && mpos.Y <= winRect.Y1+ctY {
 		return PART_BOTTOM_RIGHT
 	}
 	outRect := winRect
-	outRect.X0 -= t
-	outRect.X1 += t
-	outRect.Y0 -= t
-	outRect.Y1 += t
+	outRect.X0 -= tX
+	outRect.X1 += tX
+	outRect.Y0 -= tY
+	outRect.Y1 += tY
 
 	inRect := winRect
-	inRect.X0 += t
-	inRect.X1 -= t
-	inRect.Y0 += t
-	inRect.Y1 -= t
+	inRect.X0 += tX
+	inRect.X1 -= tX
+	inRect.Y0 += tY
+	inRect.Y1 -= tY
 
 	if outRect.containsPoint(mpos) && !inRect.containsPoint(mpos) {
 		top := mpos.Y < inRect.Y0


### PR DESCRIPTION
## Summary
- express resize tolerances as fractions of the screen dimensions
- convert normalized tolerances to pixels in `getResizePart`

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./eui` *(fails: GLFW library is not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_689ab1353330832aa03dc6efbace8fe4