### PR TITLE
docs: document normalized coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,32 @@ building a game UI. Highlights include:
 - **Logarithmic sliders** – sliders can map values on a logarithmic scale.
 - **Hidden inputs** – text fields can mask their contents and reveal them while the eye icon is pressed.
 - **Tooltips** – optional text hints appear when hovering over any item except flows.
+- **Normalized coordinates** – specify window and item positions and sizes using
+  normalized values in the range 0–1. Helper functions like `ScreenToNorm` and
+  `NormToScreen` convert to and from pixel units.
+
+
+## Coordinate System
+
+EUI expresses all positions and sizes as values between 0 and 1 relative to the
+current screen dimensions. Convert pixel measurements before assigning them to
+windows or items:
+
+```go
+size := eui.ScreenToNorm(eui.Point{X: 200, Y: 100})
+pos  := eui.ScreenToNorm(eui.Point{X: 50, Y: 50})
+win := &eui.WindowData{
+    Title:    "Stats",
+    Position: pos,
+    Size:     size,
+}
+```
+
+To obtain pixel values from normalized coordinates use `NormToScreen`:
+
+```go
+px := eui.NormToScreen(win.GetSize())
+```
 
 
 ## Running the Demo

--- a/api.md
+++ b/api.md
@@ -6,6 +6,7 @@ This document lists all exported functions, types and constants in the
 ## Table of Contents
 
 - [Setup](#setup)
+- [Coordinate System](#coordinate-system)
 - [Pinning Windows and Items](#pinning-windows-and-items)
 - [Window Transparency](#window-transparency)
 
@@ -30,6 +31,29 @@ Format modified Go files before committing:
 
 ```sh
 gofmt -w <files>
+```
+
+
+## Coordinate System
+
+EUI uses normalized coordinates for all positions and sizes. Values must be in
+the range 0–1 relative to the current screen dimensions. Convert pixel values
+before assigning them to windows or items:
+
+```go
+size := eui.ScreenToNorm(eui.Point{X: 200, Y: 100})
+pos  := eui.ScreenToNorm(eui.Point{X: 50, Y: 50})
+win := &eui.WindowData{
+    Title:    "Stats",
+    Position: pos,
+    Size:     size,
+}
+```
+
+To convert normalized values back to pixels use `NormToScreen`:
+
+```go
+px := eui.NormToScreen(win.GetSize())
 ```
 
 
@@ -61,9 +85,10 @@ Available anchors:
 Example anchoring a window to the bottom-right of the screen:
 
 ```go
+size := eui.ScreenToNorm(eui.Point{X: 200, Y: 100})
 win := &eui.WindowData{
     Title: "Stats",
-    Size:  eui.Point{X: 200, Y: 100},
+    Size:  size,
     PinTo: eui.PIN_BOTTOM_RIGHT,
 }
 


### PR DESCRIPTION
## Summary
- clarify that window and item sizes/positions use normalized 0–1 coordinates
- show how to convert pixels with `ScreenToNorm` and `NormToScreen`

## Testing
- `go fmt ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_689ad3a230b8832a94a660a175086660