### PR TITLE
Clamp out-of-range window sizes

### DIFF
--- a/eui/util.go
+++ b/eui/util.go
@@ -2,6 +2,7 @@ package eui
 
 import (
 	"image/color"
+	"log"
 	"math"
 	"strings"
 
@@ -647,6 +648,16 @@ func (win *windowData) GetSize() point {
 	if sy < minY {
 		sy = minY
 	}
+
+	if sx > 1.0 {
+		log.Printf("GetSize: window width %f out of range, clamping to 1.0", sx)
+		sx = 1.0
+	}
+	if sy > 1.0 {
+		log.Printf("GetSize: window height %f out of range, clamping to 1.0", sy)
+		sy = 1.0
+	}
+
 	return point{X: sx * float32(screenWidth), Y: sy * float32(screenHeight)}
 }
 

--- a/eui/util_test.go
+++ b/eui/util_test.go
@@ -6,7 +6,9 @@ import (
 	"bytes"
 	"image"
 	"image/color"
+	"log"
 	"math"
+	"strings"
 	"testing"
 
 	"github.com/hajimehoshi/ebiten/v2"
@@ -57,6 +59,26 @@ func TestCenterOffset(t *testing.T) {
 	want := point{X: pos.X - win.Size.X/2, Y: pos.Y - win.Size.Y/2}
 	if got != want {
 		t.Errorf("center offset got %+v want %+v", got, want)
+	}
+}
+
+func TestGetSizeClampsAndLogs(t *testing.T) {
+	screenWidth = 800
+	screenHeight = 600
+	win := &windowData{Size: point{X: 2, Y: 2}}
+
+	var buf bytes.Buffer
+	orig := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(orig)
+
+	got := win.GetSize()
+	want := point{X: float32(screenWidth), Y: float32(screenHeight)}
+	if got != want {
+		t.Fatalf("GetSize clamp got %+v want %+v", got, want)
+	}
+	if !strings.Contains(buf.String(), "clamping") {
+		t.Fatalf("expected log warning, got %q", buf.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- prevent oversized window allocations by clamping window size to normalized bounds
- log warnings when window size exceeds 1.0
- test window size clamping and warning logs

## Testing
- `go vet ./... && echo vet-ok`
- `go build ./... && echo build-ok`
- `go test -tags test ./eui` *(fails: glfw: X11: The DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689ad3a048a4832a9f3cabce6097b11e