### PR TITLE
Set screen size before creating pinned windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ EUI is a minimal retained‑mode UI built with the [Ebiten](https://ebiten.org/)
 It provides basic window management, flows and widgets built entirely with vector graphics.
 The project is currently in early development and APIs will likely change.
 
+Before creating any windows or overlay items that use the `PinTo` field, set the
+screen size by calling `eui.RenderSize` (usually from Ebiten's `Layout`
+callback) or `eui.SetScreenSize(width, height)` with the window dimensions so
+anchors resolve correctly.
+
 [Live demo here](https://m45sci.xyz/u/dist/eui/)
 
 ## Currently the API is not complete!

--- a/api.md
+++ b/api.md
@@ -39,6 +39,11 @@ the `PinTo` field. When a value other than `PIN_TOP_LEFT` is used, the
 position is calculated relative to that anchor instead of the top-left
 origin.
 
+Call `eui.RenderSize` (typically from Ebiten's `Layout` callback) or
+`eui.SetScreenSize(width, height)` with the window dimensions before adding
+any pinned windows or items so the anchors resolve to the correct screen
+coordinates.
+
 ## Window Transparency
 
 Windows can render with partial opacity by setting `Transparent` to true and

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -44,6 +44,11 @@ func main() {
 	currentScale = 1.5
 	eui.SetUIScale(currentScale)
 
+	// Set the screen size before adding any pinned windows or overlays.
+	const winWidth, winHeight = 1000, 1000
+	ebiten.SetWindowSize(winWidth, winHeight)
+	eui.SetScreenSize(winWidth, winHeight)
+
 	makeShowcaseWindow()
 	makeThemeSelector()
 
@@ -113,7 +118,6 @@ func startEbiten() {
 	ebiten.SetTPS(ebiten.SyncWithFPS)
 
 	/* Set up our window */
-	ebiten.SetWindowSize(1000, 1000)
 	ebiten.SetWindowResizingMode(ebiten.WindowResizingModeEnabled)
 
 	ebiten.SetWindowTitle("EUI Prototype")


### PR DESCRIPTION
## Summary
- initialize screen size before creating pinned demo windows
- document the requirement to set screen size prior to using `PinTo`

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./...` *(fails: undefined: DebugMode)*

------
https://chatgpt.com/codex/tasks/task_e_689ae82a31e0832a96b78d4d891dbafc