### PR TITLE
Add Draw open-state rendering test

### DIFF
--- a/eui/draw_windows_test.go
+++ b/eui/draw_windows_test.go
@@ -1,0 +1,35 @@
+//go:build test
+
+package eui
+
+import (
+	"testing"
+
+	"github.com/hajimehoshi/ebiten/v2"
+)
+
+// TestDrawWindowsSkipsClosed ensures that Draw renders only open windows.
+func TestDrawWindowsSkipsClosed(t *testing.T) {
+	winPortal := &windowData{MainPortal: true, open: true, Size: point{X: 50, Y: 50}}
+	winVisible := &windowData{open: true, Size: point{X: 50, Y: 50}}
+	winHidden := &windowData{open: false, Size: point{X: 50, Y: 50}}
+
+	winPortal.AddWindow(false)
+	winVisible.AddWindow(false)
+	winHidden.AddWindow(false)
+
+	Draw(ebiten.NewImage(100, 100))
+
+	if winPortal.Render == nil {
+		t.Fatalf("expected winPortal to be rendered")
+	}
+	if winVisible.Render == nil {
+		t.Fatalf("expected winVisible to be rendered")
+	}
+	if winHidden.Render != nil {
+		t.Fatalf("expected winHidden not to be rendered")
+	}
+
+	windows = nil
+	activeWindow = nil
+}


### PR DESCRIPTION
## Summary
- add draw_windows_test.go to verify Draw renders only open windows and skips closed ones

## Testing
- `go vet ./...`
- `go build ./...`
- `go test -tags test ./...` *(fails: undefined DebugMode and other globals)*
- `go test -tags test ./eui` *(fails: glfw DISPLAY environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689b010f1cb4832a81417856c54f9def