### PR TITLE
Maintain clamped window coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ building a game UI. Highlights include:
   `eui.UIScale()` to read the current value. The scale is clamped between 1.0
   and 2.5. Windows using `AutoSize` adjust their dimensions automatically when
   the scale changes, and all windows remain within the screen bounds.
+- **Clamped coordinates** – windows keep their requested `Position` and `Size`
+  while drawing and hit-testing use clamped values available via `GetPos` and
+  `GetSize`.
 - **Image caching** – widgets cache their drawing for better performance.
   Enable `eui.DumpMode` to write the cached images to disk for inspection.
 - **Tree dump** – press <kbd>Shift</kbd>+<kbd>`</kbd> or run the demo with

--- a/api.md
+++ b/api.md
@@ -6,6 +6,7 @@ This document lists all exported functions, types and constants in the
 ## Table of Contents
 
 - [Setup](#setup)
+- [Coordinates](#coordinates)
 - [Pinning Windows and Items](#pinning-windows-and-items)
 - [Window Transparency](#window-transparency)
 
@@ -31,6 +32,12 @@ Format modified Go files before committing:
 gofmt -w <files>
 ```
 
+
+## Coordinates
+
+Windows keep their requested `Position` and `Size` values. Clamped
+coordinates used for drawing and hit-testing are stored separately and
+returned by `GetPos` and `GetSize`.
 
 ## Pinning Windows and Items
 

