### PR TITLE
Add point arithmetic helpers

### DIFF
--- a/api.md
+++ b/api.md
@@ -376,6 +376,12 @@ type PinType = pinType
 
 type Point = point
 
+func PointAdd(a, b Point) Point
+    PointAdd returns the vector sum of a and b.
+
+func PointSub(a, b Point) Point
+    PointSub returns the vector difference of b from a.
+
 type Rect = rect
 
 type RoundRect = roundRect

--- a/eui/geometry.go
+++ b/eui/geometry.go
@@ -22,6 +22,13 @@ func pointAdd(a, b point) point { return point{X: a.X + b.X, Y: a.Y + b.Y} }
 func pointSub(a, b point) point { return point{X: a.X - b.X, Y: a.Y - b.Y} }
 func pointMul(a, b point) point { return point{X: a.X * b.X, Y: a.Y * b.Y} }
 func pointDiv(a, b point) point { return point{X: a.X / b.X, Y: a.Y / b.Y} }
+
+// PointAdd returns the vector sum of a and b.
+func PointAdd(a, b Point) Point { return pointAdd(a, b) }
+
+// PointSub returns the vector difference of b from a.
+func PointSub(a, b Point) Point { return pointSub(a, b) }
+
 func pointFloor(a point) point {
 	return point{X: float32(math.Floor(float64(a.X))), Y: float32(math.Floor(float64(a.Y)))}
 }

--- a/eui/util_test.go
+++ b/eui/util_test.go
@@ -24,13 +24,13 @@ func TestWithinRange(t *testing.T) {
 }
 
 func TestPointOperations(t *testing.T) {
-	a := point{X: 1, Y: 2}
-	b := point{X: 3, Y: 4}
-	if r := pointAdd(a, b); r.X != 4 || r.Y != 6 {
-		t.Errorf("pointAdd result %+v", r)
+	a := Point{X: 1, Y: 2}
+	b := Point{X: 3, Y: 4}
+	if r := PointAdd(a, b); r.X != 4 || r.Y != 6 {
+		t.Errorf("PointAdd result %+v", r)
 	}
-	if r := pointSub(b, a); r.X != 2 || r.Y != 2 {
-		t.Errorf("pointSub result %+v", r)
+	if r := PointSub(b, a); r.X != 2 || r.Y != 2 {
+		t.Errorf("PointSub result %+v", r)
 	}
 	if r := pointMul(a, b); r.X != 3 || r.Y != 8 {
 		t.Errorf("pointMul result %+v", r)
@@ -42,7 +42,7 @@ func TestPointOperations(t *testing.T) {
 	if r := pointScaleMul(a); r.X != 2 || r.Y != 4 {
 		t.Errorf("pointScaleMul result %+v", r)
 	}
-	if r := pointScaleDiv(point{X: 4, Y: 6}); r.X != 2 || r.Y != 3 {
+	if r := pointScaleDiv(Point{X: 4, Y: 6}); r.X != 2 || r.Y != 3 {
 		t.Errorf("pointScaleDiv result %+v", r)
 	}
 	uiScale = 1


### PR DESCRIPTION
## Summary
- export `PointAdd` and `PointSub` for `eui.Point`
- document and test the new point helpers

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./...` *(fails: undefined: DebugMode)*

------
https://chatgpt.com/codex/tasks/task_e_689ad49a08b0832aa280825423acd563