--- a/eui/input.go
+++ b/eui/input.go
@@ -120,7 +120,7 @@ func Update() error {
 				dragPart = part
 				dragWin = win
 			} else if clickDrag && dragPart != PART_NONE && dragWin == win {
-				origPos := win.Position
+				origPos := win.renderPos
 				switch dragPart {
 				case PART_BAR:
 					if win.PinTo == PIN_TOP_LEFT {
@@ -170,7 +170,7 @@ func Update() error {
 					dragWindowScroll(win, mpos, false)
 				}
 				win.clampToScreen()
-				delta := pointSub(win.Position, origPos)
+				delta := pointSub(win.renderPos, origPos)
 				if delta.X != 0 || delta.Y != 0 {
 					shiftDrawRects(win, pointScaleMul(delta))
 				}

--- a/eui/public.go
+++ b/eui/public.go
@@ -53,6 +53,7 @@ func SetScreenSize(w, h int) {
 			resized = true
 		}
 		if resized {
+			win.renderSize = win.Size
 			win.resizeFlows()
 			win.adjustScrollForResize()
 			win.Dirty = true

--- a/eui/render.go
+++ b/eui/render.go
@@ -183,7 +183,9 @@ func (win *windowData) Draw(screen *ebiten.Image) {
 			win.Render.Clear()
 		}
 		origPos := win.Position
+		origRender := win.renderPos
 		win.Position = point{}
+		win.renderPos = point{}
 		localPos = win.getPosition()
 		if !win.MainPortal {
 			win.drawBG(win.Render)
@@ -194,6 +196,7 @@ func (win *windowData) Draw(screen *ebiten.Image) {
 		win.drawBorder(win.Render, win.getWinRect())
 		win.drawDebug(win.Render)
 		win.Position = origPos
+		win.renderPos = origRender
 		shift := pointFloor(pointSub(pos, localPos))
 		shiftDrawRects(win, shift)
 		win.Dirty = false

--- a/eui/struct.go
+++ b/eui/struct.go
@@ -17,12 +17,14 @@ func (c Color) RGBA() (r, g, b, a uint32) {
 func (c Color) ToRGBA() color.RGBA { return color.RGBA(c) }
 
 type windowData struct {
-	Title    string
-	Position point
-	Size     point
-	AspectA  float32
-	AspectB  float32
-	PinTo    pinType
+	Title      string
+	Position   point
+	Size       point
+	renderPos  point
+	renderSize point
+	AspectA    float32
+	AspectB    float32
+	PinTo      pinType
 
 	Padding   float32
 	Margin    float32

--- a/eui/util_test.go
+++ b/eui/util_test.go
@@ -473,8 +473,8 @@ func TestSetSizeClampAndScroll(t *testing.T) {
 	// content smaller than window
 	win.Contents = []*itemData{{Size: point{X: 50, Y: 50}}}
 	win.setSize(point{-10, -10})
-	if win.Size.X < MinWinSizeX || win.Size.Y < MinWinSizeY {
-		t.Errorf("size not clamped: %+v", win.Size)
+	if win.renderSize.X < MinWinSizeX || win.renderSize.Y < MinWinSizeY {
+		t.Errorf("size not clamped: %+v", win.renderSize)
 	}
 	// enlarge window so scroll should reset
 	win.setSize(point{X: 200, Y: 200})
@@ -496,15 +496,15 @@ func TestFixedAspectRatio(t *testing.T) {
 
 	win.setSize(point{X: 160, Y: 100})
 	want := point{X: 160, Y: 100}
-	if win.Size != want {
-		t.Errorf("resize by width got %+v want %+v", win.Size, want)
+	if win.renderSize != want {
+		t.Errorf("resize by width got %+v want %+v", win.renderSize, want)
 	}
 
-	win.Size = point{X: 100, Y: 50}
+	win.setSize(point{X: 100, Y: 50})
 	win.setSize(point{X: 120, Y: 120})
 	want = point{X: 195.55556, Y: 120}
-	if math.Abs(float64(win.Size.X-want.X)) > 0.01 || math.Abs(float64(win.Size.Y-want.Y)) > 0.01 {
-		t.Errorf("resize by height got %+v want %+v", win.Size, want)
+	if math.Abs(float64(win.renderSize.X-want.X)) > 0.01 || math.Abs(float64(win.renderSize.Y-want.Y)) > 0.01 {
+		t.Errorf("resize by height got %+v want %+v", win.renderSize, want)
 	}
 }
 
@@ -759,14 +759,14 @@ func TestClampToScreen(t *testing.T) {
 		}
 		switch pin {
 		case PIN_TOP_RIGHT, PIN_MID_RIGHT, PIN_BOTTOM_RIGHT:
-			if win.Position.X != 0 {
-				t.Errorf("pin %v X offset %v not clamped to 0", pin, win.Position.X)
+			if win.renderPos.X != 0 {
+				t.Errorf("pin %v X offset %v not clamped to 0", pin, win.renderPos.X)
 			}
 		}
 		switch pin {
 		case PIN_BOTTOM_LEFT, PIN_BOTTOM_CENTER, PIN_BOTTOM_RIGHT:
-			if win.Position.Y != 0 {
-				t.Errorf("pin %v Y offset %v not clamped to 0", pin, win.Position.Y)
+			if win.renderPos.Y != 0 {
+				t.Errorf("pin %v Y offset %v not clamped to 0", pin, win.renderPos.Y)
 			}
 		}
 	}
@@ -926,7 +926,7 @@ func TestClampToScreenCenterResize(t *testing.T) {
 
 	win := &windowData{Size: point{X: 50, Y: 50}, PinTo: PIN_MID_CENTER, Margin: m, Position: point{X: 1000, Y: 0}}
 	win.clampToScreen()
-	win.Size = point{X: 80, Y: 50}
+	win.setSize(point{X: 80, Y: 50})
 	win.clampToScreen()
 	if pos := win.getPosition(); pos.X != float32(screenWidth)-win.GetSize().X-m {
 		t.Fatalf("right resize X=%v", pos.X)
@@ -934,7 +934,7 @@ func TestClampToScreenCenterResize(t *testing.T) {
 
 	win = &windowData{Size: point{X: 50, Y: 50}, PinTo: PIN_MID_CENTER, Margin: m, Position: point{X: 0, Y: 1000}}
 	win.clampToScreen()
-	win.Size = point{X: 50, Y: 80}
+	win.setSize(point{X: 50, Y: 80})
 	win.clampToScreen()
 	if pos := win.getPosition(); pos.Y != float32(screenHeight)-win.GetSize().Y-m {
 		t.Fatalf("bottom resize Y=%v", pos.Y)

--- a/eui/window.go
+++ b/eui/window.go
@@ -146,6 +146,8 @@ func (target *windowData) AddWindow(toBack bool) {
 		return
 	}
 
+	target.renderSize = target.Size
+	target.renderPos = target.Position
 	target.clampToScreen()
 
 	// Closed windows shouldn't steal focus, so add them to the back by
@@ -576,7 +578,7 @@ func (win windowData) itemOverlap(size point) (bool, bool) {
 
 	rectList := []rect{}
 
-	win.Size = size
+	win.renderSize = size
 
 	for _, item := range win.Contents {
 		rectList = append(rectList, item.getItemRect(&win))

--- a/eui/window_drag_test.go
+++ b/eui/window_drag_test.go
@@ -46,6 +46,7 @@ func TestWindowDragClickScaled(t *testing.T) {
 	// Simulate dragging the window.
 	oldPos := win.getPosition()
 	win.Position = pointAdd(win.Position, point{X: 5, Y: 7})
+	win.clampToScreen()
 	delta := pointSub(win.getPosition(), oldPos)
 	shiftDrawRects(win, delta)
 


### PR DESCRIPTION
## Summary
- separate requested window coordinates from clamped render coordinates
- clamp window size and position into new render fields and update rendering/input logic
- document new behavior and update related tests

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./...` *(fails: undefined DebugMode, windows, uiScale, etc.)*
- `go test -tags test ./eui` *(fails: X11 DISPLAY environment variable is missing)*


------
https://chatgpt.com/codex/tasks/task_e_689ae5ac6060832a808ee5b1d5ae414a